### PR TITLE
Bump to GCM 2.0.886

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,8 @@ jobs:
         uses: ./.github/workflows/test
 
       - name: 📦 pack
+        env:
+          CustomAfterMicrosoftCommonTargets: ${{ github.workspace }}/src/NuGetize.targets
         run: dotnet pack -m:1 -p:VersionLabel="$GITHUB_REF.$GITHUB_RUN_NUMBER"
 
       # Only push CI package to sleet feed if building on ubuntu (fastest)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
       - name: 🤘 checkout
         uses: actions/checkout@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,8 @@ jobs:
         uses: ./.github/workflows/test
 
       - name: 📦 pack
+        env:
+          CustomAfterMicrosoftCommonTargets: ${{ github.workspace }}/src/NuGetize.targets
         run: dotnet pack -m:1 -p:version=${GITHUB_REF#refs/*/v}
 
       - name: 🚀 nuget

--- a/.netconfig
+++ b/.netconfig
@@ -59,9 +59,7 @@
 	weak
 [file ".github/workflows/publish.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/publish.yml
-	sha = d3022567c9ef2bc9461511e53b8abe065afdf03b
-	etag = 58601b5a71c805647ab26e84053acdfb8d174eaa93330487af8a5503753c5707
-	weak
+	skip
 [file ".gitignore"]
 	url = https://github.com/devlooped/oss/blob/main/.gitignore
 	sha = c78868eba59a3e04602434684f9eac241fef13fb

--- a/.netconfig
+++ b/.netconfig
@@ -44,9 +44,7 @@
 	weak
 [file ".github/workflows/build.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/build.yml
-	sha = 7e3288c3c7746354edc2836e4fb71f11e17db83c
-	etag = bea8f881a2c7a02de70a201806edb432f7185d39df762f76efdefe392ea019a5
-	weak
+	skip
 [file ".github/workflows/changelog.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/changelog.yml
 	sha = a4b66eb5f4dfb9704502f19f59ba33cb4855188c

--- a/CredentialManager.sln
+++ b/CredentialManager.sln
@@ -8,6 +8,10 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{4ADFF2CE-47A9-4EA0-BCCF-8DE99D250051}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		.netconfig = .netconfig
+		.github\workflows\build.yml = .github\workflows\build.yml
+		src\NuGetize.targets = src\NuGetize.targets
+		.github\workflows\publish.yml = .github\workflows\publish.yml
 		readme.md = readme.md
 	EndProjectSection
 EndProject

--- a/external/Directory.Build.targets
+++ b/external/Directory.Build.targets
@@ -1,6 +1,0 @@
-﻿<Project>
-  <ItemGroup>
-	  <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
-	  <PackageReference Include="NuGetizer" Version="0.7.4" />
-  </ItemGroup>
-</Project>

--- a/src/CredentialManager/CredentialManager.cs
+++ b/src/CredentialManager/CredentialManager.cs
@@ -25,7 +25,7 @@ namespace GitCredentialManager
             else if (PlatformUtils.IsMacOS())
                 return new MacOSKeychain(@namespace);
             else if (PlatformUtils.IsLinux())
-                return new CommandContext(GetApplicationPath()).CredentialStore;
+                return new CommandContext(GetApplicationPath(), AppContext.BaseDirectory).CredentialStore;
             else
                 throw new PlatformNotSupportedException();
         }

--- a/src/CredentialManager/CredentialManager.csproj
+++ b/src/CredentialManager/CredentialManager.csproj
@@ -1,7 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">net6.0;net472</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <AssemblyName>Devlooped.CredentialManager</AssemblyName>
     <RootNamespace>GitCredentialManager</RootNamespace>
@@ -14,6 +15,8 @@ Usage:
    var store = CredentialStore.Create();
 </Description>
     <PackageReadmeFile>readme.md</PackageReadmeFile>
+    <!-- NU1701: desktop warning. NU1702: net472 warning. MSB3277: conflicts on NS2 -->
+    <NoWarn>NU1701;NU1702;MSB3277</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CredentialManager/CredentialManager.csproj
+++ b/src/CredentialManager/CredentialManager.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OSPlatform)'=='windows'">net6.0;net472</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)'=='Windows_NT'">net6.0;net472</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <AssemblyName>Devlooped.CredentialManager</AssemblyName>
     <RootNamespace>GitCredentialManager</RootNamespace>
@@ -15,21 +15,16 @@ Usage:
    var store = CredentialStore.Create();
 </Description>
     <PackageReadmeFile>readme.md</PackageReadmeFile>
-    <!-- NU1701: desktop warning. NU1702: net472 warning. MSB3277: conflicts on NS2 -->
-    <NoWarn>NU1701;NU1702;MSB3277</NoWarn>
+    <CustomAfterMicrosoftCommonTargets>$(MSBuildProjectDirectory)\..\NuGetize.targets</CustomAfterMicrosoftCommonTargets>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
-    <PackageReference Include="NuGetizer" Version="0.9.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\external\gcm\src\shared\Core\Core.csproj" />
+    <ProjectReference Include="..\..\external\gcm\src\shared\Core\Core.csproj"
+      AdditionalProperties="CustomAfterMicrosoftCommonTargets=$(MSBuildProjectDirectory)\..\NuGetize.targets" />
   </ItemGroup>
 
   <ItemGroup>
     <None Include="..\..\readme.md" PackagePath="readme.md" />
   </ItemGroup>
-  
+
 </Project>

--- a/src/NuGetize.targets
+++ b/src/NuGetize.targets
@@ -1,0 +1,12 @@
+﻿<Project>
+
+  <PropertyGroup>
+    <IsPackable Condition="$(AssemblyName) == 'gcmcore'">false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
+    <PackageReference Include="NuGetizer" Version="0.9.1" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Requires multi-targeting net6 and net472 instead of NS2. NS2 provided for backs compat, but run-time should always target either net6 or net472.