### PR TITLE
Remove current implementation of SponsorLink for now

### DIFF
--- a/src/CredentialManager/CredentialManager.csproj
+++ b/src/CredentialManager/CredentialManager.csproj
@@ -23,7 +23,7 @@ Usage:
 
   <ItemGroup>
     <ProjectReference Include="..\..\external\gcm\src\shared\Core\Core.csproj" PrivateAssets="all" />
-    <ProjectReference Include="..\Analyzer\CodeAnalysis.csproj" ReferenceOutputAssembly="false" />
+    <!--<ProjectReference Include="..\Analyzer\CodeAnalysis.csproj" ReferenceOutputAssembly="false" />-->
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Now that SponsorLink is OSS and based on received feedback it will change in many ways moving forward, we'll for now remove the current implementation from the package to address the issues that were raised.

See https://github.com/devlooped/SponsorLink