### PR TITLE
Rename main factory class and namespace

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,11 +1,12 @@
 ![Icon](https://raw.githubusercontent.com/devlooped/CredentialManager/main/assets/images/gcm.png) Git Credential Manager Lib
 ============
 
-Packages the [Microsoft.Git.CredentialManager](https://github.com/microsoft/Git-Credential-Manager-Core/tree/main/src/shared/Microsoft.Git.CredentialManager) cross-platform implementation for Windows, macOS and Linux for use as a library.
+Packages the [GitCredentialManager](https://github.com/GitCredentialManager/git-credential-manager) cross-platform implementation for 
+Windows, macOS and Linux for use as a library.
 
 This repository provides virtually no code whatesoever, it all comes from the GCM Core. 
 
-Release version numbers track the [GCM releases](https://github.com/microsoft/Git-Credential-Manager-Core/releases) themselves.
+Release version numbers track the [GCM releases](https://github.com/GitCredentialManager/git-credential-manager/releases) themselves.
 
 [![Version](https://img.shields.io/nuget/vpre/Devlooped.CredentialManager.svg?color=royalblue)](https://www.nuget.org/packages/Devlooped.CredentialManager.Css)
 [![Downloads](https://img.shields.io/nuget/dt/Devlooped.CredentialManager.svg?color=green)](https://www.nuget.org/packages/Devlooped.CredentialManager.Css)
@@ -18,18 +19,17 @@ The only code in this repository is a helper factory to create the credential st
 appropriate to the current platform:
 
 ```csharp
-using Microsoft.Git.CredentialManager;
+using GitCredentialManager;
 ...
 
-ICredentialStore store = CredentialStore.Create("myapp");
+ICredentialStore store = CredentialManager.Create("myapp");
 ```
 
-The namespace for the `CredentialStore` static factory class is the same as GCM itself 
-for convenience: `Microsoft.Git.CredentialManager`.
+The namespace for the `CredentialManager` static factory class is the same as GCM itself 
+for convenience: `GitCredentialManager`.
 
 The optional *namespace* argument (`myapp` above) can be used to scope credential 
 operations to your own app/service.
-
 
 
 

--- a/src/CredentialManager/CredentialManager.cs
+++ b/src/CredentialManager/CredentialManager.cs
@@ -1,18 +1,16 @@
 ﻿using System;
 using System.IO;
 using System.Reflection;
-using GitCredentialManager;
 using GitCredentialManager.Interop.MacOS;
 using GitCredentialManager.Interop.Windows;
 
-namespace Microsoft.Git.CredentialManager
+namespace GitCredentialManager
 {
     /// <summary>
-    /// Provides the factory method <see cref="Create"/> to instantiate the 
-    /// right implementation of <see cref="ICredentialStore"/> appropriate for 
-    /// the current platform.
+    /// Provides the factory method <see cref="Create"/> to instantiate a 
+    /// <see cref="ICredentialStore"/> appropriate for the current platform.
     /// </summary>
-    public static class CredentialStore
+    public static class CredentialManager
     {
         /// <summary>
         /// Creates the right implementation of <see cref="ICredentialStore"/> 
@@ -37,13 +35,13 @@ namespace Microsoft.Git.CredentialManager
         {
             // Assembly::Location always returns an empty string if the application was published as a single file
 #pragma warning disable IL3000
-            bool isSingleFile = string.IsNullOrEmpty(Assembly.GetEntryAssembly()?.Location);
+            var isSingleFile = string.IsNullOrEmpty(Assembly.GetEntryAssembly()?.Location);
 #pragma warning restore IL3000
 
             // Use "argv[0]" to get the full path to the entry executable - this is consistent across
             // .NET Framework and .NET >= 5 when published as a single file.
-            string[] args = Environment.GetCommandLineArgs();
-            string candidatePath = args[0];
+            var args = Environment.GetCommandLineArgs();
+            var candidatePath = args[0];
 
             // If we have not been published as a single file on .NET 5 then we must strip the ".dll" file extension
             // to get the default AppHost/SuperHost name.

--- a/src/CredentialManager/CredentialManager.csproj
+++ b/src/CredentialManager/CredentialManager.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <IsPackable>true</IsPackable>
     <AssemblyName>Devlooped.CredentialManager</AssemblyName>
-    <RootNamespace>Microsoft.Git.CredentialManager</RootNamespace>
+    <RootNamespace>GitCredentialManager</RootNamespace>
     <PackageTags>cross-platform xplat credentials manager</PackageTags>
     <PackageProjectUrl>https://clarius.org/CredentialManager</PackageProjectUrl>
     <Description>Packages the Microsoft.Git.CredentialManager cross-platform implementation for Windows, macOS and Linux for use as a library.


### PR DESCRIPTION
This matches the new namespace and avoids type conflicts since the Core project now includes an implementation of `CredentialStore`.

Fixes #12