### PR TITLE
Convert to NS2.0 implementation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,8 +54,6 @@ jobs:
           fetch-depth: 0
 
       - name: 🙏 build
-        env:
-          CustomAfterMicrosoftCommonTargets: ${{ github.workspace }}/src/NuGetize.targets
         run: dotnet build -m:1 -p:VersionLabel="$GITHUB_REF.$GITHUB_RUN_NUMBER"
 
       - name: ⚙ GNU grep
@@ -68,11 +66,9 @@ jobs:
         uses: ./.github/workflows/test
 
       - name: 📦 pack
-        env:
-          CustomAfterMicrosoftCommonTargets: ${{ github.workspace }}/src/NuGetize.targets
         run: dotnet pack -m:1 -p:VersionLabel="$GITHUB_REF.$GITHUB_RUN_NUMBER"
 
-      # Only push CI package to sleet feed if building on ubuntu (fastest)
+      # Only push CI package to sleet feed if building on windows (can't run ILRepack on linux/macOS)
       - name: 🚀 sleet
         env:
           SLEET_CONNECTION: ${{ secrets.SLEET_CONNECTION }}

--- a/.netconfig
+++ b/.netconfig
@@ -134,3 +134,601 @@
 	sha = 8990ebb36199046e0b8098bad9e46dcef739c56e
 	etag = e1dc114d2e8b57d50649989d32dbf0c9080ec77da3738a4cc79e9256d6ca5d3e
 	weak
+
+[file "src/Core/Authentication/OAuth"]
+	url = https://github.com/git-ecosystem/git-credential-manager/tree/main/src/shared/Core/Authentication/OAuth
+[file "src/Core/Interop/"]
+	url = https://github.com/git-ecosystem/git-credential-manager/tree/main/src/shared/Core/Interop
+
+[file "src/Core/CommandContext.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/CommandContext.cs
+	sha = de1ff8bdeac3d60a76e0ebba98e01781d38a9d4d
+	etag = a62f430e31fd818c9576ebd4b07544fccb16d7a5fd29bcabcc840d7ba3c523c0
+	weak
+[file "src/Core/Trace2.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Trace2.cs
+	sha = a0599d08e06097b84c0fbbb18e9133ebe9977177
+	etag = a8e7322f388aa565e9222cd0b32ffd44d7b4072da04db7ccbe3fa5d561d07b56
+	weak
+[file "src/Core/StandardStreams.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/StandardStreams.cs
+	sha = b8f4c28742268a7b5c783c1b302e12450ef7b8b1
+	etag = f73b9ea3181214fa10bce6ac62750494393f9c4086fa11954e51821de0f8c125
+	weak
+[file "src/Core/ITerminal.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/ITerminal.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = 576b88afbd5990a6839bc20ae78006a6d270f57cfc864402b5b7fc50f3dde8c1
+	weak
+[file "src/Core/ISessionManager.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/ISessionManager.cs
+	sha = e040cdff0eb0cdda610cbca1c730d020cbbfe5e8
+	etag = d0d8884d316a5782a88affa5ff83705b259e1407d328ae2ee405f477bb60a6d5
+	weak
+[file "src/Core/FileSystem.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/FileSystem.cs
+	sha = d37c201c3dc9a61078777ccaf770b707579d7722
+	etag = 11c4b510355966ca7fb9401bfb7a9ea7c08f02a061ca0c27c6aa16a3e20ec0d3
+	weak
+[file "src/Core/ICredentialStore.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/ICredentialStore.cs
+	sha = 28edc00ccca5cac29407687e09f6be4320f63f95
+	etag = a3d76b41023dad821a121db5f97cd1c8ca13050a3b67aaff159eed8d379f9c99
+	weak
+[file "src/Core/Credential.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Credential.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = c9e982b5a617e964e668a9441c599cad48a1bcfdb328cdba1c16aacc960b7c43
+	weak
+[file "src/Core/Trace.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Trace.cs
+	sha = e104c1881cbf18bc7a1efbc4d1eceb32fe3370fe
+	etag = e7c3cce66cc5be89165f1bae27bda691cf35186e6056c0221d62c8f7c937046f
+	weak
+[file "src/Core/HttpClientFactory.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/HttpClientFactory.cs
+	sha = a656832ff360c66313d0b669e27eebf22cb44e30
+	etag = 88c94e9107332d43f3b7685f376f7a1c3639367fce2a7f2294c154dd061b1051
+	weak
+[file "src/Core/Git.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Git.cs
+	sha = 6931c9275780477eae6b682a542c739924d44a36
+	etag = 08a172d297cf60dd5d978b20557021c559acf9c4028cd556f02cb23b075cdb68
+	weak
+[file "src/Core/EnvironmentBase.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/EnvironmentBase.cs
+	sha = f25667261e9df8d96b8fce25b7c39f48a800b554
+	etag = 07812af00bf0bc0d845e8c0c263d945a8e99ae058c0e46da066f27d205907b39
+	weak
+[file "src/Core/ProcessManager.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/ProcessManager.cs
+	sha = 65e5a883bacd1e3e54fc40726812237a1066c8f4
+	etag = 55bda8c781d56304e55d0da982a613bf877c69f604e535c3ffe4b41c454df4fe
+	weak
+[file "src/Core/DisposableObject.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/DisposableObject.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = 6c463a8bb34938152853feea21a08a60292d3ffb7c894ebb689f15d047bc0802
+	weak
+[file "src/Core/PlatformUtils.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/PlatformUtils.cs
+	sha = 59f01d9d737cd4b649c1596a81054e22b390fd32
+	etag = 9a2583672f4b82b9b3e18bbb13b5c83ffe3aa80db53083717df3d770c62f0cab
+	weak
+[file "src/Core/Trace2Exception.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Trace2Exception.cs
+	sha = 23997510a8cebb2e3494e9f6307b66bcfa13b6f5
+	etag = e79adb2b44d0ed5dd3feedd07689df6ab51f7aed487c1ced0d04be9c97732925
+	weak
+[file "src/Core/Trace2FileWriter.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Trace2FileWriter.cs
+	sha = 933bb26c9fa675732492eca8334db3f0dcb3d050
+	etag = 0d96497993637c9030895038c34eee99249e510ee8a8f00ee7ad0d265e6dfc35
+	weak
+[file "src/Core/Trace2StreamWriter.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Trace2StreamWriter.cs
+	sha = ec9359d15296eaaeac65056eb1b934a85680c898
+	etag = 739a550aef55822386820b8e9a4e35a7a00be51f83865e79592c3969d9e49252
+	weak
+[file "src/Core/Trace2Message.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Trace2Message.cs
+	sha = 865a3c52e0374b78f5cf29553d4c9f37799b050b
+	etag = 43c7b1db7ece0e09f8ed8576f1151bec9855f174eec33a881fc596418d4cfe08
+	weak
+[file "src/Core/ITrace2Writer.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/ITrace2Writer.cs
+	sha = 59a2692614fb3f1a8afdfeaa03f4d7e38318e648
+	etag = dd8851bb18d908dc790f6eb49326ac33325895ceaff4b43100ce4e18124303b8
+	weak
+[file "src/Core/Settings.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Settings.cs
+	sha = 3183801eacdc6653e9046d9d2fbeb6c59efc8408
+	etag = 5d1ab8c9ff66e5ee63a530f64f4deb10d62f6032c8766ff1f451e066be6e2434
+	weak
+[file "src/Core/PlaintextCredentialStore.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/PlaintextCredentialStore.cs
+	sha = e8b02e00891f718d8b9617d7944c523ebf17e60f
+	etag = 40dea3f67e29e27b9289ca3a0d8879dea85e057e77f3c3fb030260cb09fa399e
+	weak
+[file "src/Core/ISystemPrompts.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/ISystemPrompts.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = 673adabdaa4e48aa4ce75b28145c113a6a905239c710e6dd0ad0de79e3cd9134
+	weak
+[file "src/Core/Gpg.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Gpg.cs
+	sha = 40f75089539bd6908b88f3a6ae867003cd34126a
+	etag = 0e31e59cffabf4bcc13c98cf2ac5fd483e5c23a38782d44f6dbf2ea33e864843
+	weak
+[file "src/Core/GitConfiguration.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/GitConfiguration.cs
+	sha = 336278cdd430a73139d685b1d81dfd6108797a97
+	etag = 4e90a0ab5f1d8406441525f2cb93e9ba945944d11fdc51dcc9f4812377d36ce8
+	weak
+[file "src/Core/FileCredential.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/FileCredential.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = c6f8ec0141576d6fc00db4c4fc6f390c901576d9ab05aead2836fe62516d0693
+	weak
+[file "src/Core/GitVersion.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/GitVersion.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = 9ea13a9c4ca7e0938ea1b374104a4fa45f3e29f26b81acc90ddd427626b35551
+	weak
+[file "src/Core/ChildProcess.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/ChildProcess.cs
+	sha = 40f75089539bd6908b88f3a6ae867003cd34126a
+	etag = e09e721226f8c97b6481291a7d1486ccba656bfca69eace5cb637535a7d8850a
+	weak
+[file "src/Core/GitConfigurationEntry.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/GitConfigurationEntry.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = 74e4373ccff2f0f06c249c8300510286484efa9932031df1d5d82df357a077cb
+	weak
+[file "src/Core/Constants.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Constants.cs
+	sha = 46810dfd9ae67851241ab121b589a54e78e823e7
+	etag = 9c5ff045124b6cf5e98a45f2b889d311119e451da29bd4979cf298d38229d2b3
+	weak
+[file "src/Core/ConvertUtils.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/ConvertUtils.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = 53cd52a712295538009308b0ce7cb008ab776f1a8b686f90b0ad6c783b2b02cd
+	weak
+[file "src/Core/EnsureArgument.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/EnsureArgument.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = 1930fdc866b9fa2228fdf338cb5a6420d775c8d7e3d321ff30c47535aeaa2115
+	weak
+[file "src/Core/StringExtensions.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/StringExtensions.cs
+	sha = 7d2a8cc583a8aeae104c6cb144fde1328ef50cae
+	etag = f7b83bbe6f2c0d41b0f8b15f1be54d571ca0180e95ed4d016375c4f6b05ed800
+	weak
+[file "src/Core/StreamExtensions.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/StreamExtensions.cs
+	sha = 93cada914ca47632dd6972e6f5d927eebe78ca37
+	etag = 9cc36b7d21782a7a42acd08526921a2dd2f106418d13b0ad49e1e4efa182cc1d
+	weak
+[file "src/Core/Trace2CollectorWriter.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Trace2CollectorWriter.cs
+	sha = e9db80225e3961aa33442d0918827bf44176ded5
+	etag = 551cd3c933737a31c0e9cc6923eea89846146fa3072174667127b351db3847b7
+	weak
+[file "src/Core/CurlCookie.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/CurlCookie.cs
+	sha = cebbc7342410e8f3f9c03eb42124ea7f78f0beb1
+	etag = 3f60948fc943c01317d5fc3901c5fee0eabda96945c0a210f9e07f36b49a9e0f
+	weak
+[file "src/Core/WslUtils.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/WslUtils.cs
+	sha = d0b767b37d6e6fa42b7c738a3729cdfc41e1c0d1
+	etag = b5e18ee7a809623c704540c922d3fdca94ae72b97cf5b8562e232e41025dfd7c
+	weak
+[file "src/Core/TraceUtils.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/TraceUtils.cs
+	sha = c2366f7444e93600f6421da61e3773701f663e80
+	etag = 44b1a076f7212a0b2e22fefdd0430473cc0076db1371af54e69f7f4861010369
+	weak
+[file "src/Core/GitConfigurationKeyComparer.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/GitConfigurationKeyComparer.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = 6aa47b7ad804d36e31807eddd6c8297d9f3314d76e486e82824df493caeaa75a
+	weak
+[file "src/Core/IniFile.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/IniFile.cs
+	sha = 6b887e1a28f8fcc876168a9f5b0f39b9ead3879d
+	etag = 34f073b3757e0d7b536de1efa9d4f994951f11ab0e755e0f7efb6015da035fc6
+	weak
+[file "src/Core/CredentialStore.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/CredentialStore.cs
+	sha = 28edc00ccca5cac29407687e09f6be4320f63f95
+	etag = 75e39f5aa2c4556503b1cba1a0d4e68fe7b66af8c176d2c119f546161027b05e
+	weak
+[file "src/Core/CredentialCacheStore.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/CredentialCacheStore.cs
+	sha = 28edc00ccca5cac29407687e09f6be4320f63f95
+	etag = 35ce2cdfa6252d82a900e35c5dcbae44397e386621c2a261622f73a2a594143d
+	weak
+[file "src/Core/EncodingEx.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/EncodingEx.cs
+	sha = b8f4c28742268a7b5c783c1b302e12450ef7b8b1
+	etag = 62aedc21b88779f163601f289a557884d19a3c888cab3add58247a0dc3dd66ea
+	weak
+[file "src/Core/BrowserUtils.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/BrowserUtils.cs
+	sha = d0b767b37d6e6fa42b7c738a3729cdfc41e1c0d1
+	etag = f9a39627fd901ab3d2070430b6c5db768398314645cefde773e3aaf43c89904d
+	weak
+[file "src/Core/AssemblyUtils.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/AssemblyUtils.cs
+	sha = 7cee518ca65a7d455d5c6fcbbad0402222d311b7
+	etag = 9a900d42799b17385cb34bd4742b4ba67fd6b332fc569b91a579f22e73173ae1
+	weak
+[file "src/Core/Base64UrlConvert.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Base64UrlConvert.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = 245a19ebb1c92ca2f5d90d6a7d1ad1409d2114b1dbd5f3a6304e6dd86292c622
+	weak
+[file "src/Core/UriExtensions.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/UriExtensions.cs
+	sha = 62abc306bfa051ced74fb9e82a9db5b365aa57a8
+	etag = 313c8e305a46518dbb6e9ac462eba0254a6f22aeb5d691b1e656d1a60642bd4c
+	weak
+[file "src/Core/DictionaryExtensions.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/DictionaryExtensions.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = 752b70be414a32723694ce143c852e92baf8fd8b865a94f3b6382f47c95fa2e1
+	weak
+[file "src/Core/NameValueCollectionExtensions.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/NameValueCollectionExtensions.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = ebc36bdebb0c2e2a5668b8641db5df33dc70f51b11d8e05ee54d5492ece5aa71
+	weak
+[file "src/Core/HttpRequestExtensions.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/HttpRequestExtensions.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = 86395d5341813a666be65cc17b651204e05959f79060c015f1edb6a98d33c85e
+	weak
+[file "src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/HttpListenerExtensions.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Authentication/OAuth/HttpListenerExtensions.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = a6ae61ce88ceb358eb66c51e70a7f8f33fbab4d054b1285706083c0c012064f2
+	weak
+[file "src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/IOAuth2WebBrowser.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Authentication/OAuth/IOAuth2WebBrowser.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = 01968d1415a4c442dc85584255960f56905738856847610d7d485be3692b92b3
+	weak
+[file "src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/Json/DeviceAuthorizationEndpointResponseJson.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Authentication/OAuth/Json/DeviceAuthorizationEndpointResponseJson.cs
+	sha = 71d03fb493060e75f9e45bf8b87a97582a51a7b2
+	etag = 525c9d16e0e14c00d3b5b99be72068d173d39f303e9a72619e7158093331428e
+	weak
+[file "src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/Json/ErrorResponseJson.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Authentication/OAuth/Json/ErrorResponseJson.cs
+	sha = 71d03fb493060e75f9e45bf8b87a97582a51a7b2
+	etag = da7bd48c0d137f97c77b5daead4c0a51be52271ae6a0ceded3352bcaef9b15da
+	weak
+[file "src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/Json/TokenEndpointResponseJson.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Authentication/OAuth/Json/TokenEndpointResponseJson.cs
+	sha = f1bed778d415cc67758952a9a17d56f0b611f626
+	etag = 2fc143bcb9d7a6b7ee021bc980f8ec3e60cf070697a4d60e0846a62c5abdc4f4
+	weak
+[file "src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/OAuth2AuthorizationCodeResult.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Authentication/OAuth/OAuth2AuthorizationCodeResult.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = 343a0d586b41b7152576114d241755e867a39007fd0236daafa4bd7a0c198931
+	weak
+[file "src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/OAuth2Client.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Authentication/OAuth/OAuth2Client.cs
+	sha = 4e8674aeb62317641a5a53834563d48441cf4d95
+	etag = 118bf95993f7cf58dc2627b599b1d0b7915d7023ad0a4b515b2ba8c3f2df8d1a
+	weak
+[file "src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/OAuth2Constants.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Authentication/OAuth/OAuth2Constants.cs
+	sha = 06a3edf16174d9a7ffbc29c56e8554197d96d8fa
+	etag = 9eca313464868508c8a9d6163415320f29912b8fd944e1838ba8cf9ddedfd373
+	weak
+[file "src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/OAuth2CryptographicGenerator.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Authentication/OAuth/OAuth2CryptographicGenerator.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = c8c66d11b08f57cd6f1ced424d0f49cf340de3aee2f3dc724cd23f6ca77a5713
+	weak
+[file "src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/OAuth2DeviceCodeResult.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Authentication/OAuth/OAuth2DeviceCodeResult.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = a49a6b19c24542663dd176f971ea46c8eb17473b5c1183219441e379a747ae7b
+	weak
+[file "src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/OAuth2Exception.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Authentication/OAuth/OAuth2Exception.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = a5fac5128a0bc160e4fd95fdf9f115e2a80eaacb4f2e2a6129eebfe17ba1308a
+	weak
+[file "src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/OAuth2ServerEndpoints.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Authentication/OAuth/OAuth2ServerEndpoints.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = 957ea8a9567c7b7012a88a28cfc50c65f2002254e2e35eb2c0ff6c78d37c4331
+	weak
+[file "src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/OAuth2SystemWebBrowser.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Authentication/OAuth/OAuth2SystemWebBrowser.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = f1dfa70e7f6096ef5a0fccc3d3737bcb4e22089dfeeb2afc6b3e722ca40da888
+	weak
+[file "src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/OAuth2TokenResult.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Authentication/OAuth/OAuth2TokenResult.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = 7942488c12152b9069d6cf11921fa0506b4a656628f2f96cad62ea91b1c165b6
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop"]
+	url = https://github.com/git-ecosystem/git-credential-manager/tree/main/src/shared/Core/Interop
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/InteropException.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/InteropException.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = f4a2b97bdc2307040e191943e20a408e1add3895eb8c2409659ce067251dca15
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/InteropUtils.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/InteropUtils.cs
+	sha = 43b5c5133780046ed42e94aa7eb9c94fd07afe40
+	etag = dca8d5613f5627ead2e2229f46d3db365cfe533e0677c32077fbc943d38b0ad0
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Linux/LinuxFileSystem.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/Linux/LinuxFileSystem.cs
+	sha = ca19938cc0171e89245447be8e534ee93507ed6a
+	etag = 45542500a9797765b8cb91f4cc588af80ee1345050db2fadcb6edf71ce299d7b
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Linux/LinuxSessionManager.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/Linux/LinuxSessionManager.cs
+	sha = d0b767b37d6e6fa42b7c738a3729cdfc41e1c0d1
+	etag = 84b54d3c5af611ac8410acffe5600b9644e359d64b33550259bf7ad1293c1dd0
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Linux/LinuxTerminal.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/Linux/LinuxTerminal.cs
+	sha = 94f8d91eacc5ffc5037ab0d96337a531419b4021
+	etag = 7feccef50d58fd90c408910dd2e33e7226676b5cc2635c23a44649d57a776115
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Linux/Native/Glib.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/Linux/Native/Glib.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = 5bc2ebdca310c5e15d1d6c7e3e4ca31942f44b4097a1285cdf8578de1b912efb
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Linux/Native/Gobject.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/Linux/Native/Gobject.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = e1382665b774a1bbb6bec13f90c8089d078df7dd3bb866c41f5b81ae4f9f1419
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Linux/Native/Libsecret.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/Linux/Native/Libsecret.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = 8adee76b5d50c9ddec440987cf9a6111c296ea6095b72df92a1bb29327db3c31
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Linux/Native/termios_Linux.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/Linux/Native/termios_Linux.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = 6df5d1e191d616cbff2fe3d71636c62674c577b6638add1cd42364ff24acd82d
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Linux/SecretServiceCollection.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/Linux/SecretServiceCollection.cs
+	sha = e8b02e00891f718d8b9617d7944c523ebf17e60f
+	etag = 972a9897b6965920d50df8ac0096fd20b19d5b8ca6ab47545efb13727c7f09d8
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Linux/SecretServiceCredential.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/Linux/SecretServiceCredential.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = 81f9f6596053c460f2985fb34f18c81bff20592da3b049ad8c6e22a8f0437dc7
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/MacOS/MacOSEnvironment.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/MacOS/MacOSEnvironment.cs
+	sha = a130fec718edbc83e8067f0cde58b1fd720ce087
+	etag = 632d1e96b5fd90a4f5c8bcc6d5301d0e6091730e6201474e42ee1c4881340450
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/MacOS/MacOSFileSystem.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/MacOS/MacOSFileSystem.cs
+	sha = ca19938cc0171e89245447be8e534ee93507ed6a
+	etag = 35caf38c0f385f3b4c25be84b3c2e653aea3bfb01fc6e70b8c3a976bae40c0f9
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/MacOS/MacOSKeychain.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/MacOS/MacOSKeychain.cs
+	sha = e8b02e00891f718d8b9617d7944c523ebf17e60f
+	etag = b5620ea3389be1b835fea207842a003bf9454e0170b00ccd22472e0a9ce0f4fc
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/MacOS/MacOSKeychainCredential.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/MacOS/MacOSKeychainCredential.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = a779c3a8d51f10326eb557063f185276b2f78807e1bbe064876658561fdbcb22
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/MacOS/MacOSSessionManager.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/MacOS/MacOSSessionManager.cs
+	sha = d0b767b37d6e6fa42b7c738a3729cdfc41e1c0d1
+	etag = a841138dad7dd688e2b6481f099b2f81d4caec1f57e1ff9d4f487f5fe5dd4bf1
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/MacOS/MacOSTerminal.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/MacOS/MacOSTerminal.cs
+	sha = 94f8d91eacc5ffc5037ab0d96337a531419b4021
+	etag = 8781a490dcd3f396279f9de3d4a164cd36cc49044227494b974f0359d2aa365b
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/MacOS/Native/CoreFoundation.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/MacOS/Native/CoreFoundation.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = 62b890c452dfaafdf8d681084b6625d146373ac2bb37c446defc70128dbb7179
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/MacOS/Native/LibC.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/MacOS/Native/LibC.cs
+	sha = 7366a54fef612322a8fcbe8c2b8c273e46737358
+	etag = 2f699a6798408046255138f57a090168028d4d41a00a78924b70dc66f4345cc5
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/MacOS/Native/LibSystem.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/MacOS/Native/LibSystem.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = b498c2d322c4078bec002ac1b26335c37917231ca1dec6d04746411872de97a6
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/MacOS/Native/SecurityFramework.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/MacOS/Native/SecurityFramework.cs
+	sha = 28edc00ccca5cac29407687e09f6be4320f63f95
+	etag = 1fceccc37794b0938b6d5d01f48ead468d1956dff3c032edb998a1a9e85bdefc
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/MacOS/Native/termios_MacOS.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/MacOS/Native/termios_MacOS.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = ff460668bc6e9f9d431ca4aa3e5ed6066453d411572fbc00b17ec2303aed1f9f
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Posix/GpgPassCredentialStore.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/Posix/GpgPassCredentialStore.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = 29dbffffd90bd6167a3f6e6f52e0a918ee1447cf571da3257aaea077b2ea41e5
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Posix/Native/Fcntl.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/Posix/Native/Fcntl.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = dd87dc81c72259c941104f12199323916698f06bbdf7e157c895280ef147eb3e
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Posix/Native/Signal.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/Posix/Native/Signal.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = aee509b4626bd9de0ee713ba08315e9c816bca7c90f7379ab4730bb7b3488e1c
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Posix/Native/Stat.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/Posix/Native/Stat.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = 6d0d2b5deff0b6554cf2e8fcdba10717253a85aca9abeebde39b264cc39d452e
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Posix/Native/Stdio.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/Posix/Native/Stdio.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = 03500cbe78f498f2d72fe86ffb05e9207022e8ff1898015903cba2aec16f5d1c
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Posix/Native/Stdlib.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/Posix/Native/Stdlib.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = 1397abe89883a92138b9b011751c611e7e1a8ac3fa10a104e8c8e038789b1fba
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Posix/Native/Termios.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/Posix/Native/Termios.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = b86393bf808f9246e62f78bbdbe5e49fe13dc0a26f0fccb9fa71561c9e410020
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Posix/Native/Unistd.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/Posix/Native/Unistd.cs
+	sha = 7366a54fef612322a8fcbe8c2b8c273e46737358
+	etag = 3753d6444a3319b6bc35c7ab719d989bd2d79ff8e297247ce5dbe15d4a49a566
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Posix/PosixEnvironment.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/Posix/PosixEnvironment.cs
+	sha = a130fec718edbc83e8067f0cde58b1fd720ce087
+	etag = 12e8e06a15efbef40f84b7cf38432146d66416012dfbd8c47815dd279ed75d7e
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Posix/PosixFileDescriptor.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/Posix/PosixFileDescriptor.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = 125d0a1c8ca34099eb44bccb0b5dfeece94186857dd485ab30ca48cd69e75665
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Posix/PosixFileSystem.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/Posix/PosixFileSystem.cs
+	sha = ca19938cc0171e89245447be8e534ee93507ed6a
+	etag = 9d4c92402f7abcd44248d9029af7acd52395d0c15619e4bc8fa29acf86f2fcf3
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Posix/PosixSessionManager.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/Posix/PosixSessionManager.cs
+	sha = d0b767b37d6e6fa42b7c738a3729cdfc41e1c0d1
+	etag = 6bd57a3335e1d5d594b32aa874c4185a870b25b98558d4da56a98c3660269857
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Posix/PosixTerminal.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/Posix/PosixTerminal.cs
+	sha = dfd3dadc75a823ccdd58222af2435bb811fc2ab0
+	etag = 45b94e78b9a3c918368421196073da6b178e9d4b846274d79d9ee4bd483c0f69
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/U8StringConverter.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/U8StringConverter.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = 6c842097307e6fa8ea6f8b97f5deef4d33f3a7300c66566bedff7316baf3c089
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/U8StringMarshaler.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/U8StringMarshaler.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = a1551b8a18fbb79a48a6d6e78a8202f5d0ba83e81bc1ec35dce7119cd43b8407
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/DpapiCredentialStore.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/Windows/DpapiCredentialStore.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = 80f94fbc0f53a91cc31db26114611f17372fa925734e647f081bfe2379814411
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/Native/Advapi32.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/Windows/Native/Advapi32.cs
+	sha = e0218ace4a93dcb152e528b24f600bed0ee8483c
+	etag = 4e799d8a0fb8841225668697344a55f0042763f63edb67290fe56bedfcce8fb4
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/Native/CredUi.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/Windows/Native/CredUi.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = 40fd47027fe8477fab05a514a76b86beef9f6b4d9d6750454d06a0a638dc23a0
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/Native/Kernel32.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/Windows/Native/Kernel32.cs
+	sha = 134e622aefa7f334f656c3356120956c2997e595
+	etag = b2e62982877004fe44051a5a398fc725ac432c917a5baa24820323a2cbde5565
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/Native/Ole32.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/Windows/Native/Ole32.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = f8d11d3dc82d81f75f58198023073e640313b01954b47387c50f59981290447a
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/Native/Shell32.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/Windows/Native/Shell32.cs
+	sha = fa2cc1805a6f617d7e4dd242501fad860d5fbce2
+	etag = 8e8d401cedb13f66c314e7f695903d72a880802f00a8a6722dbd24c8dbffbdab
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/Native/User32.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/Windows/Native/User32.cs
+	sha = 134e622aefa7f334f656c3356120956c2997e595
+	etag = 73f2ef305aa6614bc3f9d81933fa9c2148c77ab5b7fc3254f4d8084bdc011ff2
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/Native/Win32Error.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/Windows/Native/Win32Error.cs
+	sha = 94f8d91eacc5ffc5037ab0d96337a531419b4021
+	etag = a067404240ae5a98728e74994a426ee85fae5421b573e8658adbaa3034562a4d
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/WindowsCredential.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/Windows/WindowsCredential.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = d9bb85480d058d90c08096b5dfabf4d51934a155627218ec7aceaa67f7dc964d
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/WindowsCredentialManager.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/Windows/WindowsCredentialManager.cs
+	sha = e8b02e00891f718d8b9617d7944c523ebf17e60f
+	etag = 3c1ba5e089f75be24172e73767805ca16200230a725f8390c8d1866d9c7a876b
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/WindowsEnvironment.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/Windows/WindowsEnvironment.cs
+	sha = a130fec718edbc83e8067f0cde58b1fd720ce087
+	etag = 905ca0898944337420aab8f31e6dc3babc54f1921c8d9346f58f785ff2e7fbf1
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/WindowsFileSystem.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/Windows/WindowsFileSystem.cs
+	sha = ca19938cc0171e89245447be8e534ee93507ed6a
+	etag = aff622066a29a9b90e6c77ef75206cf8fde7627a4d6c9ff88e0c3126e9a0df2b
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/WindowsProcessManager.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/Windows/WindowsProcessManager.cs
+	sha = d1b64ccd07239bdb8de4b732e9963753d4e89a62
+	etag = fc48908142dff5de467bfdbe61d7e026cc463d2abefaa92f39301e4b43b56540
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/WindowsSessionManager.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/Windows/WindowsSessionManager.cs
+	sha = d0b767b37d6e6fa42b7c738a3729cdfc41e1c0d1
+	etag = 64ea73ae307d85e4f2e8d69c130454743cc9587a67cc0c1242d4a65f03fd2f32
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/WindowsSettings.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/Windows/WindowsSettings.cs
+	sha = 8122dc0c8fdff17654ce3dea17b3a6fb0c899fff
+	etag = 723171f86db2ec3eb329eed519d74078c75571c44a16eb23b0b95063306b105d
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/WindowsSystemPrompts.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/Windows/WindowsSystemPrompts.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = 4e9d2b7252fd16b25dd68daa1dc2703f39cfe223a97b7629d6d93a1b318d1ed5
+	weak
+[file "src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/WindowsTerminal.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/Windows/WindowsTerminal.cs
+	sha = 94f8d91eacc5ffc5037ab0d96337a531419b4021
+	etag = 6ee21893c4a201ba834c9749b5518fb25f5702e7c4a29c68d3abd5cdf547301e
+	weak

--- a/CredentialManager.sln
+++ b/CredentialManager.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CredentialManager", "src\Cr
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CodeAnalysis", "src\Analyzer\CodeAnalysis.csproj", "{47DE5EE9-22A7-4D23-A50E-0724A900D290}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Core", "src\Core\Core.csproj", "{D0CE060F-5C92-494F-A4D4-441F7CDB1340}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{47DE5EE9-22A7-4D23-A50E-0724A900D290}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{47DE5EE9-22A7-4D23-A50E-0724A900D290}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{47DE5EE9-22A7-4D23-A50E-0724A900D290}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D0CE060F-5C92-494F-A4D4-441F7CDB1340}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D0CE060F-5C92-494F-A4D4-441F7CDB1340}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D0CE060F-5C92-494F-A4D4-441F7CDB1340}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D0CE060F-5C92-494F-A4D4-441F7CDB1340}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Core/.editorconfig
+++ b/src/Core/.editorconfig
@@ -1,0 +1,2 @@
+[**]
+generated_code = true

--- a/src/Core/AssemblyUtils.cs
+++ b/src/Core/AssemblyUtils.cs
@@ -1,0 +1,24 @@
+using System.Reflection;
+
+namespace GitCredentialManager;
+
+public static class AssemblyUtils
+{
+    public static bool TryGetAssemblyVersion(out string version)
+    {
+        try
+        {
+            var assembly = Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly();
+            var assemblyVersionAttribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+            version = assemblyVersionAttribute is null
+                ? assembly.GetName().Version.ToString()
+                : assemblyVersionAttribute.InformationalVersion;
+            return true;
+        }
+        catch
+        {
+            version = null;
+            return false;
+        }
+    }
+}

--- a/src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/HttpListenerExtensions.cs
+++ b/src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/HttpListenerExtensions.cs
@@ -1,0 +1,16 @@
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GitCredentialManager.Authentication.OAuth
+{
+    public static class HttpListenerExtensions
+    {
+        public static async Task WriteResponseAsync(this HttpListenerResponse response, string responseText)
+        {
+            byte[] responseData = Encoding.UTF8.GetBytes(responseText);
+            response.ContentLength64 = responseData.Length;
+            await response.OutputStream.WriteAsync(responseData, 0, responseData.Length);
+        }
+    }
+}

--- a/src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/IOAuth2WebBrowser.cs
+++ b/src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/IOAuth2WebBrowser.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GitCredentialManager.Authentication.OAuth
+{
+    public interface IOAuth2WebBrowser
+    {
+        Uri UpdateRedirectUri(Uri uri);
+
+        Task<Uri> GetAuthenticationCodeAsync(Uri authorizationUri, Uri redirectUri, CancellationToken ct);
+    }
+}

--- a/src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/Json/DeviceAuthorizationEndpointResponseJson.cs
+++ b/src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/Json/DeviceAuthorizationEndpointResponseJson.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace GitCredentialManager.Authentication.OAuth.Json
+{
+    public class DeviceAuthorizationEndpointResponseJson
+    {
+        [JsonRequired]
+        [JsonPropertyName("device_code")]
+        public string DeviceCode { get; set; }
+
+        [JsonRequired]
+        [JsonPropertyName("user_code")]
+        public string UserCode { get; set; }
+
+        [JsonRequired]
+        [JsonPropertyName("verification_uri")]
+        public Uri VerificationUri { get; set; }
+
+        [JsonPropertyName("expires_in")]
+        public long ExpiresIn { get; set; }
+
+        [JsonPropertyName("interval")]
+        public long PollingInterval { get; set; }
+
+        public OAuth2DeviceCodeResult ToResult()
+        {
+            return new OAuth2DeviceCodeResult(DeviceCode, UserCode, VerificationUri, TimeSpan.FromSeconds(PollingInterval))
+            {
+                ExpiresIn = TimeSpan.FromSeconds(ExpiresIn)
+            };
+        }
+    }
+}

--- a/src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/Json/ErrorResponseJson.cs
+++ b/src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/Json/ErrorResponseJson.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace GitCredentialManager.Authentication.OAuth.Json
+{
+    public class ErrorResponseJson
+    {
+        [JsonRequired]
+        [JsonPropertyName("error")]
+        public string Error { get; set; }
+
+        [JsonPropertyName("error_description")]
+        public string Description { get; set; }
+
+        [JsonPropertyName("error_uri")]
+        public Uri Uri { get; set; }
+
+        public OAuth2Exception ToException(Exception innerException = null)
+        {
+            var message = new StringBuilder(Error);
+
+            if (!string.IsNullOrEmpty(Description))
+            {
+                message.AppendFormat(": {0}", Description);
+            }
+
+            if (Uri != null)
+            {
+                message.AppendFormat(" [{0}]", Uri);
+            }
+
+            return new OAuth2Exception(message.ToString(), innerException) {HelpLink = Uri?.ToString()};
+        }
+    }
+}

--- a/src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/Json/TokenEndpointResponseJson.cs
+++ b/src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/Json/TokenEndpointResponseJson.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace GitCredentialManager.Authentication.OAuth.Json
+{
+    public class TokenEndpointResponseJson
+    {
+        [JsonRequired]
+        [JsonPropertyName("access_token")]
+        public string AccessToken { get; set; }
+
+        [JsonRequired]
+        [JsonPropertyName("token_type")]
+        public string TokenType { get; set; }
+
+        [JsonPropertyName("expires_in")]
+        public long? ExpiresIn { get; set; }
+
+        [JsonPropertyName("refresh_token")]
+        public string RefreshToken { get; set; }
+
+        [JsonPropertyName("scope")]
+        public virtual string Scope { get; set; }
+
+        public OAuth2TokenResult ToResult()
+        {
+            return new OAuth2TokenResult(AccessToken, TokenType)
+            {
+                ExpiresIn = ExpiresIn.HasValue ? TimeSpan.FromSeconds(ExpiresIn.Value) : null,
+                RefreshToken = RefreshToken,
+                Scopes = Scope?.Split(' ')
+            };
+        }
+    }
+}

--- a/src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/OAuth2AuthorizationCodeResult.cs
+++ b/src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/OAuth2AuthorizationCodeResult.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace GitCredentialManager.Authentication.OAuth
+{
+    public class OAuth2AuthorizationCodeResult
+    {
+        public OAuth2AuthorizationCodeResult(string code, Uri redirectUri = null, string codeVerifier = null)
+        {
+            Code = code;
+            RedirectUri = redirectUri;
+            CodeVerifier = codeVerifier;
+        }
+
+        public string Code { get; }
+        public Uri RedirectUri { get; }
+        public string CodeVerifier { get; }
+    }
+}

--- a/src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/OAuth2Client.cs
+++ b/src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/OAuth2Client.cs
@@ -1,0 +1,438 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+using GitCredentialManager.Authentication.OAuth.Json;
+using System.Text.Json;
+
+namespace GitCredentialManager.Authentication.OAuth
+{
+    /// <summary>
+    /// Represents an OAuth2 client application that can perform the basic flows outlined in RFC 6749,
+    /// as well as extensions such as OAuth2 Device Authorization Grant (RFC 8628).
+    /// </summary>
+    public interface IOAuth2Client
+    {
+        /// <summary>
+        /// Retrieve an authorization code grant using a user agent.
+        /// </summary>
+        /// <param name="scopes">Scopes to request.</param>
+        /// <param name="browser">User agent to use to start the authorization code grant flow.</param>
+        /// <param name="extraQueryParams">Extra parameters to add to the URL query component.</param>
+        /// <param name="ct">Token to cancel the operation.</param>
+        /// <returns>Authorization code.</returns>
+        Task<OAuth2AuthorizationCodeResult> GetAuthorizationCodeAsync(
+            IEnumerable<string> scopes,
+            IOAuth2WebBrowser browser,
+            IDictionary<string, string> extraQueryParams,
+            CancellationToken ct
+        );
+
+        /// <summary>
+        /// Retrieve a device code grant.
+        /// </summary>
+        /// <param name="scopes">Scopes to request.</param>
+        /// <param name="ct">Token to cancel the operation.</param>
+        /// <exception cref="InvalidOperationException">Thrown if the client has not been configured with a device authorization endpoint.</exception>
+        /// <returns>Device code grant result.</returns>
+        Task<OAuth2DeviceCodeResult> GetDeviceCodeAsync(IEnumerable<string> scopes, CancellationToken ct);
+
+        /// <summary>
+        /// Exchange an authorization code acquired from <see cref="GetAuthorizationCodeAsync"/> for an access token.
+        /// </summary>
+        /// <param name="authorizationCodeResult">Authorization code grant result.</param>
+        /// <param name="ct">Token to cancel the operation.</param>
+        /// <returns>Token result.</returns>
+        Task<OAuth2TokenResult> GetTokenByAuthorizationCodeAsync(OAuth2AuthorizationCodeResult authorizationCodeResult, CancellationToken ct);
+
+        /// <summary>
+        /// Use a refresh token to get a new access token.
+        /// </summary>
+        /// <param name="refreshToken">Refresh token.</param>
+        /// <param name="ct">Token to cancel the operation.</param>
+        /// <returns>Token result.</returns>
+        Task<OAuth2TokenResult> GetTokenByRefreshTokenAsync(string refreshToken, CancellationToken ct);
+
+        /// <summary>
+        /// Exchange a device code grant acquired from <see cref="GetDeviceCodeAsync"/> for an access token.
+        /// </summary>
+        /// <param name="deviceCodeResult">Device code grant result.</param>
+        /// <param name="ct">Token to cancel the operation.</param>
+        /// <returns>Token result.</returns>
+        Task<OAuth2TokenResult> GetTokenByDeviceCodeAsync(OAuth2DeviceCodeResult deviceCodeResult, CancellationToken ct);
+    }
+
+    public class OAuth2Client : IOAuth2Client
+    {
+        private readonly HttpClient _httpClient;
+        private readonly OAuth2ServerEndpoints _endpoints;
+        private readonly Uri _redirectUri;
+        private readonly string _clientId;
+        private readonly ITrace2 _trace2;
+        private readonly string _clientSecret;
+        private readonly bool _addAuthHeader;
+
+        private IOAuth2CodeGenerator _codeGenerator;
+
+        public OAuth2Client(HttpClient httpClient,
+            OAuth2ServerEndpoints endpoints,
+            string clientId,
+            ITrace2 trace2,
+            Uri redirectUri = null,
+            string clientSecret = null,
+            bool addAuthHeader = true)
+        {
+            _httpClient = httpClient;
+            _endpoints = endpoints;
+            _clientId = clientId;
+            _trace2 = trace2;
+            _redirectUri = redirectUri;
+            _clientSecret = clientSecret;
+            _addAuthHeader = addAuthHeader;
+        }
+
+        public IOAuth2CodeGenerator CodeGenerator
+        {
+            get => _codeGenerator ?? (_codeGenerator = new OAuth2CryptographicCodeGenerator());
+            set => _codeGenerator = value;
+        }
+
+        #region IOAuth2Client
+
+        public async Task<OAuth2AuthorizationCodeResult> GetAuthorizationCodeAsync(IEnumerable<string> scopes,
+            IOAuth2WebBrowser browser, IDictionary<string, string> extraQueryParams, CancellationToken ct)
+        {
+            string state = CodeGenerator.CreateNonce();
+            string codeVerifier = CodeGenerator.CreatePkceCodeVerifier();
+            string codeChallenge = CodeGenerator.CreatePkceCodeChallenge(OAuth2PkceChallengeMethod.Sha256, codeVerifier);
+
+            var queryParams = new Dictionary<string, string>
+            {
+                [OAuth2Constants.AuthorizationEndpoint.ResponseTypeParameter] =
+                    OAuth2Constants.AuthorizationEndpoint.AuthorizationCodeResponseType,
+                [OAuth2Constants.ClientIdParameter] = _clientId,
+                [OAuth2Constants.AuthorizationEndpoint.StateParameter] = state,
+                [OAuth2Constants.AuthorizationEndpoint.PkceChallengeMethodParameter] =
+                    OAuth2Constants.AuthorizationEndpoint.PkceChallengeMethodS256,
+                [OAuth2Constants.AuthorizationEndpoint.PkceChallengeParameter] = codeChallenge
+            };
+
+            if (extraQueryParams?.Count > 0)
+            {
+                foreach (var kvp in extraQueryParams)
+                {
+                    if (queryParams.ContainsKey(kvp.Key))
+                    {
+                        throw new ArgumentException(
+                            $"Extra query parameter '{kvp.Key}' would override required standard OAuth parameters.",
+                            nameof(extraQueryParams));
+                    }
+
+                    queryParams[kvp.Key] = kvp.Value;
+                }
+            }
+
+            Uri redirectUri = null;
+            if (_redirectUri != null)
+            {
+                redirectUri = browser.UpdateRedirectUri(_redirectUri);
+
+                // We must use the .OriginalString property here over .ToString() because OAuth requires the redirect
+                // URLs to be compared exactly, respecting missing/present trailing slashes, byte-for-byte.
+                queryParams[OAuth2Constants.RedirectUriParameter] = redirectUri.OriginalString;
+            }
+
+            string scopesStr = string.Join(" ", scopes);
+            if (!string.IsNullOrWhiteSpace(scopesStr))
+            {
+                queryParams[OAuth2Constants.ScopeParameter] = scopesStr;
+            }
+
+            var authorizationUriBuilder = new UriBuilder(_endpoints.AuthorizationEndpoint)
+            {
+                Query = queryParams.ToQueryString()
+            };
+
+            Uri authorizationUri = authorizationUriBuilder.Uri;
+
+            // Open the browser at the request URI to start the authorization code grant flow.
+            Uri finalUri = await browser.GetAuthenticationCodeAsync(authorizationUri, redirectUri, ct);
+
+            // Check for errors serious enough we should terminate the flow, such as if the state value returned does
+            // not match the one we passed. This indicates a badly implemented Authorization Server, or worse, some
+            // form of failed MITM or replay attack.
+            IDictionary<string, string> redirectQueryParams = finalUri.GetQueryParameters();
+            if (!redirectQueryParams.TryGetValue(OAuth2Constants.AuthorizationGrantResponse.StateParameter, out string replyState))
+            {
+                throw new Trace2OAuth2Exception(_trace2, $"Missing '{OAuth2Constants.AuthorizationGrantResponse.StateParameter}' in response.");
+            }
+            if (!StringComparer.Ordinal.Equals(state, replyState))
+            {
+                throw new Trace2OAuth2Exception(_trace2,
+                    $"Missing '{OAuth2Constants.AuthorizationGrantResponse.StateParameter}' in response.");
+            }
+
+            // We expect to have the auth code in the response otherwise terminate the flow (we failed authentication for some reason)
+            if (!redirectQueryParams.TryGetValue(OAuth2Constants.AuthorizationGrantResponse.AuthorizationCodeParameter, out string authCode))
+            {
+                throw new Trace2OAuth2Exception(_trace2,
+                    $"Missing '{OAuth2Constants.AuthorizationGrantResponse.AuthorizationCodeParameter}' in response.");
+            }
+
+            return new OAuth2AuthorizationCodeResult(authCode, redirectUri, codeVerifier);
+        }
+
+        public async Task<OAuth2DeviceCodeResult> GetDeviceCodeAsync(IEnumerable<string> scopes, CancellationToken ct)
+        {
+            var label = "get device code";
+            using IDisposable region = _trace2.CreateRegion(OAuth2Constants.Trace2Category, label);
+
+            if (_endpoints.DeviceAuthorizationEndpoint is null)
+            {
+                throw new Trace2InvalidOperationException(_trace2,
+                    "No device authorization endpoint has been configured for this client.");
+            }
+
+            string scopesStr = string.Join(" ", scopes);
+
+            var formData = new Dictionary<string, string>
+            {
+                [OAuth2Constants.ClientIdParameter] = _clientId
+            };
+
+            if (!string.IsNullOrWhiteSpace(scopesStr))
+            {
+                formData[OAuth2Constants.ScopeParameter] = scopesStr;
+            }
+
+            using (HttpContent requestContent = new FormUrlEncodedContent(formData))
+            using (HttpRequestMessage request = CreateRequestMessage(HttpMethod.Post, _endpoints.DeviceAuthorizationEndpoint, requestContent))
+            using (HttpResponseMessage response = await _httpClient.SendAsync(request, ct))
+            {
+                string json = await response.Content.ReadAsStringAsync();
+
+                if (response.IsSuccessStatusCode && TryDeserializeJson(json, out DeviceAuthorizationEndpointResponseJson jsonObj))
+                {
+                    return jsonObj.ToResult();
+                }
+
+                throw CreateExceptionFromResponse(json);
+            }
+        }
+
+        public async Task<OAuth2TokenResult> GetTokenByAuthorizationCodeAsync(OAuth2AuthorizationCodeResult authorizationCodeResult, CancellationToken ct)
+        {
+            var label = "get token by auth code";
+            using IDisposable region = _trace2.CreateRegion(OAuth2Constants.Trace2Category, label);
+
+            var formData = new Dictionary<string, string>
+            {
+                [OAuth2Constants.TokenEndpoint.GrantTypeParameter] = OAuth2Constants.TokenEndpoint.AuthorizationCodeGrantType,
+                [OAuth2Constants.TokenEndpoint.AuthorizationCodeParameter] = authorizationCodeResult.Code,
+                [OAuth2Constants.TokenEndpoint.PkceVerifierParameter] = authorizationCodeResult.CodeVerifier,
+                [OAuth2Constants.ClientIdParameter] = _clientId,
+                [OAuth2Constants.ClientSecretParameter] = _clientSecret
+            };
+
+            if (authorizationCodeResult.RedirectUri != null)
+            {
+                formData[OAuth2Constants.RedirectUriParameter] = authorizationCodeResult.RedirectUri.OriginalString;
+            }
+
+            if (authorizationCodeResult.CodeVerifier != null)
+            {
+                formData[OAuth2Constants.TokenEndpoint.PkceVerifierParameter] = authorizationCodeResult.CodeVerifier;
+            }
+
+            using (HttpContent requestContent = new FormUrlEncodedContent(formData))
+            using (HttpRequestMessage request = CreateRequestMessage(HttpMethod.Post, _endpoints.TokenEndpoint, requestContent, _addAuthHeader))
+            using (HttpResponseMessage response = await _httpClient.SendAsync(request, ct))
+            {
+                string json = await response.Content.ReadAsStringAsync();
+
+                if (response.IsSuccessStatusCode && TryCreateTokenEndpointResult(json, out OAuth2TokenResult result))
+                {
+                    return result;
+                }
+
+                throw CreateExceptionFromResponse(json);
+            }
+        }
+
+        public async Task<OAuth2TokenResult> GetTokenByRefreshTokenAsync(string refreshToken, CancellationToken ct)
+        {
+            var label = "get token by refresh token";
+            using IDisposable region = _trace2.CreateRegion(OAuth2Constants.Trace2Category, label);
+
+            var formData = new Dictionary<string, string>
+            {
+                [OAuth2Constants.TokenEndpoint.GrantTypeParameter] = OAuth2Constants.TokenEndpoint.RefreshTokenGrantType,
+                [OAuth2Constants.TokenEndpoint.RefreshTokenParameter] = refreshToken,
+                [OAuth2Constants.ClientIdParameter] = _clientId,
+                [OAuth2Constants.ClientSecretParameter] = _clientSecret
+            };
+
+            if (_redirectUri != null)
+            {
+                formData[OAuth2Constants.RedirectUriParameter] = _redirectUri.ToString();
+            }
+
+            using (HttpContent requestContent = new FormUrlEncodedContent(formData))
+            using (HttpRequestMessage request = CreateRequestMessage(HttpMethod.Post, _endpoints.TokenEndpoint, requestContent, _addAuthHeader))
+            using (HttpResponseMessage response = await _httpClient.SendAsync(request, ct))
+            {
+                string json = await response.Content.ReadAsStringAsync();
+
+                if (response.IsSuccessStatusCode && TryCreateTokenEndpointResult(json, out OAuth2TokenResult result))
+                {
+                    return result;
+                }
+
+                throw CreateExceptionFromResponse(json);
+            }
+        }
+
+        public async Task<OAuth2TokenResult> GetTokenByDeviceCodeAsync(OAuth2DeviceCodeResult deviceCodeResult, CancellationToken ct)
+        {
+            var formData = new Dictionary<string, string>
+            {
+                [OAuth2Constants.DeviceAuthorization.GrantTypeParameter] = OAuth2Constants.DeviceAuthorization.DeviceCodeGrantType,
+                [OAuth2Constants.DeviceAuthorization.DeviceCodeParameter] = deviceCodeResult.DeviceCode,
+                [OAuth2Constants.ClientIdParameter] = _clientId,
+            };
+
+            TimeSpan retryInterval = deviceCodeResult.PollingInterval;
+            while (true)
+            {
+                ct.ThrowIfCancellationRequested();
+
+                try
+                {
+                    using (HttpContent requestContent = new FormUrlEncodedContent(formData))
+                    using (HttpRequestMessage request = CreateRequestMessage(HttpMethod.Post, _endpoints.TokenEndpoint, requestContent))
+                    using (HttpResponseMessage response = await _httpClient.SendAsync(request, ct))
+                    {
+                        string json = await response.Content.ReadAsStringAsync();
+
+                        if (response.IsSuccessStatusCode && TryCreateTokenEndpointResult(json, out OAuth2TokenResult result))
+                        {
+                            return result;
+                        }
+
+                        var error = JsonSerializer.Deserialize<ErrorResponseJson>(json, new JsonSerializerOptions
+                        {
+                            PropertyNameCaseInsensitive = true
+                        });
+
+                        switch (error.Error)
+                        {
+                            case OAuth2Constants.DeviceAuthorization.Errors.AuthorizationPending:
+                                // Retry with the current polling interval value
+                                break;
+                            case OAuth2Constants.DeviceAuthorization.Errors.SlowDown:
+                                // We must increase the polling interval by 5 seconds
+                                retryInterval = retryInterval.Add(TimeSpan.FromSeconds(5));
+                                break;
+                            default:
+                                // For all other errors do not retry
+                                throw CreateExceptionFromResponse(json);
+                        }
+                    }
+                }
+                catch (TimeoutException)
+                {
+                    // Back-off exponentially (2 * x = x + x)
+                    retryInterval += retryInterval;
+                }
+
+                // Wait the polling interval before retrying
+                await Task.Delay(retryInterval, ct);
+            }
+        }
+
+        #endregion
+
+        #region Extension Points
+
+        protected virtual bool TryCreateTokenEndpointResult(string json, out OAuth2TokenResult result)
+        {
+            if (TryDeserializeJson(json, out TokenEndpointResponseJson jsonObj))
+            {
+                result = jsonObj.ToResult();
+                return true;
+            }
+
+            result = null;
+            return false;
+        }
+
+        protected virtual bool TryCreateExceptionFromResponse(string json, out OAuth2Exception exception)
+        {
+            if (TryDeserializeJson(json, out ErrorResponseJson obj))
+            {
+                exception = obj.ToException();
+                return true;
+            }
+
+            exception = null;
+            return false;
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private HttpRequestMessage CreateRequestMessage(HttpMethod method, Uri requestUri, HttpContent content = null, bool addAuthHeader = false)
+        {
+            var request = new HttpRequestMessage(method, requestUri) {Content = content};
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(Constants.Http.MimeTypeJson));
+
+            if (addAuthHeader && !string.IsNullOrEmpty(_clientSecret))
+            {
+                request.AddBasicAuthenticationHeader(_clientId, _clientSecret);
+            }
+
+            return request;
+        }
+
+        protected Exception CreateExceptionFromResponse(string json)
+        {
+            if (TryCreateExceptionFromResponse(json, out OAuth2Exception exception))
+            {
+                _trace2.WriteError(exception.Message);
+                return exception;
+            }
+
+            var format = "Unknown OAuth error: {0}";
+            var message = string.Format(format, json);
+            return new Trace2OAuth2Exception(_trace2, message, format);
+        }
+
+        protected static bool TryDeserializeJson<T>(string json, out T obj)
+        {
+            try
+            {
+                obj = JsonSerializer.Deserialize<T>(json);
+                return true;
+            }
+            catch
+            {
+                obj = default;
+                return false;
+            }
+        }
+
+        #endregion
+    }
+
+    public static class OAuth2ClientExtensions
+    {
+        public static Task<OAuth2AuthorizationCodeResult> GetAuthorizationCodeAsync(
+            this IOAuth2Client client, IEnumerable<string> scopes, IOAuth2WebBrowser browser, CancellationToken ct)
+        {
+            return client.GetAuthorizationCodeAsync(scopes, browser, null, ct);
+        }
+    }
+}

--- a/src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/OAuth2Constants.cs
+++ b/src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/OAuth2Constants.cs
@@ -1,0 +1,55 @@
+
+namespace GitCredentialManager.Authentication.OAuth
+{
+    public static class OAuth2Constants
+    {
+        public const string ClientIdParameter = "client_id";
+        public const string ClientSecretParameter = "client_secret";
+        public const string RedirectUriParameter = "redirect_uri";
+        public const string ScopeParameter = "scope";
+        public const string Trace2Category = "oauth2";
+
+        public static class AuthorizationEndpoint
+        {
+            public const string StateParameter = "state";
+            public const string AuthorizationCodeResponseType = "code";
+            public const string ResponseTypeParameter = "response_type";
+            public const string PkceChallengeParameter = "code_challenge";
+            public const string PkceChallengeMethodParameter = "code_challenge_method";
+            public const string PkceChallengeMethodPlain = "plain";
+            public const string PkceChallengeMethodS256 = "S256";
+        }
+
+        public static class AuthorizationGrantResponse
+        {
+            public const string AuthorizationCodeParameter = "code";
+            public const string ErrorCodeParameter = "error";
+            public const string ErrorDescriptionParameter = "error_description";
+            public const string ErrorUriParameter = "error_uri";
+            public const string StateParameter = "state";
+        }
+
+        public static class TokenEndpoint
+        {
+            public const string GrantTypeParameter = "grant_type";
+            public const string AuthorizationCodeGrantType = "authorization_code";
+            public const string RefreshTokenGrantType = "refresh_token";
+            public const string PkceVerifierParameter = "code_verifier";
+            public const string AuthorizationCodeParameter = "code";
+            public const string RefreshTokenParameter = "refresh_token";
+        }
+
+        public static class DeviceAuthorization
+        {
+            public const string GrantTypeParameter = "grant_type";
+            public const string DeviceCodeParameter = "device_code";
+            public const string DeviceCodeGrantType = "urn:ietf:params:oauth:grant-type:device_code";
+
+            public static class Errors
+            {
+                public const string AuthorizationPending = "authorization_pending";
+                public const string SlowDown = "slow_down";
+            }
+        }
+    }
+}

--- a/src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/OAuth2CryptographicGenerator.cs
+++ b/src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/OAuth2CryptographicGenerator.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace GitCredentialManager.Authentication.OAuth
+{
+    public enum OAuth2PkceChallengeMethod
+    {
+        Plain = 0,
+        Sha256 = 1
+    }
+
+    public interface IOAuth2CodeGenerator
+    {
+        /// <summary>
+        /// Create a random string value suitable for use as a nonce.
+        /// </summary>
+        /// <returns>A random string.</returns>
+        string CreateNonce();
+
+        /// <summary>
+        /// Create a cryptographically random code verifier for use with Proof Key for Code Exchange (PKCE).
+        /// </summary>
+        /// <returns>PKCE code verifier.</returns>
+        string CreatePkceCodeVerifier();
+
+        /// <summary>
+        /// Create a code challenge for the given Proof Key for Code Exchange (PKCE) code verifier.
+        /// </summary>
+        /// <param name="challengeMethod">Challenge method.</param>
+        /// /// <param name="codeVerifier">PKCE code verifier.</param>
+        /// <returns>PKCE code challenge.</returns>
+        string CreatePkceCodeChallenge(OAuth2PkceChallengeMethod challengeMethod, string codeVerifier);
+    }
+
+    public class OAuth2CryptographicCodeGenerator : IOAuth2CodeGenerator
+    {
+        // Do not include padding of the base64url string to avoid percent-encoding when passed in a URI
+        private const bool PkceIncludeBase64UrlPadding = false;
+
+        public string CreateNonce()
+        {
+            return Guid.NewGuid().ToString("N");
+        }
+
+        public string CreatePkceCodeVerifier()
+        {
+            //
+            // RFC 7636 requires the code verifier to match the following ABNF:
+            //
+            //   code-verifier = 43*128unreserved
+            //   unreserved = ALPHA / DIGIT / "-" / "." / "_" / "~"
+            //   ALPHA = %x41-5A / %x61-7A
+            //   DIGIT = %x30-39
+            //
+            // The base64url encoding (RFC 6749) is a subset of these characters
+            // so we opt to convert our random bytes into Base64URL format for
+            // the code verifier.
+            //
+            // RFC 7636 mandates the code verifier must be between 43 and 128 characters
+            // long (inclusive). We want to generate a string at the top end of this range
+            // for maximum entropy. At the same time we want to avoid using the padding
+            // character '=' because this character is percent-encoded when used in URLs.
+            // To avoid padding we need the number of input bytes to be divisible by 3.
+            //
+            // In order to achieve 128 base64url characters AND avoid padding we should
+            // generate exactly 96 random bytes. Why 96 bytes? 96 is divisible by 3 and:
+            //
+            //   96 bytes -> 768 bits -> 128 base64url characters (6 bits per character)
+            //
+            var buf = new byte[96];
+            var rng = RandomNumberGenerator.Create();
+            rng.GetBytes(buf);
+
+            return Base64UrlConvert.Encode(buf, PkceIncludeBase64UrlPadding);
+        }
+
+        public string CreatePkceCodeChallenge(OAuth2PkceChallengeMethod challengeMethod, string codeVerifier)
+        {
+            switch (challengeMethod)
+            {
+                case OAuth2PkceChallengeMethod.Plain:
+                    return codeVerifier;
+
+                case OAuth2PkceChallengeMethod.Sha256:
+                    // The "S256" code challenge is computed as follows, per RFC 7636:
+                    //
+                    //   code_challenge = BASE64URL-ENCODE(SHA256(ASCII(code_verifier)))
+                    //
+                    using (var sha256 = SHA256.Create())
+                    {
+                        return Base64UrlConvert.Encode(
+                            sha256.ComputeHash(
+                                Encoding.ASCII.GetBytes(codeVerifier)
+                            ),
+                            PkceIncludeBase64UrlPadding
+                        );
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(challengeMethod), challengeMethod, "Unknown PKCE code challenge method.");
+            }
+        }
+    }
+}

--- a/src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/OAuth2DeviceCodeResult.cs
+++ b/src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/OAuth2DeviceCodeResult.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace GitCredentialManager.Authentication.OAuth
+{
+    public class OAuth2DeviceCodeResult
+    {
+        public OAuth2DeviceCodeResult(string deviceCode, string userCode, Uri verificationUri, TimeSpan? interval)
+        {
+            DeviceCode = deviceCode;
+            UserCode = userCode;
+            VerificationUri = verificationUri;
+            PollingInterval = interval ?? TimeSpan.FromSeconds(5);
+        }
+
+        public string DeviceCode { get; }
+
+        public string UserCode { get; }
+
+        public Uri VerificationUri { get; }
+
+        public TimeSpan PollingInterval { get; }
+
+        public TimeSpan? ExpiresIn { get; internal set; }
+    }
+}

--- a/src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/OAuth2Exception.cs
+++ b/src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/OAuth2Exception.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace GitCredentialManager.Authentication.OAuth
+{
+    public class OAuth2Exception : Exception
+    {
+        public OAuth2Exception(string message) : base(message) { }
+
+        public OAuth2Exception(string message, Exception innerException) : base(message, innerException) { }
+    }
+}

--- a/src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/OAuth2ServerEndpoints.cs
+++ b/src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/OAuth2ServerEndpoints.cs
@@ -1,0 +1,39 @@
+using System;
+
+namespace GitCredentialManager.Authentication.OAuth
+{
+    /// <summary>
+    /// Represents the various OAuth2 endpoints for an <see cref="OAuth2Client"/>.
+    /// </summary>
+    public class OAuth2ServerEndpoints
+    {
+        private Uri _deviceAuthorizationEndpoint;
+
+        public OAuth2ServerEndpoints(Uri authorizationEndpoint, Uri tokenEndpoint)
+        {
+            EnsureArgument.AbsoluteUri(authorizationEndpoint, nameof(authorizationEndpoint));
+            EnsureArgument.AbsoluteUri(tokenEndpoint, nameof(tokenEndpoint));
+
+            AuthorizationEndpoint = authorizationEndpoint;
+            TokenEndpoint = tokenEndpoint;
+        }
+
+        public Uri AuthorizationEndpoint { get; }
+
+        public Uri TokenEndpoint { get; }
+
+        public Uri DeviceAuthorizationEndpoint
+        {
+            get => _deviceAuthorizationEndpoint;
+            set
+            {
+                if (value != null)
+                {
+                    EnsureArgument.AbsoluteUri(value, nameof(value));
+                }
+
+                _deviceAuthorizationEndpoint = value;
+            }
+        }
+    }
+}

--- a/src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/OAuth2SystemWebBrowser.cs
+++ b/src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/OAuth2SystemWebBrowser.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GitCredentialManager.Authentication.OAuth
+{
+    public class OAuth2WebBrowserOptions
+    {
+        internal const string DefaultSuccessHtml = @"<!DOCTYPE html><html><head>
+<style>body{font-family:sans-serif;}dt{font-weight:bold;}dd{margin-bottom:10px;}</style>
+<title>Authentication successful</title></head>
+<body><h1>Authentication successful</h1><p>You can now close this page.</p></body>
+</html>";
+        internal const string DefaultFailureHtmlFormat = @"<!DOCTYPE html><html><head>
+<style>body{{font-family:sans-serif;}}dt{{font-weight:bold;}}dd{{margin-bottom:10px;}}</style>
+<title>Authentication failed</title></head>
+<body><h1>Authentication failed</h1><dl>
+<dt>Error:</dt><dd>{0}</dd>
+<dt>Description:</dt><dd>{1}</dd>
+<dt>URL:</dt><dd>{2}</dd>
+</dl></body></html>";
+
+        public string SuccessResponseHtml { get; set; }
+        public string FailureResponseHtmlFormat { get; set; }
+
+        public Uri SuccessRedirect { get; set; }
+        public Uri FailureRedirectFormat { get; set; }
+    }
+
+    public class OAuth2SystemWebBrowser : IOAuth2WebBrowser
+    {
+        private readonly IEnvironment _environment;
+        private readonly OAuth2WebBrowserOptions _options;
+
+        public OAuth2SystemWebBrowser(IEnvironment environment, OAuth2WebBrowserOptions options)
+        {
+            EnsureArgument.NotNull(environment, nameof(environment));
+            EnsureArgument.NotNull(options, nameof(options));
+
+            _environment = environment;
+            _options = options;
+        }
+
+        public Uri UpdateRedirectUri(Uri uri)
+        {
+            if (!uri.IsLoopback)
+            {
+                throw new ArgumentException("Only localhost is supported as a redirect URI.", nameof(uri));
+            }
+
+            // If a port has been specified use it, otherwise find a free one
+            if (uri.IsDefaultPort)
+            {
+                int port = GetFreeTcpPort();
+                return new UriBuilder(uri) {Port = port}.Uri;
+            }
+
+            return uri;
+        }
+
+        public async Task<Uri> GetAuthenticationCodeAsync(Uri authorizationUri, Uri redirectUri, CancellationToken ct)
+        {
+            if (!redirectUri.IsLoopback)
+            {
+                throw new ArgumentException("Only localhost is supported as a redirect URI.", nameof(redirectUri));
+            }
+
+            Task<Uri> interceptTask = InterceptRequestsAsync(redirectUri, ct);
+
+            BrowserUtils.OpenDefaultBrowser(_environment, authorizationUri);
+
+            return await interceptTask;
+        }
+
+        private async Task<Uri> InterceptRequestsAsync(Uri listenUri, CancellationToken ct)
+        {
+            // Create a TaskCompletionSource which completes when we're asked to cancel.
+            // We can then await the this task together with other tasks that don't take a
+            // CancellationToken and exit the method quickly when cancelled.
+            var tcs = new TaskCompletionSource<Uri>();
+            ct.Register(() => tcs.SetCanceled());
+
+            // Prefixes must end with a '/'
+            string prefix = listenUri.GetLeftPart(UriPartial.Path);
+            if (!prefix.EndsWith("/"))
+            {
+                prefix += "/";
+            }
+
+            var listener = new HttpListener {Prefixes = {prefix}};
+            listener.Start();
+
+            try
+            {
+                Task<HttpListenerContext> contextTask = listener.GetContextAsync();
+                Task<Uri> cancelTask = tcs.Task;
+
+                Task completedTask = await Task.WhenAny(contextTask, tcs.Task);
+
+                // Check if we 'completed' the context task or the cancellation task
+                if (completedTask == cancelTask)
+                {
+                    // We were cancelled!
+                    return await cancelTask;
+                }
+
+                // We intercepted a request!
+                HttpListenerContext context = await contextTask;
+
+                await HandleInterceptedRequestAsync(context.Request, context.Response);
+
+                // Return the final intercepted URI
+                return context.Request.Url;
+            }
+            finally
+            {
+                listener.Stop();
+                listener.Close();
+            }
+        }
+
+        private async Task HandleInterceptedRequestAsync(HttpListenerRequest request, HttpListenerResponse response)
+        {
+            IDictionary<string, string> queryParams = request.QueryString.ToDictionary(StringComparer.OrdinalIgnoreCase);
+
+            // If we have an error value then the request failed and we should reply with a page containing the error information
+            bool hasError = queryParams.TryGetValue(OAuth2Constants.AuthorizationGrantResponse.ErrorCodeParameter, out string errorCode);
+            queryParams.TryGetValue(OAuth2Constants.AuthorizationGrantResponse.ErrorDescriptionParameter, out string errorDescription);
+            queryParams.TryGetValue(OAuth2Constants.AuthorizationGrantResponse.ErrorUriParameter, out string errorUri);
+            if (hasError)
+            {
+                string FormatError(string format)
+                {
+                    if (string.IsNullOrWhiteSpace(errorCode)) errorCode = "unknown";
+                    if (string.IsNullOrWhiteSpace(errorDescription)) errorDescription = "Unknown error.";
+                    if (string.IsNullOrWhiteSpace(errorUri)) errorUri = "none";
+                    return string.Format(format, errorCode, errorDescription, errorUri);
+                }
+
+                // Prefer redirection options to raw HTML
+                if (_options.FailureRedirectFormat != null)
+                {
+                    string failureUrl = FormatError(_options.FailureRedirectFormat.ToString());
+                    response.Redirect(failureUrl);
+                    response.Close();
+                }
+                else
+                {
+                    string failureHtml = FormatError(_options.FailureResponseHtmlFormat ?? OAuth2WebBrowserOptions.DefaultFailureHtmlFormat);
+                    await response.WriteResponseAsync(failureHtml);
+                    response.Close();
+                }
+            }
+            else
+            {
+                // Prefer redirection options to raw HTML
+                if (_options.SuccessRedirect != null)
+                {
+                    string successUrl = _options.SuccessRedirect.ToString();
+                    response.Redirect(successUrl);
+                    response.Close();
+                }
+                else
+                {
+                    string successHtml = _options.SuccessResponseHtml ?? OAuth2WebBrowserOptions.DefaultSuccessHtml;
+                    await response.WriteResponseAsync(successHtml);
+                    response.Close();
+                }
+            }
+        }
+
+        private static int GetFreeTcpPort()
+        {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+
+            try
+            {
+                listener.Start();
+                return ((IPEndPoint) listener.LocalEndpoint).Port;
+            }
+            finally
+            {
+                listener.Stop();
+            }
+        }
+
+    }
+}

--- a/src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/OAuth2TokenResult.cs
+++ b/src/Core/Authentication/OAuth/src/shared/Core/Authentication/OAuth/OAuth2TokenResult.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace GitCredentialManager.Authentication.OAuth
+{
+    public class OAuth2TokenResult
+    {
+        public OAuth2TokenResult(string accessToken, string tokenType)
+        {
+            AccessToken = accessToken;
+            TokenType = tokenType;
+        }
+
+        public string AccessToken { get; }
+
+        public string TokenType { get; }
+
+        public string RefreshToken { get; set; }
+
+        public TimeSpan? ExpiresIn { get; set; }
+
+        public string[] Scopes { get; set; }
+    }
+}

--- a/src/Core/Base64UrlConvert.cs
+++ b/src/Core/Base64UrlConvert.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace GitCredentialManager
+{
+    public static class Base64UrlConvert
+    {
+        public static string Encode(byte[] data, bool includePadding = true)
+        {
+            const char base64PadCharacter = '=';
+            const char base64Character62 = '+';
+            const char base64Character63 = '/';
+            const char base64UrlCharacter62 = '-';
+            const char base64UrlCharacter63 = '_';
+
+            // The base64url format is the same as regular base64 format except:
+            //   1. character 62 is "-" (minus) not "+" (plus)
+            //   2. character 63 is "_" (underscore) not "/" (slash)
+            string base64Url = Convert.ToBase64String(data)
+                .Replace(base64Character62, base64UrlCharacter62)
+                .Replace(base64Character63, base64UrlCharacter63);
+
+            return includePadding ? base64Url : base64Url.TrimEnd(base64PadCharacter);
+        }
+    }
+}

--- a/src/Core/BrowserUtils.cs
+++ b/src/Core/BrowserUtils.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Diagnostics;
+
+namespace GitCredentialManager
+{
+    public static class BrowserUtils
+    {
+        public static void OpenDefaultBrowser(IEnvironment environment, string url)
+        {
+            if (!Uri.TryCreate(url, UriKind.Absolute, out Uri uri))
+            {
+                throw new ArgumentException($"Not a valid URI: '{url}'");
+            }
+
+            OpenDefaultBrowser(environment, uri);
+        }
+
+        public static void OpenDefaultBrowser(IEnvironment environment, Uri uri)
+        {
+            if (!uri.Scheme.Equals(Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) &&
+                !uri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new ArgumentException("Can only open HTTP/HTTPS URIs", nameof(uri));
+            }
+
+            string url = uri.ToString();
+
+            ProcessStartInfo psi;
+            if (PlatformUtils.IsLinux())
+            {
+                //
+                // On Linux, 'shell execute' utilities like xdg-open launch a process without
+                // detaching from the standard in/out descriptors. Some applications (like
+                // Chromium) write messages to stdout, which is currently hooked up and being
+                // consumed by Git, and cause errors.
+                //
+                // Sadly, the Framework does not allow us to redirect standard streams if we
+                // set ProcessStartInfo::UseShellExecute = true, so we must manually launch
+                // these utilities and redirect the standard streams manually.
+                //
+                // We try and use the same 'shell execute' utilities as the Framework does,
+                // searching for them in the same order until we find one.
+                //
+                if (!TryGetLinuxShellExecuteHandler(environment, out string shellExecPath))
+                {
+                    throw new Exception("Failed to locate a utility to launch the default web browser.");
+                }
+
+                psi = new ProcessStartInfo(shellExecPath, url)
+                {
+                    RedirectStandardOutput = true,
+                    // Ok to redirect stderr for non-git-related processes
+                    RedirectStandardError = true
+                };
+            }
+            else
+            {
+                // On Windows and macOS, `ShellExecute` and `/usr/bin/open` disconnect the child process
+                // from our standard in/out streams, so we can just use the Framework to do this.
+                psi = new ProcessStartInfo(url) {UseShellExecute = true};
+            }
+
+            // We purposefully do not use a ChildProcess here, as the purpose of that
+            // class is to allow us to collect child process information using TRACE2.
+            // Since we will not be collecting TRACE2 data from the browser, there
+            // is no need to add the extra overhead associated with ChildProcess here.
+            Process.Start(psi);
+        }
+
+        public static bool TryGetLinuxShellExecuteHandler(IEnvironment env, out string shellExecPath)
+        {
+            // One additional 'shell execute' utility we also attempt to use over the Framework
+            // is `wslview` that is commonly found on WSL (Windows Subsystem for Linux) distributions
+            // that opens the browser on the Windows host.
+            string[] shellHandlers = { "xdg-open", "gnome-open", "kfmclient", WslUtils.WslViewShellHandlerName };
+            foreach (string shellExec in shellHandlers)
+            {
+                if (env.TryLocateExecutable(shellExec, out shellExecPath))
+                {
+                    return true;
+                }
+            }
+
+            shellExecPath = null;
+            return false;
+        }
+    }
+}

--- a/src/Core/ChildProcess.cs
+++ b/src/Core/ChildProcess.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace GitCredentialManager;
+
+public class ChildProcess : DisposableObject
+{
+    private readonly ITrace2 _trace2;
+
+    private DateTimeOffset _startTime;
+    private DateTimeOffset _exitTime => Process.ExitTime;
+    private ProcessStartInfo _startInfo => Process.StartInfo;
+
+    private int _id => Process.Id;
+
+    public ProcessStartInfo StartInfo => Process.StartInfo;
+    public Process Process { get; }
+    public StreamWriter StandardInput => Process.StandardInput;
+    public StreamReader StandardOutput => Process.StandardOutput;
+    public StreamReader StandardError => Process.StandardError;
+    public int ExitCode => Process.ExitCode;
+
+    public static ChildProcess Start(ITrace2 trace2, ProcessStartInfo startInfo, Trace2ProcessClass processClass)
+    {
+        var childProc = new ChildProcess(trace2, startInfo);
+        childProc.Start(processClass);
+        return childProc;
+    }
+
+    public ChildProcess(ITrace2 trace2, ProcessStartInfo startInfo)
+    {
+        _trace2 = trace2;
+        Process = new Process() { StartInfo = startInfo };
+        Process.Exited += ProcessOnExited;
+    }
+
+    public bool Start(Trace2ProcessClass processClass)
+    {
+        ThrowIfDisposed();
+        // Record the time just before the process starts, since:
+        // (1) There is no event related to Start as there is with Exit.
+        // (2) Using Process.StartTime causes a race condition that leads
+        // to an exception if the process finishes executing before the
+        // variable is passed to Trace2.
+        _startTime = DateTimeOffset.UtcNow;
+        _trace2.WriteChildStart(
+            _startTime,
+            processClass,
+            _startInfo.UseShellExecute,
+            _startInfo.FileName,
+            _startInfo.Arguments);
+        return Process.Start();
+    }
+
+    public void WaitForExit() => Process.WaitForExit();
+
+    public void Kill() => Process.Kill();
+
+    protected override void ReleaseManagedResources()
+    {
+        Process.Exited -= ProcessOnExited;
+        Process.Dispose();
+        base.ReleaseUnmanagedResources();
+    }
+
+    private void ProcessOnExited(object sender, EventArgs e)
+    {
+        if (sender is Process)
+        {
+            double elapsedTime = (_exitTime - _startTime).TotalSeconds;
+            _trace2.WriteChildExit(
+                elapsedTime,
+                _id,
+                Process.ExitCode);
+        }
+    }
+}

--- a/src/Core/CommandContext.cs
+++ b/src/Core/CommandContext.cs
@@ -1,0 +1,250 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using GitCredentialManager.Interop.Linux;
+using GitCredentialManager.Interop.MacOS;
+using GitCredentialManager.Interop.Posix;
+using GitCredentialManager.Interop.Windows;
+
+namespace GitCredentialManager
+{
+    /// <summary>
+    /// Represents the execution environment for a Git credential helper command.
+    /// </summary>
+    public interface ICommandContext : IDisposable
+    {
+        /// <summary>
+        /// Absolute path the application entry executable.
+        /// </summary>
+        string ApplicationPath { get; set; }
+
+        /// <summary>
+        /// Absolute path to the Git Credential Manager installation directory.
+        /// </summary>
+        string InstallationDirectory { get; }
+
+        /// <summary>
+        /// Settings and configuration for Git Credential Manager.
+        /// </summary>
+        ISettings Settings { get; }
+
+        /// <summary>
+        /// Standard I/O text streams, typically connected to the parent Git process.
+        /// </summary>
+        IStandardStreams Streams { get; }
+
+        /// <summary>
+        /// The attached terminal (TTY) to this process tree.
+        /// </summary>
+        ITerminal Terminal { get; }
+
+        /// <summary>
+        /// Provides services regarding user sessions.
+        /// </summary>
+        ISessionManager SessionManager { get; }
+
+        /// <summary>
+        /// Application tracing system.
+        /// </summary>
+        ITrace Trace { get; }
+
+        /// <summary>
+        /// Application TRACE2 tracing system.
+        /// </summary>
+        ITrace2 Trace2 { get; }
+
+        /// <summary>
+        /// File system abstraction (exists mainly for testing).
+        /// </summary>
+        IFileSystem FileSystem { get; }
+
+        /// <summary>
+        /// Secure credential storage.
+        /// </summary>
+        ICredentialStore CredentialStore { get; }
+
+        /// <summary>
+        /// Factory for creating new <see cref="System.Net.Http.HttpClient"/> instances.
+        /// </summary>
+        IHttpClientFactory HttpClientFactory { get; }
+
+        /// <summary>
+        /// Component for interacting with Git.
+        /// </summary>
+        IGit Git { get; }
+
+        /// <summary>
+        /// The current process environment.
+        /// </summary>
+        IEnvironment Environment { get; }
+
+        /// <summary>
+        /// Process manager.
+        /// </summary>
+        IProcessManager ProcessManager { get; }
+    }
+
+    /// <summary>
+    /// Real command execution environment using the actual <see cref="Console"/>, file system calls and environment.
+    /// </summary>
+    public class CommandContext : DisposableObject, ICommandContext
+    {
+        public CommandContext()
+        {
+            ApplicationPath = GetEntryApplicationPath();
+            InstallationDirectory = GetInstallationDirectory();
+
+            Streams = new StandardStreams();
+            Trace   = new Trace();
+            Trace2  = new Trace2(this);
+
+            if (PlatformUtils.IsWindows())
+            {
+                FileSystem        = new WindowsFileSystem();
+                Environment       = new WindowsEnvironment(FileSystem);
+                SessionManager    = new WindowsSessionManager(Environment, FileSystem);
+                ProcessManager    = new WindowsProcessManager(Trace2);
+                Terminal          = new WindowsTerminal(Trace, Trace2);
+                string gitPath    = GetGitPath(Environment, FileSystem, Trace);
+                Git               = new GitProcess(
+                                            Trace,
+                                            Trace2,
+                                            ProcessManager,
+                                            gitPath,
+                                            FileSystem.GetCurrentDirectory()
+                                        );
+                Settings          = new WindowsSettings(Environment, Git, Trace);
+            }
+            else if (PlatformUtils.IsMacOS())
+            {
+                FileSystem        = new MacOSFileSystem();
+                Environment       = new MacOSEnvironment(FileSystem);
+                SessionManager    = new MacOSSessionManager(Environment, FileSystem);
+                ProcessManager    = new ProcessManager(Trace2);
+                Terminal          = new MacOSTerminal(Trace, Trace2);
+                string gitPath    = GetGitPath(Environment, FileSystem, Trace);
+                Git               = new GitProcess(
+                                            Trace,
+                                            Trace2,
+                                            ProcessManager,
+                                            gitPath,
+                                            FileSystem.GetCurrentDirectory()
+                                        );
+                Settings          = new Settings(Environment, Git);
+            }
+            else if (PlatformUtils.IsLinux())
+            {
+                FileSystem        = new LinuxFileSystem();
+                Environment       = new PosixEnvironment(FileSystem);
+                SessionManager    = new LinuxSessionManager(Environment, FileSystem);
+                ProcessManager    = new ProcessManager(Trace2);
+                Terminal          = new LinuxTerminal(Trace, Trace2);
+                string gitPath    = GetGitPath(Environment, FileSystem, Trace);
+                Git               = new GitProcess(
+                                            Trace,
+                                            Trace2,
+                                            ProcessManager,
+                                            gitPath,
+                                            FileSystem.GetCurrentDirectory()
+                                        );
+                Settings          = new Settings(Environment, Git);
+            }
+            else
+            {
+                throw new PlatformNotSupportedException();
+            }
+
+            HttpClientFactory = new HttpClientFactory(FileSystem, Trace, Trace2, Settings, Streams);
+            CredentialStore   = new CredentialStore(this);
+        }
+
+        private static string GetGitPath(IEnvironment environment, IFileSystem fileSystem, ITrace trace)
+        {
+            const string unixGitName = "git";
+            const string winGitName = "git.exe";
+
+            string gitExecPath;
+            string programName = PlatformUtils.IsWindows() ? winGitName : unixGitName;
+
+            // Use the GIT_EXEC_PATH environment variable if set
+            if (environment.Variables.TryGetValue(Constants.EnvironmentVariables.GitExecutablePath,
+                out gitExecPath))
+            {
+                // If we're invoked from WSL we must locate the UNIX Git executable
+                if (PlatformUtils.IsWindows() && WslUtils.IsWslPath(gitExecPath))
+                {
+                    programName = unixGitName;
+                }
+
+                string candidatePath = Path.Combine(gitExecPath, programName);
+                if (fileSystem.FileExists(candidatePath))
+                {
+                    trace.WriteLine($"Using Git executable from GIT_EXEC_PATH: {candidatePath}");
+                    return candidatePath;
+                }
+            }
+
+            // Otherwise try to locate the git(.exe) on the current PATH
+            gitExecPath = environment.LocateExecutable(programName);
+            trace.WriteLine($"Using PATH-located Git executable: {gitExecPath}");
+            return gitExecPath;
+        }
+
+        #region ICommandContext
+
+        public string ApplicationPath { get; set; }
+
+        public string InstallationDirectory { get; }
+
+        public ISettings Settings { get; }
+
+        public IStandardStreams Streams { get; }
+
+        public ITerminal Terminal { get; }
+
+        public ISessionManager SessionManager { get; }
+
+        public ITrace Trace { get; }
+
+        public ITrace2 Trace2 { get; }
+
+        public IFileSystem FileSystem { get; }
+
+        public ICredentialStore CredentialStore { get; }
+
+        public IHttpClientFactory HttpClientFactory { get; }
+
+        public IGit Git { get; }
+
+        public IEnvironment Environment { get; }
+
+        public IProcessManager ProcessManager { get; }
+
+        #endregion
+
+        #region IDisposable
+
+        protected override void ReleaseManagedResources()
+        {
+            Settings?.Dispose();
+            Trace?.Dispose();
+
+            base.ReleaseManagedResources();
+        }
+
+        #endregion
+
+        public static string GetEntryApplicationPath()
+        {
+            return PlatformUtils.GetNativeEntryPath() ??
+                   Process.GetCurrentProcess().MainModule?.FileName ??
+                   System.Environment.GetCommandLineArgs()[0];
+        }
+
+        public static string GetInstallationDirectory()
+        {
+            return AppContext.BaseDirectory;
+        }
+    }
+}

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -1,0 +1,273 @@
+using System;
+using System.Reflection;
+
+namespace GitCredentialManager
+{
+    public static class Constants
+    {
+        public const string DefaultWindowTitle = "Git Credential Manager";
+        public const string PersonalAccessTokenUserName = "PersonalAccessToken";
+        public const string DefaultCredentialNamespace = "git";
+        public const int DefaultAutoDetectProviderTimeoutMs = 2000; // 2 seconds
+        public const string DefaultUiHelper = "git-credential-manager-ui";
+
+        public const string ProviderIdAuto  = "auto";
+        public const string AuthorityIdAuto = "auto";
+
+        public const string GcmDataDirectoryName = ".gcm";
+
+        public static readonly Guid DevBoxPartnerId = new("e3171dd9-9a5f-e5be-b36c-cc7c4f3f3bcf");
+
+        /// <summary>
+        /// Home tenant ID for Microsoft Accounts (MSA).
+        /// </summary>
+        public static readonly Guid MsaHomeTenantId = new("9188040d-6c67-4c5b-b112-36a304b66dad");
+
+        /// <summary>
+        /// Special tenant ID for transferring between Microsoft Account (MSA) native tokens
+        /// and AAD tokens. Only required for MSA-Passthrough applications.
+        /// </summary>
+        public static readonly Guid MsaTransferTenantId = new("f8cdef31-a31e-4b4a-93e4-5f571e91255a");
+
+        public static class CredentialStoreNames
+        {
+            public const string WindowsCredentialManager = "wincredman";
+            public const string Dpapi = "dpapi";
+            public const string MacOSKeychain = "keychain";
+            public const string Gpg = "gpg";
+            public const string SecretService = "secretservice";
+            public const string Plaintext = "plaintext";
+            public const string Cache = "cache";
+        }
+
+        public static class RegexPatterns
+        {
+            /// <summary>
+            /// A regular expression that matches any value.
+            /// </summary>
+            public const string Any = @".*";
+
+            /// <summary>
+            /// A regular expression that matches no value.
+            /// </summary>
+            public const string None = @"$.+";
+
+            /// <summary>
+            /// A regular expression that matches empty strings.
+            /// </summary>
+            public const string Empty = @"^$";
+        }
+
+        public static class EnvironmentVariables
+        {
+            public const string GcmTrace              = "GCM_TRACE";
+            public const string GcmTraceSecrets       = "GCM_TRACE_SECRETS";
+            public const string GcmTraceMsAuth        = "GCM_TRACE_MSAUTH";
+            public const string GcmDebug              = "GCM_DEBUG";
+            public const string GcmProvider           = "GCM_PROVIDER";
+            public const string GcmAuthority          = "GCM_AUTHORITY";
+            public const string GitTerminalPrompts    = "GIT_TERMINAL_PROMPT";
+            public const string GcmAllowWia           = "GCM_ALLOW_WINDOWSAUTH";
+            public const string GitTrace2Event        = "GIT_TRACE2_EVENT";
+            public const string GitTrace2Normal       = "GIT_TRACE2";
+            public const string GitTrace2Performance  = "GIT_TRACE2_PERF";
+
+            /*
+             * Unlike other environment variables, these proxy variables are normally lowercase only.
+             * However, libcurl also implemented checks for the uppercase variants! The lowercase
+             * variants should take precedence over the uppercase ones since the former are quasi-standard.
+             *
+             * One exception to this is that libcurl does not even look for the uppercase variant of
+             * http_proxy (for some security reasons).
+             */
+            public const string CurlNoProxy           = "no_proxy";
+            public const string CurlNoProxyUpper      = "NO_PROXY";
+            public const string CurlHttpsProxy        = "https_proxy";
+            public const string CurlHttpsProxyUpper   = "HTTPS_PROXY";
+            public const string CurlHttpProxy         = "http_proxy";
+            // Note there is no uppercase variant of the http_proxy since libcurl doesn't use it
+            public const string CurlAllProxy          = "all_proxy";
+            public const string CurlAllProxyUpper     = "ALL_PROXY";
+
+            public const string GcmHttpProxy          = "GCM_HTTP_PROXY";
+            public const string GitSslNoVerify        = "GIT_SSL_NO_VERIFY";
+            public const string GitSslCaInfo          = "GIT_SSL_CAINFO";
+            public const string GcmInteractive        = "GCM_INTERACTIVE";
+            public const string GcmParentWindow       = "GCM_MODAL_PARENTHWND";
+            public const string MsAuthFlow            = "GCM_MSAUTH_FLOW";
+            public const string MsAuthUseBroker       = "GCM_MSAUTH_USEBROKER";
+            public const string MsAuthUseDefaultAccount = "GCM_MSAUTH_USEDEFAULTACCOUNT";
+            public const string GcmCredNamespace      = "GCM_NAMESPACE";
+            public const string GcmCredentialStore    = "GCM_CREDENTIAL_STORE";
+            public const string GcmCredCacheOptions   = "GCM_CREDENTIAL_CACHE_OPTIONS";
+            public const string GcmPlaintextStorePath = "GCM_PLAINTEXT_STORE_PATH";
+            public const string GcmDpapiStorePath     = "GCM_DPAPI_STORE_PATH";
+            public const string GitExecutablePath     = "GIT_EXEC_PATH";
+            public const string GpgExecutablePath     = "GCM_GPG_PATH";
+            public const string GcmAutoDetectTimeout  = "GCM_AUTODETECT_TIMEOUT";
+            public const string GcmGuiPromptsEnabled  = "GCM_GUI_PROMPT";
+            public const string GcmUiHelper           = "GCM_UI_HELPER";
+            public const string OAuthAuthenticationModes = "GCM_OAUTH_AUTHMODES";
+            public const string OAuthClientId            = "GCM_OAUTH_CLIENTID";
+            public const string OAuthClientSecret        = "GCM_OAUTH_CLIENTSECRET";
+            public const string OAuthRedirectUri         = "GCM_OAUTH_REDIRECTURI";
+            public const string OAuthScopes              = "GCM_OAUTH_SCOPES";
+            public const string OAuthAuthzEndpoint       = "GCM_OAUTH_AUTHORIZE_ENDPOINT";
+            public const string OAuthTokenEndpoint       = "GCM_OAUTH_TOKEN_ENDPOINT";
+            public const string OAuthDeviceEndpoint      = "GCM_OAUTH_DEVICE_ENDPOINT";
+            public const string OAuthClientAuthHeader    = "GCM_OAUTH_USE_CLIENT_AUTH_HEADER";
+            public const string OAuthDefaultUserName     = "GCM_OAUTH_DEFAULT_USERNAME";
+            public const string GcmDevUseLegacyUiHelpers = "GCM_DEV_USELEGACYUIHELPERS";
+            public const string GcmGuiSoftwareRendering  = "GCM_GUI_SOFTWARE_RENDERING";
+        }
+
+        public static class Http
+        {
+            public const string WwwAuthenticateBasicScheme     = "Basic";
+            public const string WwwAuthenticateBearerScheme    = "Bearer";
+            public const string WwwAuthenticateNegotiateScheme = "Negotiate";
+            public const string WwwAuthenticateNtlmScheme      = "NTLM";
+
+            public const string MimeTypeJson = "application/json";
+        }
+
+        public static class GitConfiguration
+        {
+            public static class Credential
+            {
+                public const string SectionName = "credential";
+                public const string Helper      = "helper";
+                public const string Trace       = "trace";
+                public const string TraceSecrets = "traceSecrets";
+                public const string TraceMsAuth = "traceMsAuth";
+                public const string Debug       = "debug";
+                public const string Provider    = "provider";
+                public const string Authority   = "authority";
+                public const string AllowWia    = "allowWindowsAuth";
+                public const string HttpProxy   = "httpProxy";
+                public const string HttpsProxy  = "httpsProxy";
+                public const string UseHttpPath = "useHttpPath";
+                public const string Interactive = "interactive";
+                public const string MsAuthFlow  = "msauthFlow";
+                public const string MsAuthUseBroker = "msauthUseBroker";
+                public const string CredNamespace = "namespace";
+                public const string CredentialStore = "credentialStore";
+                public const string CredCacheOptions = "cacheOptions";
+                public const string PlaintextStorePath = "plaintextStorePath";
+                public const string DpapiStorePath = "dpapiStorePath";
+                public const string UserName = "username";
+                public const string AutoDetectTimeout = "autoDetectTimeout";
+                public const string GuiPromptsEnabled = "guiPrompt";
+                public const string UiHelper = "uiHelper";
+                public const string DevUseLegacyUiHelpers = "devUseLegacyUiHelpers";
+                public const string MsAuthUseDefaultAccount = "msauthUseDefaultAccount";
+                public const string GuiSoftwareRendering = "guiSoftwareRendering";
+
+                public const string OAuthAuthenticationModes = "oauthAuthModes";
+                public const string OAuthClientId            = "oauthClientId";
+                public const string OAuthClientSecret        = "oauthClientSecret";
+                public const string OAuthRedirectUri         = "oauthRedirectUri";
+                public const string OAuthScopes              = "oauthScopes";
+                public const string OAuthAuthzEndpoint       = "oauthAuthorizeEndpoint";
+                public const string OAuthTokenEndpoint       = "oauthTokenEndpoint";
+                public const string OAuthDeviceEndpoint      = "oauthDeviceEndpoint";
+                public const string OAuthClientAuthHeader    = "oauthUseClientAuthHeader";
+                public const string OAuthDefaultUserName     = "oauthDefaultUserName";
+            }
+
+            public static class Http
+            {
+                public const string SectionName = "http";
+                public const string Proxy = "proxy";
+                public const string SchannelUseSslCaInfo = "schannelUseSSLCAInfo";
+                public const string SslBackend = "sslBackend";
+                public const string SslVerify = "sslVerify";
+                public const string SslCaInfo = "sslCAInfo";
+                public const string SslAutoClientCert = "sslAutoClientCert";
+                public const string CookieFile = "cookieFile";
+            }
+
+            public static class Remote
+            {
+                public const string SectionName = "remote";
+                public const string FetchUrl = "url";
+                public const string PushUrl = "pushUrl";
+            }
+
+            public static class Trace2
+            {
+                public const string SectionName       = "trace2";
+                public const string EventTarget       = "eventtarget";
+                public const string NormalTarget      = "normaltarget";
+                public const string PerformanceTarget = "perftarget";
+            }
+        }
+
+        public static class WindowsRegistry
+        {
+            public const string HKAppBasePath = @"SOFTWARE\GitCredentialManager";
+            public const string HKConfigurationPath = HKAppBasePath + @"\Configuration";
+
+            public const string HKWindows365Path = @"SOFTWARE\Microsoft\Windows365";
+            public const string IsW365EnvironmentKeyName = "IsW365Environment";
+            public const string W365PartnerIdKeyName = "PartnerId";
+        }
+
+        public static class HelpUrls
+        {
+            public const string GcmProjectUrl          = "https://aka.ms/gcm";
+            public const string GcmNewIssue            = "https://aka.ms/gcm/bug";
+            public const string GcmAuthorityDeprecated = "https://aka.ms/gcm/authority";
+            public const string GcmHttpProxyGuide      = "https://aka.ms/gcm/httpproxy";
+            public const string GcmTlsVerification     = "https://aka.ms/gcm/tlsverify";
+            public const string GcmCredentialStores    = "https://aka.ms/gcm/credstores";
+            public const string GcmWamComSecurity      = "https://aka.ms/gcm/wamadmin";
+            public const string GcmAutoDetect          = "https://aka.ms/gcm/autodetect";
+            public const string GcmDefaultAccount      = "https://aka.ms/gcm/defaultaccount";
+            public const string GcmMultipleUsers       = "https://aka.ms/gcm/multipleusers";
+        }
+
+        private static Version _gcmVersion;
+
+        public static Version GcmVersion
+        {
+            get
+            {
+                if (_gcmVersion is null)
+                {
+                    var assembly = Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly();
+                    var attr = assembly.GetCustomAttribute<AssemblyFileVersionAttribute>();
+                    if (attr is null)
+                    {
+                        _gcmVersion = assembly.GetName().Version;
+                    }
+                    else if (Version.TryParse(attr.Version, out Version asmVersion))
+                    {
+                        _gcmVersion = asmVersion;
+                    }
+                    else
+                    {
+                        // Unknown version!
+                        _gcmVersion = new Version(0, 0);
+                    }
+                }
+
+                return _gcmVersion;
+            }
+        }
+
+        /// <summary>
+        /// Get the HTTP user-agent for Git Credential Manager.
+        /// </summary>
+        /// <returns>User-agent string for HTTP requests.</returns>
+        public static string GetHttpUserAgent(ITrace2 trace2)
+        {
+            PlatformInformation info = PlatformUtils.GetPlatformInformation(trace2);
+            string osType     = info.OperatingSystemType;
+            string cpuArch    = info.CpuArchitecture;
+            string clrVersion = info.ClrVersion;
+
+            return string.Format($"Git-Credential-Manager/{GcmVersion} ({osType}; {cpuArch}) CLR/{clrVersion}");
+        }
+    }
+}

--- a/src/Core/ConvertUtils.cs
+++ b/src/Core/ConvertUtils.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace GitCredentialManager
+{
+    public static class ConvertUtils
+    {
+        public static bool TryToInt32(object value, out int i)
+        {
+            return TryConvert(Convert.ToInt32, value, out i);
+        }
+
+        public static bool TryConvert<T>(Func<object, T> convert, object value, out T @out)
+        {
+            try
+            {
+                @out = convert(value);
+                return true;
+            }
+            catch
+            {
+                @out = default(T);
+                return false;
+            }
+        }
+    }
+}

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <Nullable>annotations</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.3" />
+  </ItemGroup>
+
+</Project>

--- a/src/Core/Credential.cs
+++ b/src/Core/Credential.cs
@@ -1,0 +1,35 @@
+
+namespace GitCredentialManager
+{
+    /// <summary>
+    /// Represents a credential.
+    /// </summary>
+    public interface ICredential
+    {
+        /// <summary>
+        /// Account associated with this credential.
+        /// </summary>
+        string Account { get; }
+
+        /// <summary>
+        /// Password.
+        /// </summary>
+        string Password { get; }
+    }
+
+    /// <summary>
+    /// Represents a credential (username/password pair) that Git can use to authenticate to a remote repository.
+    /// </summary>
+    public class GitCredential : ICredential
+    {
+        public GitCredential(string userName, string password)
+        {
+            Account = userName;
+            Password = password;
+        }
+
+        public string Account { get; }
+
+        public string Password { get; }
+    }
+}

--- a/src/Core/CredentialCacheStore.cs
+++ b/src/Core/CredentialCacheStore.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+
+namespace GitCredentialManager
+{
+    public class CredentialCacheStore : ICredentialStore
+    {
+        readonly IGit _git;
+        readonly string _options;
+
+        public CredentialCacheStore(IGit git, string options)
+        {
+            _git = git;
+            if (string.IsNullOrEmpty(options))
+            {
+                _options = string.Empty;
+            }
+            else
+            {
+                _options = options;
+            }
+        }
+
+        #region ICredentialStore
+
+        public IList<string> GetAccounts(string service)
+        {
+            // Listing accounts is not supported by the credential-cache store so we just attempt to retrieve
+            // the username from first credential for the given service and return an empty list if it fails.
+            var input = MakeGitCredentialsEntry(service, null);
+
+            var result = _git.InvokeHelperAsync(
+                $"credential-cache get {_options}",
+                input
+            ).GetAwaiter().GetResult();
+
+            if (result.TryGetValue("username", out string value))
+            {
+                return new List<string> { value };
+            }
+
+            return Array.Empty<string>();
+        }
+
+        public ICredential Get(string service, string account)
+        {
+            var input = MakeGitCredentialsEntry(service, account);
+
+            var result = _git.InvokeHelperAsync(
+                $"credential-cache get {_options}",
+                input
+            ).GetAwaiter().GetResult();
+
+            if (result.ContainsKey("username") && result.ContainsKey("password"))
+            {
+                return new GitCredential(result["username"], result["password"]);
+            }
+
+            return null;
+        }
+
+        public void AddOrUpdate(string service, string account, string secret)
+        {
+            var input = MakeGitCredentialsEntry(service, account);
+            input["password"] = secret;
+
+            // per https://git-scm.com/docs/gitcredentials :
+            // For a store or erase operation, the helper’s output is ignored.
+            _git.InvokeHelperAsync(
+                $"credential-cache store {_options}",
+                input
+            ).GetAwaiter().GetResult();
+        }
+
+        public bool Remove(string service, string account)
+        {
+            var input = MakeGitCredentialsEntry(service, account);
+
+            // per https://git-scm.com/docs/gitcredentials :
+            // For a store or erase operation, the helper’s output is ignored.
+            _git.InvokeHelperAsync(
+                $"credential-cache erase {_options}",
+                input
+            ).GetAwaiter().GetResult();
+
+            // the credential cache doesn't tell us whether anything was erased
+            // but we're optimistic sorts
+            return true;
+        }
+
+        #endregion
+
+        private Dictionary<string, string> MakeGitCredentialsEntry(string service, string account)
+        {
+            var result = new Dictionary<string, string>();
+
+            result["url"] = service;
+            if (!string.IsNullOrEmpty(account))
+            {
+                result["username"] = account;
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/Core/CredentialStore.cs
+++ b/src/Core/CredentialStore.cs
@@ -1,0 +1,368 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using GitCredentialManager.Interop.Linux;
+using GitCredentialManager.Interop.MacOS;
+using GitCredentialManager.Interop.Posix;
+using GitCredentialManager.Interop.Windows;
+using StoreNames = GitCredentialManager.Constants.CredentialStoreNames;
+
+namespace GitCredentialManager
+{
+    public class CredentialStore : ICredentialStore
+    {
+        private readonly ICommandContext _context;
+
+        private ICredentialStore _backingStore;
+
+        public CredentialStore(ICommandContext context)
+        {
+            EnsureArgument.NotNull(context, nameof(context));
+
+            _context = context;
+        }
+
+        #region ICredentialStore
+
+        public IList<string> GetAccounts(string service)
+        {
+            EnsureBackingStore();
+            return _backingStore.GetAccounts(service);
+        }
+
+        public ICredential Get(string service, string account)
+        {
+            EnsureBackingStore();
+            return _backingStore.Get(service, account);
+        }
+
+        public void AddOrUpdate(string service, string account, string secret)
+        {
+            EnsureBackingStore();
+            _backingStore.AddOrUpdate(service, account, secret);
+        }
+
+        public bool Remove(string service, string account)
+        {
+            EnsureBackingStore();
+            return _backingStore.Remove(service, account);
+        }
+
+        #endregion
+
+        private void EnsureBackingStore()
+        {
+            if (_backingStore != null)
+            {
+                return;
+            }
+
+            string ns = _context.Settings.CredentialNamespace;
+            string credStoreName = _context.Settings.CredentialBackingStore?.ToLowerInvariant()
+                                ?? GetDefaultStore();
+
+            switch (credStoreName)
+            {
+                case StoreNames.WindowsCredentialManager:
+                    ValidateWindowsCredentialManager();
+                    _backingStore = new WindowsCredentialManager(ns);
+                    break;
+
+                case StoreNames.Dpapi:
+                    ValidateDpapi(out string dpapiStoreRoot);
+                    _backingStore = new DpapiCredentialStore(_context.FileSystem, dpapiStoreRoot, ns);
+                    break;
+
+                case StoreNames.MacOSKeychain:
+                    ValidateMacOSKeychain();
+                    _backingStore = new MacOSKeychain(ns);
+                    break;
+
+                case StoreNames.SecretService:
+                    ValidateSecretService();
+                    _backingStore = new SecretServiceCollection(ns);
+                    break;
+
+                case StoreNames.Gpg:
+                    ValidateGpgPass(out string gpgStoreRoot, out string gpgExec);
+                    IGpg gpg = new Gpg(gpgExec, _context.SessionManager, _context.ProcessManager, _context.Trace2);
+                    _backingStore = new GpgPassCredentialStore(_context.FileSystem, gpg, gpgStoreRoot, ns);
+                    break;
+
+                case StoreNames.Cache:
+                    ValidateCredentialCache(out string options);
+                    _backingStore = new CredentialCacheStore(_context.Git, options);
+                    break;
+
+                case StoreNames.Plaintext:
+                    ValidatePlaintext(out string plainStoreRoot);
+                    _backingStore = new PlaintextCredentialStore(_context.FileSystem, plainStoreRoot, ns);
+                    break;
+
+                default:
+                    var sb = new StringBuilder();
+                    sb.AppendLine(string.IsNullOrWhiteSpace(credStoreName)
+                        ? "No credential store has been selected."
+                        : $"Unknown credential store '{credStoreName}'.");
+                    _context.Trace2.WriteError(sb.ToString());
+                    sb.AppendFormat(
+                        "{3}Set the {0} environment variable or the {1}.{2} Git configuration setting to one of the following options:{3}{3}",
+                        Constants.EnvironmentVariables.GcmCredentialStore,
+                        Constants.GitConfiguration.Credential.SectionName,
+                        Constants.GitConfiguration.Credential.CredentialStore,
+                        Environment.NewLine);
+                    AppendAvailableStoreList(sb);
+                    sb.AppendLine();
+                    sb.AppendLine($"See {Constants.HelpUrls.GcmCredentialStores} for more information.");
+                    throw new Exception(sb.ToString());
+            }
+        }
+
+        private static string GetDefaultStore()
+        {
+            if (PlatformUtils.IsWindows())
+                return StoreNames.WindowsCredentialManager;
+
+            if (PlatformUtils.IsMacOS())
+                return StoreNames.MacOSKeychain;
+
+            // Other platforms have no default store
+            return null;
+        }
+
+        private static void AppendAvailableStoreList(StringBuilder sb)
+        {
+            if (PlatformUtils.IsWindows())
+            {
+                sb.AppendFormat("  {1,-13} : Windows Credential Manager (not available over network/SSH sessions){0}",
+                    Environment.NewLine, StoreNames.WindowsCredentialManager);
+
+                sb.AppendFormat("  {1,-13} : DPAPI protected files{0}",
+                    Environment.NewLine, StoreNames.Dpapi);
+            }
+
+            if (PlatformUtils.IsMacOS())
+            {
+                sb.AppendFormat("  {1,-13} : macOS Keychain{0}",
+                    Environment.NewLine, StoreNames.MacOSKeychain);
+            }
+
+            if (PlatformUtils.IsLinux())
+            {
+                sb.AppendFormat("  {1,-13} : freedesktop.org Secret Service (requires graphical interface){0}",
+                    Environment.NewLine, StoreNames.SecretService);
+            }
+
+            if (PlatformUtils.IsPosix())
+            {
+                sb.AppendFormat("  {1,-13} : GNU `pass` compatible credential storage (requires GPG and `pass`){0}",
+                    Environment.NewLine, StoreNames.Gpg);
+            }
+
+            if (!PlatformUtils.IsWindows())
+            {
+                sb.AppendFormat("  {1,-13} : Git's in-memory credential cache{0}",
+                    Environment.NewLine, StoreNames.Cache);
+            }
+
+            sb.AppendFormat("  {1,-13} : store credentials in plain-text files (UNSECURE){0}",
+                Environment.NewLine, StoreNames.Plaintext);
+        }
+
+        private void ValidateWindowsCredentialManager()
+        {
+            if (!PlatformUtils.IsWindows())
+            {
+                var message = $"Can only use the '{StoreNames.WindowsCredentialManager}' credential store on Windows.";
+                _context.Trace2.WriteError(message);
+                throw new Exception(message + Environment.NewLine +
+                            $"See {Constants.HelpUrls.GcmCredentialStores} for more information."
+                );
+            }
+
+            if (!WindowsCredentialManager.CanPersist())
+            {
+                var message = $"Unable to persist credentials with the '{StoreNames.WindowsCredentialManager}' credential store.";
+                _context.Trace2.WriteError(message);
+                throw new Exception(message + Environment.NewLine +
+                    $"See {Constants.HelpUrls.GcmCredentialStores} for more information."
+                );
+            }
+        }
+
+        private void ValidateDpapi(out string storeRoot)
+        {
+            if (!PlatformUtils.IsWindows())
+            {
+                var message = $"Can only use the '{StoreNames.Dpapi}' credential store on Windows.";
+                _context.Trace2.WriteError(message);
+                throw new Exception(message  + Environment.NewLine +
+                    $"See {Constants.HelpUrls.GcmCredentialStores} for more information."
+                );
+            }
+
+            // Check for a redirected credential store location
+            if (!_context.Settings.TryGetSetting(
+                Constants.EnvironmentVariables.GcmDpapiStorePath,
+                Constants.GitConfiguration.Credential.SectionName,
+                Constants.GitConfiguration.Credential.DpapiStorePath,
+                out storeRoot))
+            {
+                // Use default store root at ~/.gcm/dpapi_store
+                storeRoot = Path.Combine(_context.FileSystem.UserDataDirectoryPath, "dpapi_store");
+            }
+        }
+
+        private void ValidateMacOSKeychain()
+        {
+            if (!PlatformUtils.IsMacOS())
+            {
+                var message = $"Can only use the '{StoreNames.MacOSKeychain}' credential store on macOS.";
+                _context.Trace2.WriteError(message);
+                throw new Exception(message  + Environment.NewLine +
+                                    $"See {Constants.HelpUrls.GcmCredentialStores} for more information."
+                );
+            }
+        }
+
+        private void ValidateSecretService()
+        {
+            if (!PlatformUtils.IsLinux())
+            {
+                var message = $"Can only use the '{StoreNames.SecretService}' credential store on Linux.";
+                _context.Trace2.WriteError(message);
+                throw new Exception(message + Environment.NewLine +
+                                    $"See {Constants.HelpUrls.GcmCredentialStores} for more information."
+                );
+            }
+
+            if (!_context.SessionManager.IsDesktopSession)
+            {
+                var message = $"Cannot use the '{StoreNames.SecretService}' credential backing store without a graphical interface present.";
+                _context.Trace2.WriteError(message);
+                throw new Exception(message + Environment.NewLine +
+                                    $"See {Constants.HelpUrls.GcmCredentialStores} for more information."
+                );
+            }
+        }
+
+        private void ValidateGpgPass(out string storeRoot, out string execPath)
+        {
+            if (!PlatformUtils.IsPosix())
+            {
+                var message = $"Can only use the '{StoreNames.Gpg}' credential store on POSIX systems.";
+                _context.Trace2.WriteError(message);
+                throw new Exception(message + Environment.NewLine +
+                                    $"See {Constants.HelpUrls.GcmCredentialStores} for more information."
+                );
+            }
+
+            execPath = GetGpgPath();
+
+            // If we are in a headless environment, and don't have the GPG_TTY or SSH_TTY
+            // variables set, then error - we need a TTY device path for pin-entry to work headless.
+            if (!_context.SessionManager.IsDesktopSession &&
+                !_context.Environment.Variables.ContainsKey("GPG_TTY") &&
+                !_context.Environment.Variables.ContainsKey("SSH_TTY"))
+            {
+                var message = "GPG_TTY is not set; add `export GPG_TTY=$(tty)` to your profile.";
+                _context.Trace2.WriteError(message);
+                throw new Exception(message + Environment.NewLine +
+                                    $"See {Constants.HelpUrls.GcmCredentialStores} for more information."
+                );
+            }
+
+            // Check for a redirected pass store location
+            if (!_context.Settings.TryGetSetting(
+                GpgPassCredentialStore.PasswordStoreDirEnvar,
+                null, null,
+                out storeRoot))
+            {
+                // Use default store root at ~/.password-store
+                storeRoot = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".password-store");
+            }
+
+            // Check we have a GPG ID to sign credential files with
+            string gpgIdFile = Path.Combine(storeRoot, ".gpg-id");
+            if (!_context.FileSystem.FileExists(gpgIdFile))
+            {
+                var format =
+                    "Password store has not been initialized at '{0}'; run `pass init <gpg-id>` to initialize the store.";
+                var message = string.Format(format, storeRoot);
+                _context.Trace2.WriteError(message);
+                throw new Exception(message + Environment.NewLine +
+                                    $"See {Constants.HelpUrls.GcmCredentialStores} for more information."
+                );
+            }
+        }
+
+        private void ValidateCredentialCache(out string options)
+        {
+            if (PlatformUtils.IsWindows())
+            {
+                var message = $"Can not use the '{StoreNames.Cache}' credential store on Windows due to lack of UNIX socket support in Git for Windows.";
+                _context.Trace2.WriteError(message);
+                throw new Exception(message + Environment.NewLine +
+                                    $"See {Constants.HelpUrls.GcmCredentialStores} for more information."
+                );
+            }
+
+            // allow for --timeout and other options
+            if (!_context.Settings.TryGetSetting(
+                Constants.EnvironmentVariables.GcmCredCacheOptions,
+                Constants.GitConfiguration.Credential.SectionName,
+                Constants.GitConfiguration.Credential.CredCacheOptions,
+                out options))
+            {
+                options = string.Empty;
+            }
+        }
+
+        private void ValidatePlaintext(out string storeRoot)
+        {
+            // Check for a redirected credential store location
+            if (!_context.Settings.TryGetSetting(
+                Constants.EnvironmentVariables.GcmPlaintextStorePath,
+                Constants.GitConfiguration.Credential.SectionName,
+                Constants.GitConfiguration.Credential.PlaintextStorePath,
+                out storeRoot))
+            {
+                // Use default store root at ~/.gcm/store
+                storeRoot = Path.Combine(_context.FileSystem.UserDataDirectoryPath, "store");
+            }
+        }
+
+        private string GetGpgPath()
+        {
+            string gpgPath;
+
+            // Use the GCM_GPG_PATH environment variable if set
+            if (_context.Environment.Variables.TryGetValue(Constants.EnvironmentVariables.GpgExecutablePath,
+                out gpgPath))
+            {
+                if (_context.FileSystem.FileExists(gpgPath))
+                {
+                    _context.Trace.WriteLine($"Using Git executable from GCM_GPG_PATH: {gpgPath}");
+                    return gpgPath;
+                }
+
+                var format = "GPG executable does not exist with path '{0}'";
+                var message = string.Format(format, gpgPath);
+                throw new Trace2Exception(_context.Trace2, message, format);
+            }
+
+            // If no explicit GPG path is specified, mimic the way `pass`
+            // determines GPG dependency (use gpg2 if available, otherwise gpg)
+            if (_context.Environment.TryLocateExecutable("gpg2", out string gpg2Path))
+            {
+                _context.Trace.WriteLine($"Using PATH-located GPG (gpg2) executable: {gpg2Path}");
+                return gpg2Path;
+            }
+
+            gpgPath = _context.Environment.LocateExecutable("gpg");
+            _context.Trace.WriteLine($"Using PATH-located GPG (gpg) executable: {gpgPath}");
+            return gpgPath;
+        }
+    }
+}

--- a/src/Core/CurlCookie.cs
+++ b/src/Core/CurlCookie.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using GitCredentialManager;
+
+namespace GitCredentialManager
+{
+    public class CurlCookieParser
+    {
+        private readonly ITrace _trace;
+
+        public CurlCookieParser(ITrace trace)
+        {
+            _trace = trace;
+        }
+
+        public IList<Cookie> Parse(string content)
+        {
+            if (string.IsNullOrWhiteSpace(content))
+            {
+                return Array.Empty<Cookie>();
+            }
+
+            const string HttpOnlyPrefix = "#HttpOnly_";
+
+            var cookies = new List<Cookie>();
+
+            // Parse the cookie file content
+            var lines = content.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+            foreach (var line in lines)
+            {
+                var parts = line.Split(new[] { '\t' }, StringSplitOptions.None);
+                if (parts.Length >= 7 && (!parts[0].StartsWith("#") || parts[0].StartsWith(HttpOnlyPrefix)))
+                {
+                    var domain = parts[0].StartsWith(HttpOnlyPrefix) ? parts[0].Substring(HttpOnlyPrefix.Length) : parts[0];
+                    var includeSubdomains = StringComparer.OrdinalIgnoreCase.Equals(parts[1], "TRUE");
+                    if (!includeSubdomains)
+                    {
+                        domain = domain.TrimStart('.');
+                    }
+                    var path = string.IsNullOrWhiteSpace(parts[2]) ? "/" : parts[2];
+                    var secureOnly = parts[3].Equals("TRUE", StringComparison.OrdinalIgnoreCase);
+                    var expires = ParseExpires(parts[4]);
+                    var name = parts[5];
+                    var value = parts[6];
+
+                    cookies.Add(new Cookie()
+                    {
+                        Domain = domain,
+                        Path = path,
+                        Expires = expires,
+                        HttpOnly = true,
+                        Secure = secureOnly,
+                        Name = name,
+                        Value = value,
+                    });
+                }
+                else
+                {
+                    _trace.WriteLine($"Invalid cookie line: {line}");
+                }
+            }
+
+            return cookies;
+        }
+
+        private static DateTime ParseExpires(string expires)
+        {
+#if NETFRAMEWORK || NETSTANDARD2_0
+            DateTime epoch = new DateTime(1970, 01, 01, 0, 0, 0, DateTimeKind.Utc);
+#else
+            DateTime epoch = DateTime.UnixEpoch;
+#endif
+
+            if (long.TryParse(expires, out long i))
+            {
+                return epoch.AddSeconds(i);
+            }
+
+            return epoch;
+        }
+    }
+}

--- a/src/Core/DictionaryExtensions.cs
+++ b/src/Core/DictionaryExtensions.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Web;
+
+namespace GitCredentialManager
+{
+    public static class DictionaryExtensions
+    {
+        /// <summary>
+        /// Get the value of a dictionary entry as 'booleany' (either 'truthy' or 'falsey').
+        /// </summary>
+        /// <param name="dict">Dictionary.</param>
+        /// <param name="key">Dictionary entry key.</param>
+        /// <param name="defaultValue">Default value if the key is not present, or was neither 'truthy' or 'falsey'.</param>
+        /// <returns>Dictionary entry value.</returns>
+        /// <remarks>
+        /// 'Truthy' and 'fasley' is defined by the implementation of <see cref="StringExtensions.IsTruthy"/> and <see cref="StringExtensions.IsFalsey"/>.
+        /// </remarks>
+        public static bool GetBooleanyOrDefault(this IReadOnlyDictionary<string, string> dict, string key, bool defaultValue)
+        {
+            if (dict.TryGetValue(key, out string value))
+            {
+                return value.ToBooleanyOrDefault(defaultValue);
+            }
+
+            return defaultValue;
+        }
+
+        public static string ToQueryString(this IDictionary<string, string> dict)
+        {
+            var sb = new StringBuilder();
+            int i = 0;
+
+            foreach (var kvp in dict)
+            {
+                string key  = HttpUtility.UrlEncode(kvp.Key);
+                string value = HttpUtility.UrlEncode(kvp.Value);
+
+                if (i > 0)
+                {
+                    sb.Append('&');
+                }
+
+                sb.AppendFormat("{0}={1}", key, value);
+
+                i++;
+            }
+
+            return sb.ToString();
+        }
+
+        public static void Append<TKey, TValue>(this IDictionary<TKey, ICollection<TValue>> dict, TKey key, TValue value)
+        {
+            if (!dict.TryGetValue(key, out var values))
+            {
+                values = new List<TValue>();
+                dict[key] = values;
+            }
+
+            values.Add(value);
+        }
+
+        public static IEnumerable<TValue> GetValues<TKey, TValue>(this IDictionary<TKey, IEnumerable<TValue>> dict, TKey key)
+        {
+            return dict.TryGetValue(key, out var values) ? values : Enumerable.Empty<TValue>();
+        }
+        
+        public static IEnumerable<TValue> GetValues<TKey, TValue>(this IDictionary<TKey, ICollection<TValue>> dict, TKey key)
+        {
+            return dict.TryGetValue(key, out var values) ? values : Enumerable.Empty<TValue>();
+        }
+
+        public static IDictionary<TKey, IEnumerable<TValue>> ToDictionary<TKey, TValue>(this IEnumerable<IGrouping<TKey, TValue>> grouping)
+        {
+            return grouping.ToDictionary(x => x.Key, x => (IEnumerable<TValue>) x);
+        }
+    }
+}

--- a/src/Core/DisposableObject.cs
+++ b/src/Core/DisposableObject.cs
@@ -1,0 +1,66 @@
+using System;
+
+namespace GitCredentialManager
+{
+    /// <summary>
+    /// An object that implements the <see cref="IDisposable"/> interface and the disposable pattern.
+    /// </summary>
+    public abstract class DisposableObject : IDisposable
+    {
+        private bool _isDisposed;
+
+        /// <summary>
+        /// Throw an exception if the object has been disposed.
+        /// </summary>
+        /// <exception cref="ObjectDisposedException">Thrown if the object has been disposed.</exception>
+        protected void ThrowIfDisposed()
+        {
+            if (_isDisposed)
+            {
+                throw new ObjectDisposedException(GetType().Name);
+            }
+        }
+
+        /// <summary>
+        /// Called when unmanaged resources should be released and memory freed.
+        /// </summary>
+        protected virtual void ReleaseUnmanagedResources() { }
+
+        /// <summary>
+        /// Called when managed resources should be released.
+        /// </summary>
+        protected virtual void ReleaseManagedResources() { }
+
+        /// <summary>
+        /// Called when the application is being terminated. Clean up and release any resources.
+        /// </summary>
+        /// <param name="disposing">True if the instance is being disposed, false if being finalized.</param>
+        private void Dispose(bool disposing)
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            ReleaseUnmanagedResources();
+
+            if (disposing)
+            {
+                ReleaseManagedResources();
+            }
+
+            _isDisposed = true;
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        ~DisposableObject()
+        {
+            Dispose(false);
+        }
+    }
+}

--- a/src/Core/EncodingEx.cs
+++ b/src/Core/EncodingEx.cs
@@ -1,0 +1,8 @@
+using System.Text;
+
+namespace GitCredentialManager;
+
+public static class EncodingEx
+{
+    public static readonly Encoding UTF8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+}

--- a/src/Core/EnsureArgument.cs
+++ b/src/Core/EnsureArgument.cs
@@ -1,0 +1,100 @@
+using System;
+
+namespace GitCredentialManager
+{
+    public static class EnsureArgument
+    {
+        public static void NotNull<T>(T arg, string name)
+        {
+            if (arg is null)
+            {
+                throw new ArgumentNullException(name);
+            }
+        }
+
+        public static void NotNullOrEmpty(string arg, string name)
+        {
+            NotNull(arg, name);
+
+            if (string.IsNullOrEmpty(arg))
+            {
+                throw new ArgumentException("Argument cannot be empty.", name);
+            }
+        }
+
+        public static void NotNullOrWhiteSpace(string arg, string name)
+        {
+            NotNull(arg, name);
+
+            if (string.IsNullOrWhiteSpace(arg))
+            {
+                throw new ArgumentException("Argument cannot be empty or white space.", name);
+            }
+        }
+
+        public static void AbsoluteUri(Uri arg, string name)
+        {
+            NotNull(arg, name);
+
+            if (!arg.IsAbsoluteUri)
+            {
+                throw new ArgumentException("Argument must be an absolute URI.", name);
+            }
+        }
+
+        public static void PositiveOrZero(int arg, string name)
+        {
+            if (arg < 0)
+            {
+                throw new ArgumentOutOfRangeException(name, "Argument must be positive or zero (non-negative).");
+            }
+        }
+
+        public static void Positive(int arg, string name)
+        {
+            if (arg <= 0)
+            {
+                throw new ArgumentOutOfRangeException(name, "Argument must be positive.");
+            }
+        }
+
+        public static void NegativeOrZero(int arg, string name)
+        {
+            if (arg > 0)
+            {
+                throw new ArgumentOutOfRangeException(name, "Argument must be negative or zero (non-positive).");
+            }
+        }
+
+        public static void Negative(int arg, string name)
+        {
+            if (arg >= 0)
+            {
+                throw new ArgumentOutOfRangeException(name, "Argument must be negative.");
+            }
+        }
+
+        public static void InRange(int arg, string name, int lower, int upper, bool lowerInclusive = true, bool upperInclusive = true)
+        {
+            if (lowerInclusive && arg < lower)
+            {
+                throw new ArgumentOutOfRangeException(name, $"Argument must be greater than or equal to {lower}.");
+            }
+
+            if (!lowerInclusive && arg <= lower)
+            {
+                throw new ArgumentOutOfRangeException(name, $"Argument must be strictly greater than {lower}.");
+            }
+
+            if (upperInclusive && arg > upper)
+            {
+                throw new ArgumentOutOfRangeException(name, $"Argument must be less than or equal to {upper}.");
+            }
+
+            if (!upperInclusive && arg >= upper)
+            {
+                throw new ArgumentOutOfRangeException(name, $"Argument must be strictly less than {upper}.");
+            }
+        }
+    }
+}

--- a/src/Core/EnvironmentBase.cs
+++ b/src/Core/EnvironmentBase.cs
@@ -1,0 +1,208 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+
+namespace GitCredentialManager
+{
+    /// <summary>
+    /// Component that encapsulates the process environment, including environment variables.
+    /// </summary>
+    public interface IEnvironment
+    {
+        /// <summary>
+        /// Current process environment variables.
+        /// </summary>
+        IReadOnlyDictionary<string, string> Variables { get; }
+
+        /// <summary>
+        /// Check if the given directory exists on the path.
+        /// </summary>
+        /// <param name="directoryPath">Path to directory to check for existence on the path.</param>
+        /// <returns>True if the directory is on the path, false otherwise.</returns>
+        bool IsDirectoryOnPath(string directoryPath);
+
+        /// <summary>
+        /// Add the directory to the path.
+        /// </summary>
+        /// <param name="directoryPath">Path to directory to add to the path.</param>
+        /// <param name="target">The level of the path environment variable that should be modified.</param>
+        void AddDirectoryToPath(string directoryPath, EnvironmentVariableTarget target);
+
+        /// <summary>
+        /// Remove the directory from the path.
+        /// </summary>
+        /// <param name="directoryPath">Path to directory to remove from the path.</param>
+        /// <param name="target">The level of the path environment variable that should be modified.</param>
+        void RemoveDirectoryFromPath(string directoryPath, EnvironmentVariableTarget target);
+
+        /// <summary>
+        /// Locate an executable on the current PATH.
+        /// </summary>
+        /// <param name="program">Executable program name.</param>
+        /// <param name="path">First instance of the found executable program.</param>
+        /// <returns>True if the executable was found, false otherwise.</returns>
+        bool TryLocateExecutable(string program, out string path);
+
+        /// <summary>
+        /// Set an environment variable at the specified target level.
+        /// </summary>
+        /// <param name="variable">Name of the environment variable to set.</param>
+        /// <param name="value">Value of the environment variable to set.</param>
+        /// <param name="target">Target level of environment variable to set (Machine, Process, or User).</param>
+        void SetEnvironmentVariable(string variable, string value,
+            EnvironmentVariableTarget target = EnvironmentVariableTarget.Process);
+
+        /// <summary>
+        /// Refresh the current process environment variables. See <see cref="Variables"/>.
+        /// </summary>
+        /// <remarks>This is automatically called after <see cref="SetEnvironmentVariable"/>.</remarks>
+        void Refresh();
+    }
+
+    public abstract class EnvironmentBase : IEnvironment
+    {
+        private IReadOnlyDictionary<string, string> _variables;
+
+        protected EnvironmentBase(IFileSystem fileSystem)
+        {
+            EnsureArgument.NotNull(fileSystem, nameof(fileSystem));
+            FileSystem = fileSystem;
+        }
+
+        internal EnvironmentBase(IFileSystem fileSystem, IReadOnlyDictionary<string, string> variables)
+            : this(fileSystem)
+        {
+            EnsureArgument.NotNull(variables, nameof(variables));
+            _variables = variables;
+        }
+
+        public IReadOnlyDictionary<string, string> Variables
+        {
+            get
+            {
+                // Variables are lazily loaded
+                if (_variables is null)
+                {
+                    Refresh();
+                }
+
+                Debug.Assert(_variables != null);
+                return _variables;
+            }
+        }
+
+        protected IFileSystem FileSystem { get; }
+
+        public bool IsDirectoryOnPath(string directoryPath)
+        {
+            if (Variables.TryGetValue("PATH", out string pathValue))
+            {
+                string[] paths = SplitPathVariable(pathValue);
+                return paths.Any(x => FileSystem.IsSamePath(x, directoryPath));
+            }
+
+            return false;
+        }
+
+        public abstract void AddDirectoryToPath(string directoryPath, EnvironmentVariableTarget target);
+
+        public abstract void RemoveDirectoryFromPath(string directoryPath, EnvironmentVariableTarget target);
+
+        protected abstract string[] SplitPathVariable(string value);
+
+        public virtual bool TryLocateExecutable(string program, out string path)
+        {
+            return TryLocateExecutable(program, null, out path);
+        }
+
+        internal virtual bool TryLocateExecutable(string program, ICollection<string> pathsToIgnore, out string path)
+        {
+            // On UNIX-like systems we would normally use the "which" utility to locate a program,
+            // but since distributions don't always place "which" in a consistent location we cannot
+            // find it! Oh the irony..
+            // We could also try using "env" to then locate "which", but the same problem exists in
+            // that "env" isn't always in a standard location.
+            //
+            // On Windows we should avoid using the equivalent utility "where.exe" because this will
+            // include the current working directory in the search, and we don't want this.
+            //
+            // The upshot of the above means we cannot use either of "which" or "where.exe" and must
+            // instead manually scan the PATH variable looking for the program.
+            // At least both Windows and UNIX use the same name for the $PATH or %PATH% variable!
+            if (Variables.TryGetValue("PATH", out string pathValue))
+            {
+                string[] paths = SplitPathVariable(pathValue);
+                foreach (var basePath in paths)
+                {
+                    string candidatePath = Path.Combine(basePath, program);
+                    if (FileSystem.FileExists(candidatePath) && (pathsToIgnore is null ||
+                        !pathsToIgnore.Contains(candidatePath, StringComparer.OrdinalIgnoreCase)))
+                    {
+                        path = candidatePath;
+                        return true;
+                    }
+                }
+            }
+
+            path = null;
+            return false;
+        }
+
+        public void SetEnvironmentVariable(string variable, string value,
+            EnvironmentVariableTarget target = EnvironmentVariableTarget.Process)
+        {
+            // Don't bother setting the variable if it already has the same value
+            if (Variables.TryGetValue(variable, out var currentValue) &&
+                StringComparer.Ordinal.Equals(currentValue, value))
+            {
+                return;
+            }
+
+            Environment.SetEnvironmentVariable(variable, value, target);
+
+            // Immediately refresh the variables so that the new value is available to callers using IEnvironment
+            Refresh();
+        }
+
+        public void Refresh()
+        {
+            _variables = GetCurrentVariables();
+        }
+
+        protected abstract IReadOnlyDictionary<string, string> GetCurrentVariables();
+    }
+
+    public static class EnvironmentExtensions
+    {
+        /// <summary>
+        /// Locate an executable on the current PATH.
+        /// </summary>
+        /// <param name="environment">The <see cref="IEnvironment"/>.</param>
+        /// <param name="program">Executable program name.</param>
+        /// <returns>List of all instances of the found executable program, in order of most specific to least.</returns>
+        public static string LocateExecutable(this IEnvironment environment, string program)
+        {
+            if (environment.TryLocateExecutable(program, out string path))
+            {
+                return path;
+            }
+
+            throw new Exception($"Failed to locate '{program}' executable on the path.");
+        }
+
+        /// <summary>
+        /// Retrieves the value of an environment variable from the current process.
+        /// </summary>
+        /// <param name="environment">The <see cref="IEnvironment"/>.</param>
+        /// <param name="variable">The name of the environment variable.</param>
+        /// <returns>
+        /// The value of the environment variable specified by variable, or null if the environment variable is not found.
+        /// </returns>
+        public static string GetEnvironmentVariable(this IEnvironment environment, string variable)
+        {
+            return environment.Variables.TryGetValue(variable, out string value) ? value : null;
+        }
+    }
+}

--- a/src/Core/FileCredential.cs
+++ b/src/Core/FileCredential.cs
@@ -1,0 +1,21 @@
+namespace GitCredentialManager
+{
+    public class FileCredential : ICredential
+    {
+        public FileCredential(string fullPath, string service, string account, string password)
+        {
+            FullPath = fullPath;
+            Service = service;
+            Account = account;
+            Password = password;
+        }
+
+        public string FullPath { get; }
+
+        public string Service { get; }
+
+        public string Account { get; }
+
+        public string Password { get; }
+    }
+}

--- a/src/Core/FileSystem.cs
+++ b/src/Core/FileSystem.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace GitCredentialManager
+{
+    /// <summary>
+    /// Represents a file system and operations that can be performed.
+    /// </summary>
+    public interface IFileSystem
+    {
+        /// <summary>
+        /// Get the path to the user's home profile directory (Unix: $HOME, Windows: %USERPROFILE%).
+        /// </summary>
+        string UserHomePath { get; }
+
+        /// <summary>
+        /// Get the path the the user's Git Credential Manager data directory.
+        /// </summary>
+        string UserDataDirectoryPath { get; }
+
+        /// <summary>
+        /// Check if two paths are the same for the current platform and file system. Symbolic links are not followed.
+        /// </summary>
+        /// <param name="a">File path.</param>
+        /// <param name="b">File path.</param>
+        /// <returns>True if both file paths are the same, false otherwise.</returns>
+        bool IsSamePath(string a, string b);
+
+        /// <summary>
+        /// Check if a file exists at the specified path.
+        /// </summary>
+        /// <param name="path">Full path to file to test.</param>
+        /// <returns>True if a file exists, false otherwise.</returns>
+        bool FileExists(string path);
+
+        /// <summary>
+        /// Check if a directory exists at the specified path.
+        /// </summary>
+        /// <param name="path">Full path to directory to test.</param>
+        /// <returns>True if a directory exists, false otherwise.</returns>
+        bool DirectoryExists(string path);
+
+        /// <summary>
+        /// Get the path to the current directory of the currently executing process.
+        /// </summary>
+        /// <returns>Current process directory.</returns>
+        string GetCurrentDirectory();
+
+        /// <summary>
+        /// Open a file stream at the specified path with the given access and mode settings.
+        /// </summary>
+        /// <param name="path">Full file path.</param>
+        /// <param name="fileMode">File mode settings.</param>
+        /// <param name="fileAccess">File access settings.</param>
+        /// <param name="fileShare">File share settings.</param>
+        /// <returns></returns>
+        Stream OpenFileStream(string path, FileMode fileMode, FileAccess fileAccess, FileShare fileShare);
+
+        /// <summary>
+        /// Creates all directories and subdirectories in the specified path unless they already exist.
+        /// </summary>
+        /// <param name="path">The directory to create.</param>
+        void CreateDirectory(string path);
+
+        /// <summary>
+        /// Deletes the specified file.
+        /// </summary>
+        /// <param name="path">Name of the file to be deleted.</param>
+        void DeleteFile(string path);
+
+        /// <summary>
+        /// Returns an enumerable collection of full file names that match a search pattern in a specified path.
+        /// </summary>
+        /// <param name="path">The relative or absolute path to the directory to search.</param>
+        /// <param name="searchPattern">
+        /// The search string to match against the names of files in path.
+        /// This parameter can contain a combination of valid literal path and wildcard (* and ?) characters,
+        /// but it doesn't support regular expressions.
+        /// </param>
+        /// <returns>
+        /// An enumerable collection of the full names (including paths) for the files in the directory
+        /// specified by path and that match the specified search pattern.
+        /// </returns>
+        IEnumerable<string> EnumerateFiles(string path, string searchPattern);
+
+        /// <summary>
+        /// Returns an enumerable collection of directory full names in a specified path.
+        /// </summary>
+        /// <param name="path">The relative or absolute path to the directory to search. This string is not case-sensitive.</param>
+        /// <returns>
+        /// An enumerable collection of the full names (including paths) for the directories
+        /// in the directory specified by path.
+        /// </returns>
+        IEnumerable<string> EnumerateDirectories(string path);
+
+        /// <summary>
+        /// Opens a text file, reads all the text in the file, and then closes the file
+        /// </summary>
+        /// <param name="path">The file to open for reading.</param>
+        /// <returns>A string containing all the text in the file.</returns>
+        string ReadAllText(string path);
+
+        /// <summary>
+        /// Opens a text file, reads all lines of the file, and then closes the file.
+        /// </summary>
+        /// <param name="path">The file to open for reading.</param>
+        /// <returns>A string array containing all lines of the file.</returns>
+        string[] ReadAllLines(string path);
+    }
+
+    /// <summary>
+    /// The real file system.
+    /// </summary>
+    public abstract class FileSystem : IFileSystem
+    {
+        public string UserHomePath => Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+        public string UserDataDirectoryPath => Path.Combine(UserHomePath, Constants.GcmDataDirectoryName);
+
+        public abstract bool IsSamePath(string a, string b);
+
+        public bool FileExists(string path) => File.Exists(path);
+
+        public bool DirectoryExists(string path) => Directory.Exists(path);
+
+        public string GetCurrentDirectory() => Directory.GetCurrentDirectory();
+
+        public Stream OpenFileStream(string path, FileMode fileMode, FileAccess fileAccess, FileShare fileShare)
+            => File.Open(path, fileMode, fileAccess, fileShare);
+
+        public void CreateDirectory(string path) => Directory.CreateDirectory(path);
+
+        public void DeleteFile(string path) => File.Delete(path);
+
+        public IEnumerable<string> EnumerateFiles(string path, string searchPattern) => Directory.EnumerateFiles(path, searchPattern);
+
+        public IEnumerable<string> EnumerateDirectories(string path) => Directory.EnumerateDirectories(path);
+
+        public string ReadAllText(string path) => File.ReadAllText(path);
+
+        public string[] ReadAllLines(string path) => File.ReadAllLines(path);
+    }
+}

--- a/src/Core/Git.cs
+++ b/src/Core/Git.cs
@@ -1,0 +1,296 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace GitCredentialManager
+{
+    public interface IGit
+    {
+        /// <summary>
+        /// The version of the Git executable tied to this instance.
+        /// </summary>
+        GitVersion Version { get; }
+
+        /// <summary>
+        /// Create a Git process object with the specified arguments.
+        /// </summary>
+        /// <param name="args">Arguments to pass to the Git process.</param>
+        /// <returns>Process object ready to be started.</returns>
+        ChildProcess CreateProcess(string args);
+
+        /// <summary>
+        /// Returns true if the current Git instance is scoped to a local repository.
+        /// </summary>
+        /// <returns>True if inside a local Git repository, false otherwise.</returns>
+        bool IsInsideRepository();
+
+        /// <summary>
+        /// Return the path to the current repository, or null if this instance is not
+        /// scoped to a Git repository.
+        /// </summary>
+        /// <returns>Absolute path to the current Git repository, or null.</returns>
+        string GetCurrentRepository();
+
+        /// <summary>
+        /// Get all remotes for the current repository.
+        /// </summary>
+        /// <returns>Names of all remotes in the current repository.</returns>
+        IEnumerable<GitRemote> GetRemotes();
+
+        /// <summary>
+        /// Get the configuration object.
+        /// </summary>
+        /// <returns>Git configuration.</returns>
+        IGitConfiguration GetConfiguration();
+
+        /// <summary>
+        /// Run a Git helper process which expects and returns key-value maps
+        /// </summary>
+        /// <param name="args">Arguments to the executable</param>
+        /// <param name="standardInput">key-value map to pipe into stdin</param>
+        /// <returns>stdout from helper executable as key-value map</returns>
+        Task<IDictionary<string, string>> InvokeHelperAsync(string args, IDictionary<string, string> standardInput);
+    }
+
+    public class GitRemote
+    {
+        public GitRemote(string name, string fetchUrl, string pushUrl)
+        {
+            Name = name;
+            FetchUrl = fetchUrl;
+            PushUrl = pushUrl;
+        }
+
+        public string Name { get; }
+        public string FetchUrl { get; }
+        public string PushUrl { get; }
+    }
+
+    public class GitProcess : IGit
+    {
+        private readonly ITrace _trace;
+        private readonly ITrace2 _trace2;
+        private readonly IProcessManager _processManager;
+        private readonly string _gitPath;
+        private readonly string _workingDirectory;
+
+        public GitProcess(ITrace trace, ITrace2 trace2, IProcessManager processManager, string gitPath, string workingDirectory = null)
+        {
+            EnsureArgument.NotNull(trace, nameof(trace));
+            EnsureArgument.NotNull(trace2, nameof(trace2));
+            EnsureArgument.NotNull(processManager, nameof(processManager));
+            EnsureArgument.NotNullOrWhiteSpace(gitPath, nameof(gitPath));
+
+            _trace = trace;
+            _trace2 = trace2;
+            _processManager = processManager;
+            _gitPath = gitPath;
+            _workingDirectory = workingDirectory;
+        }
+
+        private GitVersion _version;
+        public GitVersion Version
+        {
+            get
+            {
+                if (_version is null)
+                {
+                    using (var git = CreateProcess("version"))
+                    {
+                        git.Start(Trace2ProcessClass.Git);
+
+                        string data = git.StandardOutput.ReadToEnd();
+                        git.WaitForExit();
+
+                        Match match = Regex.Match(data, @"^git version (?'value'.*)");
+                        if (match.Success)
+                        {
+                            _version = new GitVersion(match.Groups["value"].Value);
+                        }
+                        else
+                        {
+                            _version = new GitVersion();
+                        }
+                    }
+                }
+
+                return _version;
+            }
+        }
+
+        public IGitConfiguration GetConfiguration()
+        {
+            return new GitProcessConfiguration(_trace, this);
+        }
+
+        public bool IsInsideRepository()
+        {
+            return !string.IsNullOrWhiteSpace(GetCurrentRepositoryInternal(suppressStreams: true));
+        }
+
+        public string GetCurrentRepository()
+        {
+            return GetCurrentRepositoryInternal(suppressStreams: false);
+        }
+
+        private string GetCurrentRepositoryInternal(bool suppressStreams)
+        {
+            using (var git = CreateProcess("rev-parse --absolute-git-dir"))
+            {
+                // Redirect standard error to ensure any error messages are captured and not exposed to the user's console
+                if (suppressStreams)
+                {
+                    git.StartInfo.RedirectStandardError = true;
+                }
+
+                git.Start(Trace2ProcessClass.Git);
+                string data = git.StandardOutput.ReadToEnd();
+                git.WaitForExit();
+
+                switch (git.ExitCode)
+                {
+                    case 0: // OK
+                        return data.TrimEnd();
+                    case 128: // Not inside a Git repository
+                        return null;
+                    default:
+                        var message = "Failed to get current Git repository";
+                        _trace.WriteLine($"{message} (exit={git.ExitCode})");
+                        throw CreateGitException(git, message, _trace2);
+                }
+            }
+        }
+
+        public IEnumerable<GitRemote> GetRemotes()
+        {
+            using (var git = CreateProcess("remote -v show"))
+            {
+                git.Start(Trace2ProcessClass.Git);
+                // To avoid deadlocks, always read the output stream first and then wait
+                // TODO: don't read in all the data at once; stream it
+                string data = git.StandardOutput.ReadToEnd();
+                string stderr = git.StandardError.ReadToEnd();
+                git.WaitForExit();
+
+                switch (git.ExitCode)
+                {
+                    case 0: // OK
+                        break;
+                    case 128 when stderr.Contains("not a git repository"): // Not inside a Git repository
+                        yield break;
+                    default:
+                        var message = "Failed to enumerate Git remotes";
+                        _trace.WriteLine($"{message} (exit={git.ExitCode})");
+                        throw CreateGitException(git, message, _trace2);
+                }
+
+                string[] lines = data.Split('\n');
+
+                // Remotes are always output in groups of two (fetch and push)
+                for (int i = 0; i + 1 < lines.Length; i += 2)
+                {
+                    // The fetch URL is written first, followed by the push URL
+                    string[] fetchLine = lines[i].Split();
+                    string[] pushLine = lines[i + 1].Split();
+
+                    // Remote name is always first (and should match between fetch/push)
+                    string remoteName = fetchLine[0];
+
+                    // The next part, if present, is the URL
+                    string fetchUrl = null;
+                    string pushUrl = null;
+                    if (fetchLine.Length > 1 && !string.IsNullOrWhiteSpace(fetchLine[1])) fetchUrl = fetchLine[1].TrimEnd();
+                    if (pushLine.Length > 1 && !string.IsNullOrWhiteSpace(pushLine[1]))   pushUrl  = pushLine[1].TrimEnd();
+
+                    yield return new GitRemote(remoteName, fetchUrl, pushUrl);
+                }
+            }
+        }
+
+        public ChildProcess CreateProcess(string args)
+        {
+            return _processManager.CreateProcess(_gitPath, args, false, _workingDirectory);
+        }
+
+        // This code was originally copied from
+        // src/shared/Core/Authentication/AuthenticationBase.cs
+        // That code is for GUI helpers in this codebase, while the below is for
+        // communicating over Git's stdin/stdout helper protocol. The GUI helper
+        // protocol will one day use a different IPC mechanism, whereas this code
+        // has to follow what upstream Git does.
+        public async Task<IDictionary<string, string>> InvokeHelperAsync(string args, IDictionary<string, string> standardInput = null)
+        {
+            var procStartInfo = new ProcessStartInfo(_gitPath)
+            {
+                Arguments = args,
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = false, // Do not redirect stderr as tracing might be enabled
+                UseShellExecute = false
+            };
+
+            var process = _processManager.CreateProcess(procStartInfo);
+            if (!process.Start(Trace2ProcessClass.Git))
+            {
+                var format = "Failed to start Git helper '{0}'";
+                var message = string.Format(format, args);
+                throw new Trace2Exception(_trace2, message, format);
+            }
+
+            if (!(standardInput is null))
+            {
+                await process.StandardInput.WriteDictionaryAsync(standardInput);
+                // some helpers won't continue until they see EOF
+                // cf git-credential-cache
+                process.StandardInput.Close();
+            }
+
+            IDictionary<string, string> resultDict = await process.StandardOutput.ReadDictionaryAsync(StringComparer.OrdinalIgnoreCase);
+
+            await Task.Run(() => process.WaitForExit());
+            int exitCode = process.ExitCode;
+
+            if (exitCode != 0)
+            {
+                if (!resultDict.TryGetValue("error", out string errorMessage))
+                {
+                    errorMessage = "Unknown";
+                }
+
+                throw new Exception($"helper error ({exitCode}): {errorMessage}");
+            }
+
+            return resultDict;
+        }
+
+        public static GitException CreateGitException(ChildProcess git, string message, ITrace2 trace2 = null)
+        {
+            var gitMessage = git.StandardError.ReadToEnd();
+
+            if (trace2 != null)
+                throw new Trace2GitException(trace2, message, git.ExitCode, gitMessage);
+
+            throw new GitException(message, gitMessage, git.ExitCode);
+        }
+    }
+
+    public class GitException : Exception
+    {
+        public string GitErrorMessage { get; }
+
+        public int ExitCode { get; }
+
+        public GitException(string message, string gitErrorMessage, int exitCode)
+            : base(message)
+        {
+            GitErrorMessage = gitErrorMessage;
+            ExitCode = exitCode;
+        }
+    }
+
+    public static class GitExtensions
+    {
+    }
+}

--- a/src/Core/GitConfiguration.cs
+++ b/src/Core/GitConfiguration.cs
@@ -1,0 +1,665 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+
+namespace GitCredentialManager
+{
+    /// <summary>
+    /// Invoked for each Git configuration entry during an enumeration (<see cref="IGitConfiguration.Enumerate"/>).
+    /// </summary>
+    /// <param name="entry">Current configuration entry.</param>
+    /// <returns>True to continue enumeration, false to stop enumeration.</returns>
+    public delegate bool GitConfigurationEnumerationCallback(GitConfigurationEntry entry);
+
+    public enum GitConfigurationLevel
+    {
+        All,
+        System,
+        Global,
+        Local,
+        Unknown,
+    }
+
+    public enum GitConfigurationType
+    {
+        Raw,
+        Bool,
+        Path
+    }
+
+    public interface IGitConfiguration
+    {
+        /// <summary>
+        /// Enumerate all configuration entries invoking the specified callback for each entry.
+        /// </summary>
+        /// <param name="level">Filter to the specific configuration level.</param>
+        /// <param name="cb">Callback to invoke for each configuration entry.</param>
+        void Enumerate(GitConfigurationLevel level, GitConfigurationEnumerationCallback cb);
+
+        /// <summary>
+        /// Try and get the value of a configuration entry as a string.
+        /// </summary>
+        /// <param name="level">Filter to the specific configuration level.</param>
+        /// <param name="type">Type constraint to which the config value should be canonicalized.</param>
+        /// <param name="name">Configuration entry name.</param>
+        /// <param name="value">Configuration entry value.</param>
+        /// <returns>True if the value was found, false otherwise.</returns>
+        bool TryGet(GitConfigurationLevel level, GitConfigurationType type, string name, out string value);
+
+        /// <summary>
+        /// Set the value of a configuration entry.
+        /// </summary>
+        /// <param name="level">Filter to the specific configuration level.</param>
+        /// <param name="name">Configuration entry name.</param>
+        /// <param name="value">Configuration entry value.</param>
+        void Set(GitConfigurationLevel level, string name, string value);
+
+        /// <summary>
+        /// Add a new value for a configuration entry.
+        /// </summary>
+        /// <param name="level">Filter to the specific configuration level.</param>
+        /// <param name="name">Configuration entry name.</param>
+        /// <param name="value">Configuration entry value.</param>
+        void Add(GitConfigurationLevel level, string name, string value);
+
+        /// <summary>
+        /// Deletes a configuration entry from the highest level.
+        /// </summary>
+        /// <param name="level">Filter to the specific configuration level.</param>
+        /// <param name="name">Configuration entry name.</param>
+        void Unset(GitConfigurationLevel level, string name);
+
+        /// <summary>
+        /// Get all value of a multivar configuration entry.
+        /// </summary>
+        /// <param name="level">Filter to the specific configuration level.</param>
+        /// <param name="type">Type constraint to which the config values should be canonicalized.</param>
+        /// <param name="name">Configuration entry name.</param>
+        /// <returns>All values of the multivar configuration entry.</returns>
+        IEnumerable<string> GetAll(GitConfigurationLevel level, GitConfigurationType type, string name);
+
+        /// <summary>
+        /// Get all values of a multivar configuration entry.
+        /// </summary>
+        /// <param name="level">Filter to the specific configuration level.</param>
+        /// <param name="type">Type constraint to which the config values should be canonicalized.</param>
+        /// <param name="nameRegex">Configuration entry name regular expression.</param>
+        /// <param name="valueRegex">Regular expression to filter which variables we're interested in. Use null to indicate all.</param>
+        /// <returns>All values of the multivar configuration entry.</returns>
+        IEnumerable<string> GetRegex(GitConfigurationLevel level, GitConfigurationType type, string nameRegex, string valueRegex);
+
+        /// <summary>
+        /// Set a multivar configuration entry value.
+        /// </summary>
+        /// <param name="level">Filter to the specific configuration level.</param>
+        /// <param name="nameRegex">Configuration entry name regular expression.</param>
+        /// <param name="valueRegex">Regular expression to indicate which values to replace.</param>
+        /// <param name="value">Configuration entry value.</param>
+        /// <remarks>If the regular expression does not match any existing entry, a new entry is created.</remarks>
+        void ReplaceAll(GitConfigurationLevel level, string nameRegex, string valueRegex, string value);
+
+        /// <summary>
+        /// Deletes one or several entries from a multivar.
+        /// </summary>
+        /// <param name="level">Filter to the specific configuration level.</param>
+        /// <param name="name">Configuration entry name.</param>
+        /// <param name="valueRegex">Regular expression to indicate which values to delete.</param>
+        void UnsetAll(GitConfigurationLevel level, string name, string valueRegex);
+    }
+
+    public class GitProcessConfiguration : IGitConfiguration
+    {
+        private static readonly GitVersion TypeConfigMinVersion = new GitVersion(2, 18, 0);
+
+        private readonly ITrace _trace;
+        private readonly GitProcess _git;
+
+        internal GitProcessConfiguration(ITrace trace, GitProcess git)
+        {
+            EnsureArgument.NotNull(trace, nameof(trace));
+            EnsureArgument.NotNull(git, nameof(git));
+
+            _trace = trace;
+            _git = git;
+        }
+
+        public void Enumerate(GitConfigurationLevel level, GitConfigurationEnumerationCallback cb)
+        {
+            string levelArg = GetLevelFilterArg(level);
+            using (ChildProcess git = _git.CreateProcess($"config --null {levelArg} --list"))
+            {
+                git.Start(Trace2ProcessClass.Git);
+                // To avoid deadlocks, always read the output stream first and then wait
+                // TODO: don't read in all the data at once; stream it
+                string data = git.StandardOutput.ReadToEnd();
+                git.WaitForExit();
+
+                switch (git.ExitCode)
+                {
+                    case 0: // OK
+                        break;
+                    default:
+                        _trace.WriteLine($"Failed to enumerate config entries (exit={git.ExitCode}, level={level})");
+                        throw GitProcess.CreateGitException(git, "Failed to enumerate all Git configuration entries");
+                }
+
+                var name  = new StringBuilder();
+                var value = new StringBuilder();
+                int i = 0;
+                while (i < data.Length)
+                {
+                    name.Clear();
+                    value.Clear();
+
+                    // Read key name (LF terminated)
+                    while (i < data.Length && data[i] != '\n')
+                    {
+                        name.Append(data[i++]);
+                    }
+
+                    if (i >= data.Length)
+                    {
+                        _trace.WriteLine("Invalid Git configuration output. Expected newline terminator (\\n) after key.");
+                        break;
+                    }
+
+                    // Skip the LF terminator
+                    i++;
+
+                    // Read value (null terminated)
+                    while (i < data.Length && data[i] != '\0')
+                    {
+                        value.Append(data[i++]);
+                    }
+
+                    if (i >= data.Length)
+                    {
+                        _trace.WriteLine("Invalid Git configuration output. Expected null terminator (\\0) after value.");
+                        break;
+                    }
+
+                    // Skip the null terminator
+                    i++;
+
+                    var entry = new GitConfigurationEntry(name.ToString(), value.ToString());
+
+                    if (!cb(entry))
+                    {
+                        break;
+                    }
+                }
+            }
+        }
+
+        public bool TryGet(GitConfigurationLevel level, GitConfigurationType type, string name, out string value)
+        {
+            string levelArg = GetLevelFilterArg(level);
+            string typeArg = GetCanonicalizeTypeArg(type);
+            using (ChildProcess git = _git.CreateProcess($"config --null {levelArg} {typeArg} {QuoteCmdArg(name)}"))
+            {
+                git.Start(Trace2ProcessClass.Git);
+                // To avoid deadlocks, always read the output stream first and then wait
+                // TODO: don't read in all the data at once; stream it
+                string data = git.StandardOutput.ReadToEnd();
+                git.WaitForExit();
+
+                switch (git.ExitCode)
+                {
+                    case 0: // OK
+                        break;
+                    case 1: // Not found
+                        value = null;
+                        return false;
+                    default: // Error
+                        _trace.WriteLine($"Failed to read Git configuration entry '{name}'. (exit={git.ExitCode}, level={level})");
+                        value = null;
+                        return false;
+                }
+
+                string[] entries = data.Split('\0');
+                if (entries.Length > 0)
+                {
+                    value = entries[0];
+                    return true;
+                }
+
+                value = null;
+                return false;
+            }
+        }
+
+        public void Set(GitConfigurationLevel level, string name, string value)
+        {
+            EnsureSpecificLevel(level);
+
+            string levelArg = GetLevelFilterArg(level);
+            using (ChildProcess git = _git.CreateProcess($"config {levelArg} {QuoteCmdArg(name)} {QuoteCmdArg(value)}"))
+            {
+                git.Start(Trace2ProcessClass.Git);
+                git.WaitForExit();
+
+                switch (git.ExitCode)
+                {
+                    case 0: // OK
+                        break;
+                    default:
+                        _trace.WriteLine($"Failed to set config entry '{name}' to value '{value}' (exit={git.ExitCode}, level={level})");
+                        throw GitProcess.CreateGitException(git, $"Failed to set Git configuration entry '{name}'");
+                }
+            }
+        }
+
+        public void Add(GitConfigurationLevel level, string name, string value)
+        {
+            EnsureSpecificLevel(level);
+
+            string levelArg = GetLevelFilterArg(level);
+            using (ChildProcess git = _git.CreateProcess($"config {levelArg} --add {QuoteCmdArg(name)} {QuoteCmdArg(value)}"))
+            {
+                git.Start(Trace2ProcessClass.Git);
+                git.WaitForExit();
+
+                switch (git.ExitCode)
+                {
+                    case 0: // OK
+                        break;
+                    default:
+                        _trace.WriteLine($"Failed to add config entry '{name}' with value '{value}' (exit={git.ExitCode}, level={level})");
+                        throw GitProcess.CreateGitException(git, $"Failed to add Git configuration entry '{name}'");
+                }
+            }
+        }
+
+        public void Unset(GitConfigurationLevel level, string name)
+        {
+            EnsureSpecificLevel(level);
+
+            string levelArg = GetLevelFilterArg(level);
+            using (ChildProcess git = _git.CreateProcess($"config {levelArg} --unset {QuoteCmdArg(name)}"))
+            {
+                git.Start(Trace2ProcessClass.Git);
+                git.WaitForExit();
+
+                switch (git.ExitCode)
+                {
+                    case 0: // OK
+                    case 5: // Trying to unset a value that does not exist
+                        break;
+                    default:
+                        _trace.WriteLine($"Failed to unset config entry '{name}' (exit={git.ExitCode}, level={level})");
+                        throw GitProcess.CreateGitException(git, $"Failed to unset Git configuration entry '{name}'");
+                }
+            }
+        }
+
+        public IEnumerable<string> GetAll(GitConfigurationLevel level, GitConfigurationType type, string name)
+        {
+            string levelArg = GetLevelFilterArg(level);
+            string typeArg = GetCanonicalizeTypeArg(type);
+
+            var gitArgs = $"config --null {levelArg} {typeArg} --get-all {QuoteCmdArg(name)}";
+
+            using (ChildProcess git = _git.CreateProcess(gitArgs))
+            {
+                git.Start(Trace2ProcessClass.Git);
+                // To avoid deadlocks, always read the output stream first and then wait
+                // TODO: don't read in all the data at once; stream it
+                string data = git.StandardOutput.ReadToEnd();
+                git.WaitForExit();
+
+                switch (git.ExitCode)
+                {
+                    case 0: // OK
+                        string[] entries = data.Split('\0');
+
+                        // Because each line terminates with the \0 character, splitting leaves us with one
+                        // bogus blank entry at the end of the array which we should ignore
+                        for (var i = 0; i < entries.Length - 1; i++)
+                        {
+                            yield return entries[i];
+                        }
+                        break;
+
+                    case 1: // No results
+                        break;
+
+                    default:
+                        _trace.WriteLine($"Failed to get all config entries '{name}' (exit={git.ExitCode}, level={level})");
+                        throw GitProcess.CreateGitException(git, $"Failed to get all Git configuration entries '{name}'");
+                }
+            }
+        }
+
+        public IEnumerable<string> GetRegex(GitConfigurationLevel level, GitConfigurationType type, string nameRegex, string valueRegex)
+        {
+            string levelArg = GetLevelFilterArg(level);
+            string typeArg = GetCanonicalizeTypeArg(type);
+
+            var gitArgs = $"config --null {levelArg} {typeArg} --get-regex {QuoteCmdArg(nameRegex)}";
+            if (valueRegex != null)
+            {
+                gitArgs += $" {QuoteCmdArg(valueRegex)}";
+            }
+
+            using (ChildProcess git = _git.CreateProcess(gitArgs))
+            {
+                git.Start(Trace2ProcessClass.Git);
+                // To avoid deadlocks, always read the output stream first and then wait
+                // TODO: don't read in all the data at once; stream it
+                string data = git.StandardOutput.ReadToEnd();
+                git.WaitForExit();
+
+                switch (git.ExitCode)
+                {
+                    case 0: // OK
+                    case 1: // No results
+                        break;
+                    default:
+                        _trace.WriteLine($"Failed to get all multivar regex '{nameRegex}' and value regex '{valueRegex}' (exit={git.ExitCode}, level={level})");
+                        throw GitProcess.CreateGitException(git, $"Failed to get Git configuration multi-valued entries with name regex '{nameRegex}'");
+                }
+
+                string[] entries = data.Split('\0');
+                foreach (string entry in entries)
+                {
+                    string[] kvp = entry.Split(new[]{'\n'}, count: 2);
+
+                    if (kvp.Length == 2)
+                    {
+                        yield return kvp[1];
+                    }
+                }
+            }
+        }
+
+        public void ReplaceAll(GitConfigurationLevel level, string name, string valueRegex, string value)
+        {
+            EnsureSpecificLevel(level);
+
+            string levelArg = GetLevelFilterArg(level);
+            var gitArgs = $"config {levelArg} --replace-all {QuoteCmdArg(name)} {QuoteCmdArg(value)}";
+            if (valueRegex != null)
+            {
+                gitArgs += $" {QuoteCmdArg(valueRegex)}";
+            }
+
+            using (ChildProcess git = _git.CreateProcess(gitArgs))
+            {
+                git.Start(Trace2ProcessClass.Git);
+                git.WaitForExit();
+
+                switch (git.ExitCode)
+                {
+                    case 0: // OK
+                        break;
+                    default:
+                        _trace.WriteLine($"Failed to replace all multivar '{name}' and value regex '{valueRegex}' with new value '{value}' (exit={git.ExitCode}, level={level})");
+                        throw GitProcess.CreateGitException(git, $"Failed to replace all Git configuration multi-valued entries '{name}'");
+                }
+            }
+        }
+
+        public void UnsetAll(GitConfigurationLevel level, string name, string valueRegex)
+        {
+            EnsureSpecificLevel(level);
+
+            string levelArg = GetLevelFilterArg(level);
+            var gitArgs = $"config {levelArg} --unset-all {QuoteCmdArg(name)}";
+            if (valueRegex != null)
+            {
+                gitArgs += $" {QuoteCmdArg(valueRegex)}";
+            }
+
+            using (ChildProcess git = _git.CreateProcess(gitArgs))
+            {
+                git.Start(Trace2ProcessClass.Git);
+                git.WaitForExit();
+
+                switch (git.ExitCode)
+                {
+                    case 0: // OK
+                    case 5: // Trying to unset a value that does not exist
+                        break;
+                    default:
+                        _trace.WriteLine($"Failed to unset all multivar '{name}' with value regex '{valueRegex}' (exit={git.ExitCode}, level={level})");
+                        throw GitProcess.CreateGitException(git, $"Failed to unset all Git configuration multi-valued entries '{name}'");
+                }
+            }
+        }
+
+        private static void EnsureSpecificLevel(GitConfigurationLevel level)
+        {
+            if (level == GitConfigurationLevel.All)
+            {
+                throw new InvalidOperationException("Must have a specific configuration level filter to modify values.");
+            }
+        }
+
+        private static string GetLevelFilterArg(GitConfigurationLevel level)
+        {
+            switch (level)
+            {
+                case GitConfigurationLevel.System:
+                    return "--system";
+                case GitConfigurationLevel.Global:
+                    return "--global";
+                case GitConfigurationLevel.Local:
+                    return "--local";
+                case GitConfigurationLevel.Unknown:
+                default:
+                    return null;
+            }
+        }
+
+        private string GetCanonicalizeTypeArg(GitConfigurationType type)
+        {
+            if (_git.Version >= TypeConfigMinVersion)
+            {
+                return type switch
+                {
+                    GitConfigurationType.Bool   => "--type=bool",
+                    GitConfigurationType.Path   => "--type=path",
+                    _                           => null
+                };
+            }
+            else
+            {
+                return type switch
+                {
+                    GitConfigurationType.Bool   => "--bool",
+                    GitConfigurationType.Path   => "--path",
+                    _                           => null
+                };
+            }
+        }
+
+        public static string QuoteCmdArg(string str)
+        {
+            bool needsQuotes = string.IsNullOrEmpty(str);
+            var result = new StringBuilder();
+
+            for (int i = 0; i < (str?.Length ?? 0); i++)
+            {
+                switch (str![i])
+                {
+                    case '"':
+                        result.Append("\\\"");
+                        needsQuotes = true;
+                        break;
+
+                    case ' ':
+                    case '{':
+                    case '*':
+                    case '?':
+                    case '\r':
+                    case '\n':
+                    case '\t':
+                    case '\'':
+                        result.Append(str[i]);
+                        needsQuotes = true;
+                        break;
+
+                    case '\\':
+                        int end = i;
+
+                        // Copy all the '\'s in this run.
+                        while (end < str.Length && str[end] == '\\')
+                        {
+                            result.Append('\\');
+                            end++;
+                        }
+
+                        // If we ended the run of '\'s with a '"' then we need to double up the number of '\'s.
+                        // The '"' will be escaped on the next pass of the loop.
+                        // Also if we have reached the end of the string, and we need to book-end the result
+                        // with double quotes ('"') we should escape all the '\'s to prevent ending on an
+                        // escaped '"' in the result.
+                        if (end < str.Length && str[end] == '"' ||
+                            end == str.Length && needsQuotes)
+                        {
+                            result.Append('\\', end - i);
+                        }
+
+                        // Back-off one character
+                        if (end > i)
+                        {
+                            end--;
+                        }
+
+                        i = end;
+                        break;
+
+                    default:
+                        result.Append(str[i]);
+                        break;
+                }
+            }
+
+            if (needsQuotes)
+            {
+                result.Insert(0, '"');
+                result.Append('"');
+            }
+
+            return result.ToString();
+        }
+    }
+
+    public static class GitConfigurationExtensions
+    {
+        /// <summary>
+        /// Enumerate all configuration entries invoking the specified callback for each entry.
+        /// </summary>
+        /// <param name="config">Configuration object.</param>
+        /// <param name="cb">Callback to invoke for each matching configuration entry.</param>
+        public static void Enumerate(this IGitConfiguration config, GitConfigurationEnumerationCallback cb)
+        {
+            config.Enumerate(GitConfigurationLevel.All, cb);
+        }
+
+        /// <summary>
+        /// Enumerate all configuration entries invoking the specified callback for each entry.
+        /// </summary>
+        /// <param name="config">Configuration object.</param>
+        /// <param name="level">Filter to the specific configuration level.</param>
+        /// <param name="section">Optional section name to filter; use null for any.</param>
+        /// <param name="property">Optional property name to filter; use null for any.</param>
+        /// <param name="cb">Callback to invoke for each matching configuration entry.</param>
+        public static void Enumerate(this IGitConfiguration config,
+            GitConfigurationLevel level, string section, string property, GitConfigurationEnumerationCallback cb)
+        {
+            config.Enumerate(level, entry =>
+            {
+                if (GitConfigurationKeyComparer.TrySplit(entry.Key, out string entrySection, out _, out string entryProperty) &&
+                    (section  is null || GitConfigurationKeyComparer.SectionComparer.Equals(section, entrySection)) &&
+                    (property is null || GitConfigurationKeyComparer.PropertyComparer.Equals(property, entryProperty)))
+                {
+                    return cb(entry);
+                }
+
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// Enumerate all configuration entries invoking the specified callback for each entry.
+        /// </summary>
+        /// <param name="config">Configuration object.</param>
+        /// <param name="section">Optional section name to filter; use null for any.</param>
+        /// <param name="property">Optional property name to filter; use null for any.</param>
+        /// <param name="cb">Callback to invoke for each matching configuration entry.</param>
+        public static void Enumerate(this IGitConfiguration config, string section, string property, GitConfigurationEnumerationCallback cb)
+        {
+            Enumerate(config, GitConfigurationLevel.All, section, property, cb);
+        }
+
+        /// <summary>
+        /// Get the value of a configuration entry as a string.
+        /// </summary>
+        /// <exception cref="System.Collections.Generic.KeyNotFoundException">A configuration entry with the specified key was not found.</exception>
+        /// <param name="config">Configuration object.</param>
+        /// <param name="level">Filter to the specific configuration level.</param>
+        /// <param name="name">Configuration entry name.</param>
+        /// <returns>Configuration entry value.</returns>
+        public static string Get(this IGitConfiguration config, GitConfigurationLevel level, string name)
+        {
+            if (!config.TryGet(level, GitConfigurationType.Raw, name, out string value))
+            {
+                throw new KeyNotFoundException($"Git configuration entry with the name '{name}' was not found.");
+            }
+
+            return value;
+        }
+
+        /// <summary>
+        /// Get the value of a configuration entry as a string.
+        /// </summary>
+        /// <exception cref="System.Collections.Generic.KeyNotFoundException">A configuration entry with the specified key was not found.</exception>
+        /// <param name="config">Configuration object.</param>
+        /// <param name="name">Configuration entry name.</param>
+        /// <returns>Configuration entry value.</returns>
+        public static string Get(this IGitConfiguration config, string name)
+        {
+            return Get(config, GitConfigurationLevel.All, name);
+        }
+
+        /// <summary>
+        /// Try and get the value of a configuration entry as a string.
+        /// </summary>
+        /// <param name="config">Configuration object.</param>
+        /// <param name="name">Configuration entry name.</param>
+        /// <param name="isPath">Whether the entry should be canonicalized as a path.</param>
+        /// <param name="value">Configuration entry value.</param>
+        /// <returns>True if the value was found, false otherwise.</returns>
+        public static bool TryGet(this IGitConfiguration config, string name, bool isPath, out string value)
+        {
+            return config.TryGet(GitConfigurationLevel.All,
+                isPath ? GitConfigurationType.Path : GitConfigurationType.Raw,
+                name, out value);
+        }
+
+        /// <summary>
+        /// Get all value of a multivar configuration entry.
+        /// </summary>
+        /// <param name="config">Configuration object.</param>
+        /// <param name="name">Configuration entry name.</param>
+        /// <returns>All values of the multivar configuration entry.</returns>
+        public static IEnumerable<string> GetAll(this IGitConfiguration config, string name)
+        {
+            return config.GetAll(GitConfigurationLevel.All, GitConfigurationType.Raw, name);
+        }
+
+        /// <summary>
+        /// Get all values of a multivar configuration entry.
+        /// </summary>
+        /// <param name="config">Configuration object.</param>
+        /// <param name="nameRegex">Configuration entry name regular expression.</param>
+        /// <param name="valueRegex">Regular expression to filter which variables we're interested in. Use null to indicate all.</param>
+        /// <returns>All values of the multivar configuration entry.</returns>
+        public static IEnumerable<string> GetRegex(this IGitConfiguration config, string nameRegex, string valueRegex)
+        {
+            return config.GetRegex(GitConfigurationLevel.All, GitConfigurationType.Raw, nameRegex, valueRegex);
+        }
+    }
+}

--- a/src/Core/GitConfigurationEntry.cs
+++ b/src/Core/GitConfigurationEntry.cs
@@ -1,0 +1,14 @@
+namespace GitCredentialManager
+{
+    public class GitConfigurationEntry
+    {
+        public GitConfigurationEntry(string key, string value)
+        {
+            Key = key;
+            Value = value;
+        }
+
+        public string Key { get; }
+        public string Value { get; }
+    }
+}

--- a/src/Core/GitConfigurationKeyComparer.cs
+++ b/src/Core/GitConfigurationKeyComparer.cs
@@ -1,0 +1,84 @@
+using System;
+
+namespace GitCredentialManager
+{
+    /// <summary>
+    /// Represents string comparison of Git configuration entry key names.
+    /// </summary>
+    /// <remarks>
+    /// Git configuration entries have the form "section[.scope].property", where the
+    /// scope part is optional.
+    /// <para/>
+    /// The section and property components are NOT case sensitive.
+    /// The scope component if present IS case sensitive.
+    /// </remarks>
+    public class GitConfigurationKeyComparer : StringComparer
+    {
+        public static readonly GitConfigurationKeyComparer Instance = new GitConfigurationKeyComparer();
+
+        public static readonly StringComparer SectionComparer = OrdinalIgnoreCase;
+        public static readonly StringComparer ScopeComparer = Ordinal;
+        public static readonly StringComparer PropertyComparer = OrdinalIgnoreCase;
+
+        private GitConfigurationKeyComparer() { }
+
+        public override int Compare(string x, string y)
+        {
+            TrySplit(x, out string xSection, out string xScope, out string xProperty);
+            TrySplit(y, out string ySection, out string yScope, out string yProperty);
+
+            int cmpSection = OrdinalIgnoreCase.Compare(xSection, ySection);
+            if (cmpSection != 0) return cmpSection;
+
+            int cmpProperty = OrdinalIgnoreCase.Compare(xProperty, yProperty);
+            if (cmpProperty != 0) return cmpProperty;
+
+            return Ordinal.Compare(xScope, yScope);
+        }
+
+        public override bool Equals(string x, string y)
+        {
+            if (ReferenceEquals(x, y)) return true;
+            if (x is null || y is null) return false;
+
+            TrySplit(x, out string xSection, out string xScope, out string xProperty);
+            TrySplit(y, out string ySection, out string yScope, out string yProperty);
+
+            // Section and property names are not case sensitive, but the inner 'scope' IS case sensitive!
+            return OrdinalIgnoreCase.Equals(xSection, ySection) &&
+                   OrdinalIgnoreCase.Equals(xProperty, yProperty) &&
+                   Ordinal.Equals(xScope, yScope);
+        }
+
+        public override int GetHashCode(string obj)
+        {
+            TrySplit(obj, out string section, out string scope, out string property);
+
+            int code = OrdinalIgnoreCase.GetHashCode(section) ^
+                       OrdinalIgnoreCase.GetHashCode(property);
+
+            return scope is null
+                ? code
+                : code ^ Ordinal.GetHashCode(scope);
+        }
+
+        public static bool TrySplit(string str, out string section, out string scope, out string property)
+        {
+            section = null;
+            scope = null;
+            property = null;
+
+            if (string.IsNullOrWhiteSpace(str))
+            {
+                return false;
+            }
+
+            section = str.TruncateFromIndexOf('.');
+            property = str.TrimUntilLastIndexOf('.');
+            int scopeLength = str.Length - (section.Length + property.Length + 2);
+            scope = scopeLength > 0 ? str.Substring(section.Length + 1, scopeLength) : null;
+
+            return true;
+        }
+    }
+}

--- a/src/Core/GitVersion.cs
+++ b/src/Core/GitVersion.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace GitCredentialManager
+{
+    public class GitVersion : IComparable, IComparable<GitVersion>
+    {
+        private readonly string _originalString;
+        private List<int> _components;
+
+        public GitVersion(string versionString)
+        {
+            if (versionString is null)
+            {
+                _components = new List<int>();
+                return;
+            }
+
+            _originalString = versionString;
+
+            string[] splitVersion = versionString.Split('.');
+            _components = new List<int>(splitVersion.Length);
+
+            foreach (string part in splitVersion)
+            {
+                if (Int32.TryParse(part, out int component))
+                {
+                    _components.Add(component);
+                }
+                else
+                {
+                    // Exit at the first non-integer component
+                    break;
+                }
+            }
+        }
+
+        public GitVersion(params int[] components)
+        {
+            _components = components.ToList();
+        }
+
+        public override string ToString()
+        {
+            return string.Join(".", _components);
+        }
+
+        public string OriginalString
+        {
+            get
+            {
+                if (_originalString is null)
+                {
+                    return ToString();
+                }
+
+                return _originalString;
+            }
+        }
+
+        public int CompareTo(object obj)
+        {
+            if (obj is null)
+            {
+                return 1;
+            }
+
+            GitVersion other = obj as GitVersion;
+            if (other == null)
+            {
+                throw new ArgumentException("A GitVersion object is required for comparison.", "obj");
+            }
+
+            return CompareTo(other);
+        }
+
+        public int CompareTo(GitVersion other)
+        {
+            if (other is null)
+            {
+                return 1;
+            }
+
+            // Compare for as many components as the two versions have in common. If a
+            // component does not exist in a components list, it is assumed to be 0.
+            int thisCount = _components.Count, otherCount = other._components.Count;
+            for (int i = 0; i < Math.Max(thisCount, otherCount); i++)
+            {
+                int thisComponent = i < thisCount ? _components[i] : 0;
+                int otherComponent = i < otherCount ? other._components[i] : 0;
+                if (thisComponent != otherComponent)
+                {
+                    return thisComponent.CompareTo(otherComponent);
+                }
+            }
+
+            // No discrepencies found in versions
+            return 0;
+        }
+
+        public static int Compare(GitVersion left, GitVersion right)
+        {
+            if (object.ReferenceEquals(left, right))
+            {
+                return 0;
+            }
+
+            if (left is null)
+            {
+                return -1;
+            }
+
+            return left.CompareTo(right);
+        }
+
+        public override bool Equals(object obj)
+        {
+            GitVersion other = obj as GitVersion;
+            if (other is null)
+            {
+                return false;
+            }
+
+            return this.CompareTo(other) == 0;
+        }
+
+        public override int GetHashCode()
+        {
+            return ToString().GetHashCode();
+        }
+
+        public static bool operator ==(GitVersion left, GitVersion right)
+        {
+            if (left is null)
+            {
+                return right is null;
+            }
+
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(GitVersion left, GitVersion right)
+        {
+            return !(left == right);
+        }
+
+        public static bool operator <(GitVersion left, GitVersion right)
+        {
+            return Compare(left, right) < 0;
+        }
+
+        public static bool operator >(GitVersion left, GitVersion right)
+        {
+            return Compare(left, right) > 0;
+        }
+
+        public static bool operator <=(GitVersion left, GitVersion right)
+        {
+            return Compare(left, right) <= 0;
+        }
+
+        public static bool operator >=(GitVersion left, GitVersion right)
+        {
+            return Compare(left, right) >= 0;
+        }
+    }
+}

--- a/src/Core/Gpg.cs
+++ b/src/Core/Gpg.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Diagnostics;
+
+namespace GitCredentialManager
+{
+    public interface IGpg
+    {
+        string DecryptFile(string path);
+
+        void EncryptFile(string path, string gpgId, string contents);
+    }
+
+    public class Gpg : IGpg
+    {
+        private readonly string _gpgPath;
+        private readonly ISessionManager _sessionManager;
+        private readonly IProcessManager _processManager;
+        private readonly ITrace2 _trace2;
+
+        public Gpg(string gpgPath, ISessionManager sessionManager, IProcessManager processManager, ITrace2 trace2)
+        {
+            EnsureArgument.NotNullOrWhiteSpace(gpgPath, nameof(gpgPath));
+            EnsureArgument.NotNull(sessionManager, nameof(sessionManager));
+            EnsureArgument.NotNull(trace2, nameof(trace2));
+
+            _gpgPath = gpgPath;
+            _sessionManager = sessionManager;
+            _processManager = processManager;
+            _trace2 = trace2;
+        }
+
+        public string DecryptFile(string path)
+        {
+            var psi = new ProcessStartInfo(_gpgPath, $"--batch --decrypt \"{path}\"")
+            {
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                // Suppress verbose decryption messages
+                // Ok to redirect stderr for non-Git-related processes
+                RedirectStandardError = true,
+            };
+
+            PrepareEnvironment(psi);
+
+            using (var gpg = _processManager.CreateProcess(psi))
+            {
+                if (!gpg.Start(Trace2ProcessClass.Other))
+                {
+                    throw new Trace2Exception(_trace2, "Failed to start gpg.");
+                }
+
+                gpg.WaitForExit();
+
+                if (gpg.ExitCode != 0)
+                {
+                    string stdout = gpg.StandardOutput.ReadToEnd();
+                    string stderr = gpg.StandardError.ReadToEnd();
+                    var format = "Failed to decrypt file '{0}' with gpg. exit={1}, out={2}, err={3}";
+                    var message = string.Format(format, path, gpg.ExitCode, stdout, stderr);
+                    throw new Trace2Exception(_trace2, message, format);
+                }
+
+                return gpg.StandardOutput.ReadToEnd();
+            }
+        }
+
+        public void EncryptFile(string path, string gpgId, string contents)
+        {
+            var psi = new ProcessStartInfo(_gpgPath, $"--encrypt --batch --recipient \"{gpgId}\" --output \"{path}\"")
+            {
+                UseShellExecute = false,
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true, // Ok to redirect stderr for non-git-related processes
+            };
+
+            PrepareEnvironment(psi);
+
+            using (var gpg = _processManager.CreateProcess(psi))
+            {
+                if (!gpg.Start(Trace2ProcessClass.Other))
+                {
+                    throw new Trace2Exception(_trace2, "Failed to start gpg.");
+                }
+
+                gpg.StandardInput.Write(contents);
+                gpg.StandardInput.Close();
+
+                gpg.WaitForExit();
+
+                if (gpg.ExitCode != 0)
+                {
+                    string stdout = gpg.StandardOutput.ReadToEnd();
+                    string stderr = gpg.StandardError.ReadToEnd();
+                    var format = "Failed to encrypt file '{0}' with gpg. exit={1}, out={2}, err={3}";
+                    var message = string.Format(format, path, gpg.ExitCode, stdout, stderr);
+                    throw new Trace2Exception(_trace2, message, format);
+                }
+            }
+        }
+
+        private void PrepareEnvironment(ProcessStartInfo psi)
+        {
+            // If we're in a headless environment over SSH, and we don't have a GPG_TTY
+            // explicitly set, use the SSH_TTY variable for our GPG_TTY.
+            if (!_sessionManager.IsDesktopSession &&
+                !psi.Environment.ContainsKey("GPG_TTY") &&
+                psi.Environment.ContainsKey("SSH_TTY"))
+            {
+                psi.Environment["GPG_TTY"] = psi.Environment["SSH_TTY"];
+            }
+        }
+    }
+}

--- a/src/Core/HttpClientFactory.cs
+++ b/src/Core/HttpClientFactory.cs
@@ -1,0 +1,333 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+
+namespace GitCredentialManager
+{
+    /// <summary>
+    /// Constructs <see cref="HttpClient"/>s that have been configured for use in Git Credential Manager.
+    /// </summary>
+    public interface IHttpClientFactory
+    {
+        /// <summary>
+        /// Get a new instance of <see cref="HttpClient"/> with default request headers set.
+        /// </summary>
+        /// <remarks>
+        /// Callers should reuse instances of <see cref="HttpClient"/> returned from this method as long
+        /// as they are needed, rather than repeatably call this method to create new ones.
+        /// <para/>
+        /// Creating a new <see cref="HttpClient"/> consumes one free socket which may not be released
+        /// by the Operating System until sometime after the client is disposed, leading to possible free
+        /// socket exhaustion.
+        /// <para/>
+        /// The client instance is configured for use behind a proxy using Git's http.proxy configuration
+        /// for the local repository (the current working directory), if found.
+        /// </remarks>
+        /// <returns>New client instance with default headers.</returns>
+        HttpClient CreateClient();
+    }
+
+    public class HttpClientFactory : IHttpClientFactory
+    {
+        private readonly IFileSystem _fileSystem;
+        private readonly ITrace _trace;
+        private readonly ITrace2 _trace2;
+        private readonly ISettings _settings;
+        private readonly IStandardStreams _streams;
+
+        public HttpClientFactory(IFileSystem fileSystem, ITrace trace, ITrace2 trace2, ISettings settings, IStandardStreams streams)
+        {
+            EnsureArgument.NotNull(fileSystem, nameof(fileSystem));
+            EnsureArgument.NotNull(trace, nameof(trace));
+            EnsureArgument.NotNull(settings, nameof(settings));
+            EnsureArgument.NotNull(streams, nameof(streams));
+
+            _fileSystem = fileSystem;
+            _trace = trace;
+            _trace2 = trace2;
+            _settings = settings;
+            _streams = streams;
+        }
+
+        public HttpClient CreateClient()
+        {
+            _trace.WriteLine("Creating new HTTP client instance...");
+
+            HttpClientHandler handler;
+
+            if (TryCreateProxy(out IWebProxy proxy))
+            {
+                _trace.WriteLine("HTTP client is using the configured proxy.");
+
+                handler = new HttpClientHandler
+                {
+                    Proxy = proxy,
+                    UseProxy = true
+                };
+            }
+            else
+            {
+                handler = new HttpClientHandler();
+            }
+
+            // Trace Git's chosen SSL/TLS backend
+            _trace.WriteLine($"Git's SSL/TLS backend is: {_settings.TlsBackend}");
+
+            // Mirror Git for Windows and only send client TLS certificates automatically if we're using
+            // the schannel backend _and_ the user has opted in to sending them.
+            if (_settings.TlsBackend == TlsBackend.Schannel &&
+                _settings.AutomaticallyUseClientCertificates)
+            {
+                _trace.WriteLine("Configured to automatically send TLS client certificates.");
+                handler.ClientCertificateOptions = ClientCertificateOption.Automatic;
+            }
+
+            // Configure server certificate verification and warn if we're bypassing validation
+
+            // IsCertificateVerificationEnabled takes precedence over custom TLS cert verification
+            if (!_settings.IsCertificateVerificationEnabled)
+            {
+                _trace.WriteLine("TLS certificate verification has been disabled.");
+                _streams.Error.WriteLine("warning: ----------------- SECURITY WARNING ----------------");
+                _streams.Error.WriteLine("warning: | TLS certificate verification has been disabled! |");
+                _streams.Error.WriteLine("warning: ---------------------------------------------------");
+                _streams.Error.WriteLine($"warning: HTTPS connections may not be secure. See {Constants.HelpUrls.GcmTlsVerification} for more information.");
+
+#if NETFRAMEWORK
+                ServicePointManager.ServerCertificateValidationCallback = (req, cert, chain, errors) => true;
+#else
+                handler.ServerCertificateCustomValidationCallback = (req, cert, chain, errors) => true;
+#endif
+            }
+            // If schannel is the TLS backend, custom certificate usage must be explicitly enabled
+            else if (!string.IsNullOrWhiteSpace(_settings.CustomCertificateBundlePath) &&
+                ((_settings.TlsBackend != TlsBackend.Schannel) || _settings.UseCustomCertificateBundleWithSchannel))
+            {
+                string certBundlePath = _settings.CustomCertificateBundlePath;
+                _trace.WriteLine($"Custom certificate verification has been enabled with certificate bundle at {certBundlePath}");
+
+                // Throw exception if cert bundle file not found
+                if (!_fileSystem.FileExists(certBundlePath))
+                {
+                    var format = "Custom certificate bundle not found at path: {0}";
+                    var message = string.Format(format, certBundlePath);
+                    throw new Trace2FileNotFoundException(_trace2, message, format, certBundlePath);
+                }
+
+                Func<X509Certificate2, X509Chain, SslPolicyErrors, bool> validationCallback = (cert, chain, errors) =>
+                {
+                    // Fail immediately if there are non-chain issues with the remote cert
+                    if ((errors & ~SslPolicyErrors.RemoteCertificateChainErrors) != 0)
+                    {
+                        return false;
+                    }
+
+                    // Import the custom certs
+                    X509Certificate2Collection certBundle = new X509Certificate2Collection();
+                    certBundle.Import(certBundlePath);
+
+                    try
+                    {
+                        // Add the certs to the chain
+                        chain.ChainPolicy.ExtraStore.AddRange(certBundle);
+
+                        // Rebuild the chain
+                        if (chain.Build(cert))
+                        {
+                            return true;
+                        }
+
+                        // Manually handle case where only error is UntrustedRoot
+                        if (chain.ChainStatus.All(status => status.Status == X509ChainStatusFlags.UntrustedRoot))
+                        {
+                            // Verify root is contained within the certBundle
+                            X509Certificate2 rootCert = chain.ChainElements[chain.ChainElements.Count - 1].Certificate;
+                            var matchingCerts = certBundle.Find(X509FindType.FindByThumbprint, rootCert.Thumbprint, false);
+                            if (matchingCerts.Count > 0)
+                            {
+                                // Check the content of the first matching cert found (do
+                                // not try others if mismatched - mirrors OpenSSL:
+                                // https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_default_verify_paths.html#WARNINGS)
+                                return rootCert.RawData.SequenceEqual(matchingCerts[0].RawData);
+                            }
+                            else
+                            {
+                                // Untrusted root not found in custom cert bundle
+                                return false;
+                            }
+                        }
+
+                        // Fail for errors other than UntrustedRoot
+                        return false;
+                    }
+                    finally
+                    {
+                        // Dispose imported cert bundle
+                        for (int i = 0; i < certBundle.Count; i++)
+                        {
+                            certBundle[i].Dispose();
+                        }
+                    }
+                };
+
+                // Set the custom server certificate validation callback.
+                // NOTE: this is executed after the default platform server certificate validation is performed
+#if NETFRAMEWORK
+                ServicePointManager.ServerCertificateValidationCallback = (_, cert, chain, errors) =>
+                {
+                    // Fail immediately if the cert or chain isn't present
+                    if (cert is null || chain is null)
+                    {
+                        return false;
+                    }
+
+                    using (X509Certificate2 cert2 = new X509Certificate2(cert))
+                    {
+                        return validationCallback(cert2, chain, errors);
+                    }
+                };
+#else
+                handler.ServerCertificateCustomValidationCallback = (_, cert, chain, errors) => validationCallback(cert, chain, errors);
+#endif
+            }
+
+            // If CustomCookieFilePath is set, set Cookie header from cookie file, which is written by libcurl
+            if (!string.IsNullOrWhiteSpace(_settings.CustomCookieFilePath) && _fileSystem.FileExists(_settings.CustomCookieFilePath))
+            {
+                // get the filename from gitconfig
+                string cookieFilePath = _settings.CustomCookieFilePath;
+                _trace.WriteLine($"Custom cookie file has been enabled with {cookieFilePath}");
+
+                // get cookie from cookie file
+                string cookieFileContents = _fileSystem.ReadAllText(cookieFilePath);
+
+                var cookieParser = new CurlCookieParser(_trace);
+                var cookies = cookieParser.Parse(cookieFileContents);
+
+                // Set the cookie
+                var cookieContainer = new CookieContainer();
+                foreach (var cookie in cookies)
+                {
+                    var schema = cookie.Secure ? "https" : "http";
+                    var uri = new UriBuilder(schema, cookie.Domain.TrimStart('.')).Uri;
+                    cookieContainer.Add(uri, new Cookie(cookie.Name, cookie.Value));
+                }
+                handler.CookieContainer = cookieContainer;
+                handler.UseCookies = true;
+                
+                _trace.WriteLine("Configured to automatically send cookie header.");
+
+            }
+
+            var client = new HttpClient(handler);
+
+            // Add default headers
+            client.DefaultRequestHeaders.UserAgent.ParseAdd(Constants.GetHttpUserAgent(_trace2));
+            client.DefaultRequestHeaders.CacheControl = new CacheControlHeaderValue
+            {
+                NoCache = true
+            };
+
+            return client;
+        }
+
+        /// <summary>
+        /// Try to create an <see cref="IWebProxy"/> object from the configuration specified by environment variables,
+        /// or Git configuration for the specified repository, current user, and system.
+        /// </summary>
+        /// <param name="proxy">Configured <see cref="IWebProxy"/>, or null if no proxy configuration was found.</param>
+        /// <returns>True if proxy configuration was found, false otherwise.</returns>
+        public bool TryCreateProxy(out IWebProxy proxy)
+        {
+            // Try to extract the proxy URI from the environment or Git config
+            ProxyConfiguration proxyConfig = _settings.GetProxyConfiguration();
+            if (proxyConfig != null)
+            {
+                // Inform the user if they are using a deprecated proxy configuration
+                if (proxyConfig.IsDeprecatedSource)
+                {
+                    _trace.WriteLine("Using a deprecated proxy configuration.");
+                    _streams.Error.WriteLine($"warning: Using a deprecated proxy configuration. See {Constants.HelpUrls.GcmHttpProxyGuide} for more information.");
+                }
+
+                // If NO_PROXY is set to the value "*" then libcurl disables proxying. We should mirror this.
+                if (StringComparer.OrdinalIgnoreCase.Equals("*", proxyConfig.NoProxyRaw))
+                {
+                    _trace.WriteLine("NO_PROXY value set to \"*\"; disabling proxy settings");
+                    proxy = null;
+                    return false;
+                }
+
+                // Dictionary of proxy info for tracing
+                var dict = new Dictionary<string, string> {["address"] = proxyConfig.Address.ToString()};
+
+                // Try to configure proxy credentials.
+                // For an empty username AND password we should use the system default credentials
+                // (for example for Windows Integrated Authentication-based proxies).
+                if (!(string.IsNullOrEmpty(proxyConfig.UserName) && string.IsNullOrEmpty(proxyConfig.Password)))
+                {
+                    proxy = new WebProxy(proxyConfig.Address)
+                    {
+                        Credentials = new NetworkCredential(proxyConfig.UserName, proxyConfig.Password),
+                    };
+
+                    // Add user/pass info to the trace dictionary
+                    dict["username"] = proxyConfig.UserName;
+                    dict["password"] = proxyConfig.Password;
+                }
+                else
+                {
+                    proxy = new WebProxy(proxyConfig.Address)
+                    {
+                        UseDefaultCredentials = true,
+                    };
+
+                    // Trace the use of system default credentials
+                    dict["useDefaultCredentials"] = "true";
+                }
+
+                // Set bypass address list.
+                // The .NET WebProxy class requires that each host entry in the bypass list be a regular expression.
+                // However libcurl (that we are aiming to be compatible/co-operative with) doesn't support regexs so
+                // we must convert the libcurl-esc entries in to .NET-compatible regular expressions.
+                // If we fail at any point we shouldn't crash but write a warning to trace output.
+                if (!string.IsNullOrWhiteSpace(proxyConfig.NoProxyRaw))
+                {
+                    dict["noProxy"] = proxyConfig.NoProxyRaw;
+
+                    try
+                    {
+                        string[] bypassRegexs = ProxyConfiguration.ConvertToBypassRegexArray(proxyConfig.NoProxyRaw).ToArray();
+                        dict["bypass"] = string.Join(",", bypassRegexs);
+
+                        ((WebProxy)proxy).BypassList = bypassRegexs;
+                    }
+                    catch (Exception ex)
+                    {
+                        var message =
+                            "Failed to convert proxy bypass hosts to regular expressions; ignoring bypass list";
+                        _trace.WriteLine(message);
+                        _trace.WriteException(ex);
+                        _trace2.WriteError(message);
+                        dict["bypass"] = "<< failed to convert >>";
+                    }
+                }
+
+                // Tracer out proxy info dictionary
+                _trace.WriteLine("Created a WebProxy instance:");
+                _trace.WriteDictionarySecrets(dict, new[] {"password"});
+
+                return true;
+            }
+
+            proxy = null;
+            return false;
+        }
+    }
+}

--- a/src/Core/HttpRequestExtensions.cs
+++ b/src/Core/HttpRequestExtensions.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Globalization;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace GitCredentialManager
+{
+    public static class HttpRequestExtensions
+    {
+        /// <summary>
+        /// Add a basic authentication header to the request, with the given username and password.
+        /// </summary>
+        /// <remarks>
+        /// The header value is formed by computing the base64 string from the UTF-8 string "{<paramref name="userName"/>}:{<paramref name="password"/>}".
+        /// </remarks>
+        public static void AddBasicAuthenticationHeader(this HttpRequestMessage request, string userName, string password)
+        {
+            string basicAuthValue = string.Format(CultureInfo.InvariantCulture, "{0}:{1}", userName, password);
+            byte[] authBytes = Encoding.UTF8.GetBytes(basicAuthValue);
+            string base64String = Convert.ToBase64String(authBytes);
+            request.Headers.Authorization = new AuthenticationHeaderValue(Constants.Http.WwwAuthenticateBasicScheme, base64String);
+        }
+
+        /// <summary>
+        /// Add a bearer authentication header to the request, with the given bearer token.
+        /// </summary>
+        public static void AddBearerAuthenticationHeader(this HttpRequestMessage request, string bearerToken)
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue(Constants.Http.WwwAuthenticateBearerScheme, bearerToken);
+        }
+    }
+}

--- a/src/Core/ICredentialStore.cs
+++ b/src/Core/ICredentialStore.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+
+namespace GitCredentialManager
+{
+    /// <summary>
+    /// Represents a secure storage location for <see cref="ICredential"/>s.
+    /// </summary>
+    public interface ICredentialStore
+    {
+        /// <summary>
+        /// Get all accounts from the store for the given service.
+        /// </summary>
+        /// <param name="service">Name of the service to match against. Use null to match all values.</param>
+        /// <returns>All accounts that match the query.</returns>
+        IList<string> GetAccounts(string service);
+
+        /// <summary>
+        /// Get the first credential from the store that matches the given query.
+        /// </summary>
+        /// <param name="service">Name of the service to match against. Use null to match all values.</param>
+        /// <param name="account">Account name to match against. Use null to match all values.</param>
+        /// <returns>First matching credential or null if none are found.</returns>
+        ICredential Get(string service, string account);
+
+        /// <summary>
+        /// Add or update credential in the store with the specified key.
+        /// </summary>
+        /// <param name="service">Name of the service this credential is for. Use null to match all values.</param>
+        /// <param name="account">Account associated with this credential. Use null to match all values.</param>
+        /// <param name="secret">Secret value to store.</param>
+        void AddOrUpdate(string service, string account, string secret);
+
+        /// <summary>
+        /// Delete credential from the store that matches the given query.
+        /// </summary>
+        /// <param name="service">Name of the service to match against. Use null to match all values.</param>
+        /// <param name="account">Account name to match against. Use null to match all values.</param>
+        /// <returns>True if the credential was deleted, false otherwise.</returns>
+        bool Remove(string service, string account);
+    }
+}

--- a/src/Core/ISessionManager.cs
+++ b/src/Core/ISessionManager.cs
@@ -1,0 +1,36 @@
+namespace GitCredentialManager
+{
+    public interface ISessionManager
+    {
+        /// <summary>
+        /// Determine if the current session has access to a desktop/can display UI.
+        /// </summary>
+        /// <returns>True if the session can display UI, false otherwise.</returns>
+        bool IsDesktopSession { get; }
+
+        /// <summary>
+        /// Determine if the current session has access to a web browser.
+        /// </summary>
+        /// <returns>True if the session can display a web browser, false otherwise.</returns>
+        bool IsWebBrowserAvailable { get; }
+    }
+    
+    public abstract class SessionManager : ISessionManager
+    {
+        protected IEnvironment Environment { get; }
+        protected IFileSystem FileSystem { get; }
+
+        protected SessionManager(IEnvironment env, IFileSystem fs)
+        {
+            EnsureArgument.NotNull(env, nameof(env));
+            EnsureArgument.NotNull(fs, nameof(fs));
+
+            Environment = env;
+            FileSystem = fs;
+        }
+        
+        public abstract bool IsDesktopSession { get; }
+
+        public virtual bool IsWebBrowserAvailable => IsDesktopSession;
+    }
+}

--- a/src/Core/ISystemPrompts.cs
+++ b/src/Core/ISystemPrompts.cs
@@ -1,0 +1,24 @@
+
+namespace GitCredentialManager
+{
+    /// <summary>
+    /// Represents native system UI prompts.
+    /// </summary>
+    public interface ISystemPrompts
+    {
+        /// <summary>
+        /// The parent window handle or ID. Used for correctly positioning and parenting system dialogs.
+        /// </summary>
+        /// <remarks>This value is platform specific.</remarks>
+        object ParentWindowId { get; set; }
+
+        /// <summary>
+        /// Show a basic credential prompt using native system UI.
+        /// </summary>
+        /// <param name="resource">The name or URL of the resource to collect credentials for.</param>
+        /// <param name="userName">Optional pre-filled username.</param>
+        /// <param name="credential">The captured basic credential.</param>
+        /// <returns>True if the user completes the dialog, false otherwise.</returns>
+        bool ShowCredentialPrompt(string resource, string userName, out ICredential credential);
+    }
+}

--- a/src/Core/ITerminal.cs
+++ b/src/Core/ITerminal.cs
@@ -1,0 +1,49 @@
+using System;
+using GitCredentialManager.Interop;
+
+namespace GitCredentialManager
+{
+    /// <summary>
+    /// Represents a terminal (TTY) interface.
+    /// </summary>
+    public interface ITerminal
+    {
+        /// <summary>
+        /// Write a message to the terminal screen.
+        /// </summary>
+        /// <param name="format">Format message to print to the terminal.</param>
+        /// <param name="args">Format argument values.</param>
+        /// <exception cref="InteropException">Throw if an error occurs interacting with the native terminal device.</exception>
+        void WriteLine(string format, params object[] args);
+
+        /// <summary>
+        /// Prompt for user input.
+        /// </summary>
+        /// <param name="prompt">Prompt message.</param>
+        /// <returns>User input.</returns>
+        /// <exception cref="InteropException">Throw if an error occurs interacting with the native terminal device.</exception>
+        string Prompt(string prompt);
+
+        /// <summary>
+        /// Prompt for secret user input.
+        /// </summary>
+        /// <remarks>
+        /// Typed user input is masked or hidden.
+        /// </remarks>
+        /// <param name="prompt">Prompt message.</param>
+        /// <returns>Secret user input.</returns>
+        /// <exception cref="InteropException">Throw if an error occurs interacting with the native terminal device.</exception>
+        string PromptSecret(string prompt);
+    }
+
+    public static class TerminalExtensions
+    {
+        /// <summary>
+        /// Write a blank line to the terminal screen.
+        /// </summary>
+        public static void WriteLine(this ITerminal terminal)
+        {
+            terminal.WriteLine(Environment.NewLine);
+        }
+    }
+}

--- a/src/Core/ITrace2Writer.cs
+++ b/src/Core/ITrace2Writer.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Text;
+
+namespace GitCredentialManager;
+
+/// <summary>
+/// The different format targets supported in the TRACE2 tracing
+/// system.
+/// </summary>
+public enum Trace2FormatTarget
+{
+    Event,
+    Normal,
+    Performance
+}
+
+public interface ITrace2Writer : IDisposable
+{
+    bool Failed { get; }
+
+    void Write(Trace2Message message);
+}
+
+public class Trace2Writer : DisposableObject, ITrace2Writer
+{
+    private readonly Trace2FormatTarget _formatTarget;
+
+    public bool Failed { get; protected set; }
+
+    protected Trace2Writer(Trace2FormatTarget formatTarget)
+    {
+        _formatTarget = formatTarget;
+    }
+
+    protected string Format(Trace2Message message)
+    {
+        EnsureArgument.NotNull(message, nameof(message));
+        var sb = new StringBuilder();
+
+        switch (_formatTarget)
+        {
+            case Trace2FormatTarget.Event:
+                sb.Append(message.ToJson());
+                break;
+            case Trace2FormatTarget.Normal:
+                sb.Append(message.ToNormalString());
+                break;
+            case Trace2FormatTarget.Performance:
+                sb.Append(message.ToPerformanceString());
+                break;
+            default:
+                Console.WriteLine($"warning: unrecognized format target '{_formatTarget}', disabling TRACE2 tracing.");
+                Failed = true;
+                break;
+        }
+
+        sb.Append('\n');
+        return sb.ToString();
+    }
+
+    public virtual void Write(Trace2Message message)
+    { }
+}

--- a/src/Core/IniFile.cs
+++ b/src/Core/IniFile.cs
@@ -1,0 +1,207 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace GitCredentialManager
+{
+    public class IniFile
+    {
+        public IniFile()
+        {
+            Sections = new Dictionary<IniSectionName, IniSection>();
+        }
+
+        public IDictionary<IniSectionName, IniSection> Sections { get; }
+
+        public bool TryGetSection(string name, string subName, out IniSection section)
+        {
+            return Sections.TryGetValue(new IniSectionName(name, subName), out section);
+        }
+
+        public bool TryGetSection(string name, out IniSection section)
+        {
+            return Sections.TryGetValue(new IniSectionName(name), out section);
+        }
+    }
+
+    [DebuggerDisplay("{DebuggerDisplay}")]
+    public readonly struct IniSectionName : IEquatable<IniSectionName>
+    {
+        public IniSectionName(string name, string subName = null)
+        {
+            Name = name;
+            SubName = string.IsNullOrEmpty(subName) ? null : subName;
+        }
+
+        public string Name { get; }
+
+        public string SubName { get; }
+
+        public bool Equals(IniSectionName other)
+        {
+            // Main section name is case-insensitive, but subsection name IS case-sensitive!
+            return StringComparer.OrdinalIgnoreCase.Equals(Name, other.Name) &&
+                   StringComparer.Ordinal.Equals(SubName, other.SubName);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is IniSectionName other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return ((Name != null ? Name.ToLowerInvariant().GetHashCode() : 0) * 397) ^
+                       (SubName != null ? SubName.GetHashCode() : 0);
+            }
+        }
+
+        private string DebuggerDisplay => SubName is null ? Name : $"{Name} \"{SubName}\"";
+    }
+
+    [DebuggerDisplay("{DebuggerDisplay}")]
+    public class IniSection
+    {
+        public IniSection(IniSectionName name)
+        {
+            Name = name;
+            Properties = new List<IniProperty>();
+        }
+
+        public IniSectionName Name { get; }
+
+        public IList<IniProperty> Properties { get; }
+
+        public bool TryGetProperty(string name, out string value)
+        {
+            if (TryGetMultiProperty(name, out IEnumerable<string> values))
+            {
+                value = values.Last();
+                return true;
+            }
+
+            value = null;
+            return false;
+        }
+
+        public bool TryGetMultiProperty(string name, out IEnumerable<string> values)
+        {
+            IniProperty[] props = Properties
+                .Where(x => StringComparer.OrdinalIgnoreCase.Equals(x.Name, name))
+                .ToArray();
+
+            if (props.Length == 0)
+            {
+                values = Array.Empty<string>();
+                return false;
+            }
+
+            values = props.Select(x => x.Value);
+            return true;
+        }
+
+        private string DebuggerDisplay => Name.SubName is null
+            ? $"{Name.Name} [Properties: {Properties.Count}]"
+            : $"{Name.Name} \"{Name.SubName}\" [Properties: {Properties.Count}]";
+    }
+
+    [DebuggerDisplay("{DebuggerDisplay}")]
+    public class IniProperty
+    {
+        public IniProperty(string name, string value)
+        {
+            Name = name;
+            Value = value;
+        }
+
+        public string Name { get; }
+        public string Value { get; }
+
+        private string DebuggerDisplay => $"{Name}={Value}";
+    }
+
+    public static class IniSerializer
+    {
+        private static readonly Regex SectionRegex =
+            new Regex(@"^\[[^\S#]*(?'name'[^\s#\]]*?)(?:\s+""(?'sub'.+)"")?\s*\]", RegexOptions.Compiled);
+
+        private static readonly Regex PropertyRegex =
+            new Regex(@"^[^\S#]*?(?'name'[^\s#]+)\s*=(?'value'.*)?$", RegexOptions.Compiled);
+
+        public static IniFile Deserialize(IFileSystem fs, string path)
+        {
+            IEnumerable<string> lines = fs.ReadAllLines(path).Select(x => x.Trim());
+
+            var iniFile = new IniFile();
+            IniSection section = null;
+
+            foreach (string line in lines)
+            {
+                Match match = SectionRegex.Match(line);
+                if (match.Success)
+                {
+                    string mainName = match.Groups["name"].Value;
+                    string subName = match.Groups["sub"].Value;
+
+                    // Skip empty-named sections
+                    if (string.IsNullOrWhiteSpace(mainName))
+                    {
+                        continue;
+                    }
+
+                    if (!iniFile.TryGetSection(mainName, subName, out section))
+                    {
+                        var sectionName = new IniSectionName(mainName, subName);
+                        section = new IniSection(sectionName);
+                        iniFile.Sections[sectionName] = section;
+                    }
+
+                    continue;
+                }
+
+                match = PropertyRegex.Match(line);
+                if (match.Success)
+                {
+                    if (section is null)
+                    {
+                        throw new Exception("Missing section header");
+                    }
+
+                    string propName = match.Groups["name"].Value;
+                    string propValue = match.Groups["value"].Value.Trim();
+
+                    // Trim trailing comments
+                    int firstDQuote = propValue.IndexOf('"');
+                    int lastDQuote = propValue.LastIndexOf('"');
+                    int commentIdx = propValue.LastIndexOf('#');
+                    if (commentIdx > -1)
+                    {
+                        bool insideDQuotes = firstDQuote > -1 && lastDQuote > -1 &&
+                                             (firstDQuote < commentIdx && commentIdx < lastDQuote);
+
+                        if (!insideDQuotes)
+                        {
+                            propValue = propValue.Substring(0, commentIdx).Trim();
+                        }
+                    }
+
+                    // Trim book-ending double quotes: "foo" => foo
+                    if (propValue.Length > 1 && propValue[0] == '"' &&
+                        propValue[propValue.Length - 1] == '"')
+                    {
+                        propValue = propValue.Substring(1, propValue.Length - 2);
+                    }
+
+                    var property = new IniProperty(propName, propValue);
+                    section.Properties.Add(property);
+                }
+            }
+
+            return iniFile;
+        }
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/InteropException.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/InteropException.cs
@@ -1,0 +1,41 @@
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+
+namespace GitCredentialManager.Interop
+{
+    /// <summary>
+    /// An unexpected error occurred in interop-code.
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay}")]
+    public class InteropException : Exception
+    {
+        public InteropException()
+            : base() { }
+
+        public InteropException(string message, int errorCode)
+            : base(message)
+        {
+            ErrorCode = errorCode;
+        }
+
+        public InteropException(string message, int errorCode, Exception innerException)
+            : base(message, innerException)
+        {
+            ErrorCode = errorCode;
+        }
+
+        public InteropException(string message, Win32Exception w32Exception)
+            : base(message, w32Exception)
+        {
+            ErrorCode = w32Exception.NativeErrorCode;
+        }
+
+        /// <summary>
+        /// Native error code.
+        /// </summary>
+        public int ErrorCode { get; }
+
+        private string DebuggerDisplay => $"{Message} [0x{ErrorCode:x}]";
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/InteropUtils.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/InteropUtils.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+
+namespace GitCredentialManager.Interop
+{
+    internal static class InteropUtils
+    {
+        public static byte[] ToByteArray(IntPtr ptr, long count)
+        {
+            var destination = new byte[count];
+            Marshal.Copy(ptr, destination, 0, destination.Length);
+            return destination;
+        }
+
+        public static bool AreEqual(byte[] bytes, IntPtr ptr, uint length)
+        {
+            if (bytes.Length == 0 && (ptr == IntPtr.Zero || length == 0))
+            {
+                return true;
+            }
+
+            if (bytes.Length != length)
+            {
+                return false;
+            }
+
+            byte[] ptrBytes = ToByteArray(ptr, length);
+            return bytes.SequenceEqual(ptrBytes);
+        }
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Linux/LinuxFileSystem.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Linux/LinuxFileSystem.cs
@@ -1,0 +1,27 @@
+using System;
+using System.IO;
+using GitCredentialManager.Interop.Posix;
+
+namespace GitCredentialManager.Interop.Linux
+{
+    public class LinuxFileSystem : PosixFileSystem
+    {
+        public override bool IsSamePath(string a, string b)
+        {
+            if (string.IsNullOrWhiteSpace(a) || string.IsNullOrWhiteSpace(b))
+            {
+                return false;
+            }
+
+            // Normalize paths
+            a = Path.GetFullPath(a);
+            b = Path.GetFullPath(b);
+
+            // Resolve symbolic links
+            a = ResolveSymbolicLinks(a);
+            b = ResolveSymbolicLinks(b);
+
+            return StringComparer.Ordinal.Equals(a, b);
+        }
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Linux/LinuxSessionManager.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Linux/LinuxSessionManager.cs
@@ -1,0 +1,64 @@
+using GitCredentialManager.Interop.Posix;
+
+namespace GitCredentialManager.Interop.Linux;
+
+public class LinuxSessionManager : PosixSessionManager
+{
+    private bool? _isWebBrowserAvailable;
+
+    public LinuxSessionManager(IEnvironment env, IFileSystem fs) : base(env, fs)
+    {
+        PlatformUtils.EnsureLinux();
+    }
+    
+    public override bool IsWebBrowserAvailable
+    {
+        get
+        {
+            return _isWebBrowserAvailable ??= GetWebBrowserAvailable();
+        }
+    }
+    
+    private bool GetWebBrowserAvailable()
+    {
+        // If this is a Windows Subsystem for Linux distribution we may
+        // be able to launch the web browser of the host Windows OS.
+        if (WslUtils.IsWslDistribution(Environment, FileSystem, out _))
+        {
+            // We need a shell execute handler to be able to launch to browser
+            if (!BrowserUtils.TryGetLinuxShellExecuteHandler(Environment, out _))
+            {
+                return false;
+            }
+
+            //
+            // If we are in Windows logon session 0 then the user can never interact,
+            // even in the WinSta0 window station. This is typical when SSH-ing into a
+            // Windows 10+ machine using the default OpenSSH Server configuration,
+            // which runs in the 'services' session 0.
+            //
+            // If we're in any other session, and in the WinSta0 window station then
+            // the user can possibly interact. However, since it's hard to determine
+            // the window station from PowerShell cmdlets (we'd need to write P/Invoke
+            // code and that's just messy and too many levels of indirection quite
+            // frankly!) we just assume any non session 0 is interactive.
+            //
+            // This assumption doesn't hold true if the user has changed the user that
+            // the OpenSSH Server service runs as (not a built-in NT service) *AND*
+            // they've SSH-ed into the Windows host (and then started a WSL shell).
+            // This feels like a very small subset of users...
+            //
+            if (WslUtils.GetWindowsSessionId(FileSystem) == 0)
+            {
+                return false;
+            }
+
+            // If we are not in session 0, or we cannot get the Windows session ID,
+            // assume that we *CAN* launch the browser so that users are never blocked.
+            return true;
+        }
+
+        // We require an interactive desktop session to be able to launch a browser
+        return IsDesktopSession;
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Linux/LinuxTerminal.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Linux/LinuxTerminal.cs
@@ -1,0 +1,76 @@
+using System;
+using GitCredentialManager.Interop.Linux.Native;
+using GitCredentialManager.Interop.Posix;
+using GitCredentialManager.Interop.Posix.Native;
+
+namespace GitCredentialManager.Interop.Linux
+{
+    public class LinuxTerminal : PosixTerminal
+    {
+        public LinuxTerminal(ITrace trace, ITrace2 trace2)
+            : base(trace, trace2) { }
+
+        protected override IDisposable CreateTtyContext(int fd, bool echo)
+        {
+            return new TtyContext(Trace, Trace2, fd, echo);
+        }
+
+        private class TtyContext : IDisposable
+        {
+            private readonly ITrace _trace;
+            private readonly int _fd;
+
+            private termios_Linux _originalTerm;
+            private bool _isDisposed;
+
+            public TtyContext(ITrace trace, ITrace2 trace2, int fd, bool echo)
+            {
+                EnsureArgument.NotNull(trace, nameof(trace));
+                EnsureArgument.PositiveOrZero(fd, nameof(fd));
+
+                _trace = trace;
+                _fd = fd;
+
+                int error = 0;
+
+                // Capture current terminal settings so we can restore them later
+                if ((error = Termios_Linux.tcgetattr(_fd, out termios_Linux t)) != 0)
+                {
+                    throw new Trace2InteropException(trace2, "Failed to get initial terminal settings", error);
+                }
+
+                _originalTerm = t;
+
+                // Set desired echo state
+                _trace.WriteLine($"Setting terminal echo state to '{echo}'");
+                if (echo)
+                    t.c_lflag |= LocalFlags.ECHO;
+                else
+                    t.c_lflag &= ~LocalFlags.ECHO;
+
+                if ((error = Termios_Linux.tcsetattr(_fd, SetActionFlags.TCSAFLUSH, ref t)) != 0)
+                {
+                    throw new Trace2InteropException(trace2, "Failed to set terminal settings", error);
+                }
+            }
+
+            public void Dispose()
+            {
+                if (_isDisposed)
+                {
+                    return;
+                }
+
+                int error = 0;
+
+                // Restore original terminal settings
+                if ((error = Termios_Linux.tcsetattr(_fd, SetActionFlags.TCSAFLUSH, ref _originalTerm)) != 0)
+                {
+                    _trace.WriteLine($"Failed to get restore terminal settings (error: {error:x}");
+                }
+
+                _isDisposed = true;
+            }
+        }
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Linux/Native/Glib.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Linux/Native/Glib.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace GitCredentialManager.Interop.Linux.Native
+{
+    public static class Glib
+    {
+        private const string LibraryName = "libglib-2.0.so.0";
+
+        public struct GHashTable { /* transparent */ }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct GList
+        {
+            public IntPtr data;
+            public IntPtr next;
+            public IntPtr prev;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct GError
+        {
+            public int domain;
+            public int code;
+            public IntPtr message;
+        }
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate uint GHashFunc(IntPtr key);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate bool GEqualFunc(IntPtr a, IntPtr b);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate void GDestroyNotify(IntPtr data);
+
+        [DllImport(LibraryName, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern uint g_str_hash(IntPtr key);
+
+        [DllImport(LibraryName, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern bool g_str_equal(IntPtr a, IntPtr b);
+
+        [DllImport(LibraryName, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe GHashTable* g_hash_table_new(GHashFunc hash_func, GEqualFunc key_equal_func);
+
+        [DllImport(LibraryName, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe GHashTable* g_hash_table_new_full(
+            GHashFunc hash_func,
+            GEqualFunc key_equal_func,
+            GDestroyNotify key_destroy_func,
+            GDestroyNotify value_destroy_func);
+
+        [DllImport(LibraryName, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe void g_hash_table_destroy(GHashTable* hash_table);
+
+        [DllImport(LibraryName, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe bool g_hash_table_insert(GHashTable* hash_table, IntPtr key, IntPtr value);
+
+        [DllImport(LibraryName, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe IntPtr g_hash_table_lookup(GHashTable* hash_table, IntPtr key);
+
+        [DllImport(LibraryName, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe void g_list_free_full(GList* list, GDestroyNotify free_func);
+
+        [DllImport(LibraryName, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe void g_hash_table_unref(GHashTable* hash_table);
+
+        [DllImport(LibraryName, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe void g_error_free(GError* error);
+
+        [DllImport(LibraryName, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void g_free(IntPtr mem);
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Linux/Native/Gobject.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Linux/Native/Gobject.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace GitCredentialManager.Interop.Linux.Native
+{
+    public static class Gobject
+    {
+        private const string LibraryName = "libgobject-2.0.so.0";
+
+        [DllImport(LibraryName, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void g_object_ref(IntPtr @object);
+
+        [DllImport(LibraryName, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void g_object_unref(IntPtr @object);
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Linux/Native/Libsecret.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Linux/Native/Libsecret.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace GitCredentialManager.Interop.Linux.Native
+{
+    public static class Libsecret
+    {
+        private const string LibraryName = "libsecret-1.so.0";
+
+        public enum SecretSchemaAttributeType
+        {
+            SECRET_SCHEMA_ATTRIBUTE_STRING = 0,
+            SECRET_SCHEMA_ATTRIBUTE_INTEGER = 1,
+            SECRET_SCHEMA_ATTRIBUTE_BOOLEAN = 2,
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SecretSchemaAttribute
+        {
+            public string name;
+            public SecretSchemaAttributeType type;
+        }
+
+        [Flags]
+        public enum SecretSchemaFlags
+        {
+            SECRET_SCHEMA_NONE = 0,
+            SECRET_SCHEMA_DONT_MATCH_NAME = 1 << 1,
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SecretSchema
+        {
+            public string name;
+            public SecretSchemaFlags flags;
+
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
+            public SecretSchemaAttribute[] attributes;
+
+            int reserved;
+            IntPtr reserved1;
+            IntPtr reserved2;
+            IntPtr reserved3;
+            IntPtr reserved4;
+            IntPtr reserved5;
+            IntPtr reserved6;
+            IntPtr reserved7;
+        }
+        public struct SecretService { /* transparent */ }
+
+        [Flags]
+        public enum SecretServiceFlags
+        {
+            SECRET_SERVICE_NONE             = 0,
+            SECRET_SERVICE_OPEN_SESSION     = 1 << 1,
+            SECRET_SERVICE_LOAD_COLLECTIONS = 1 << 2,
+        }
+
+        [Flags]
+        public enum SecretSearchFlags
+        {
+            SECRET_SEARCH_NONE         = 0,
+            SECRET_SEARCH_ALL          = 1 << 1,
+            SECRET_SEARCH_UNLOCK       = 1 << 2,
+            SECRET_SEARCH_LOAD_SECRETS = 1 << 3,
+        }
+
+        public struct SecretItem { /* transparent */ }
+
+        public struct SecretValue { /* transparent */ }
+
+        [DllImport(LibraryName, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe SecretService* secret_service_get_sync(
+            SecretServiceFlags flags,
+            IntPtr cancellable,
+            out Glib.GError* error);
+
+        [DllImport(LibraryName, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe Glib.GList* secret_service_search_sync(
+            SecretService* service,
+            ref SecretSchema schema,
+            Glib.GHashTable* attributes,
+            SecretSearchFlags flags,
+            IntPtr cancellable,
+            out Glib.GError* error);
+
+        [DllImport(LibraryName, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe bool secret_service_store_sync(
+            SecretService* service,
+            ref SecretSchema schema,
+            Glib.GHashTable *attributes,
+            string collection,
+            string label,
+            SecretValue *value,
+            IntPtr cancellable,
+            out Glib.GError* error);
+
+        [DllImport(LibraryName, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe bool secret_service_clear_sync(
+            SecretService* service,
+            ref SecretSchema schema,
+            Glib.GHashTable *attributes,
+            IntPtr cancellable,
+            out Glib.GError* error);
+
+        [DllImport(LibraryName, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern string secret_item_get_label(IntPtr self);
+
+        [DllImport(LibraryName, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe Glib.GHashTable* secret_item_get_attributes(SecretItem* item);
+
+        [DllImport(LibraryName, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe void secret_item_load_secret_sync(
+            SecretItem* self,
+            IntPtr cancellable,
+            out Glib.GError* error);
+
+        [DllImport(LibraryName, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe int secret_service_unlock_sync(SecretService* service,
+            Glib.GList* objects,
+            IntPtr cancellable,
+            out Glib.GList* unlocked,
+            out Glib.GError* error);
+
+        [DllImport(LibraryName, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe bool secret_item_get_locked(SecretItem *self);
+
+        [DllImport(LibraryName, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe SecretValue* secret_item_get_secret(SecretItem* item);
+
+        [DllImport(LibraryName, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe SecretValue* secret_value_new(
+            byte[] secret,
+            int length,
+            string content_type);
+
+        [DllImport(LibraryName, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe IntPtr secret_value_get(SecretValue* value, out int length);
+
+        [DllImport(LibraryName, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe void secret_value_unref(SecretValue* value);
+
+        [DllImport(LibraryName, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe IntPtr secret_value_unref_to_password(SecretValue *value, out int length);
+
+        [DllImport(LibraryName, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void secret_password_free(IntPtr password);
+
+        [DllImport(LibraryName, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe bool secret_item_delete_sync(SecretItem* self, IntPtr cancellable, out Glib.GError* error);
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Linux/Native/termios_Linux.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Linux/Native/termios_Linux.cs
@@ -1,0 +1,33 @@
+using System.Runtime.InteropServices;
+using GitCredentialManager.Interop.Posix.Native;
+
+namespace GitCredentialManager.Interop.Linux.Native
+{
+    public static class Termios_Linux
+    {
+        [DllImport("libc", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        public static extern int tcgetattr(int fd, out termios_Linux termios);
+
+        [DllImport("libc", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        public static extern int tcsetattr(int fd, SetActionFlags optActions, ref termios_Linux termios);
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    public struct termios_Linux
+    {
+        // Linux has an array of 32 elements
+        private const int NCCS = 32;
+
+        // Linux uses unsigned 32-bit sized flags
+        [FieldOffset(0)]  public InputFlags   c_iflag;
+        [FieldOffset(4)]  public OutputFlags  c_oflag;
+        [FieldOffset(8)]  public ControlFlags c_cflag;
+        [FieldOffset(12)] public LocalFlags   c_lflag;
+
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = NCCS)]
+        [FieldOffset(16)] public byte[] c_cc;
+
+        [FieldOffset(16 + NCCS)]     public uint c_ispeed;
+        [FieldOffset(16 + NCCS + 4)] public uint c_ospeed;
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Linux/SecretServiceCollection.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Linux/SecretServiceCollection.cs
@@ -1,0 +1,370 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using static GitCredentialManager.Interop.Linux.Native.Gobject;
+using static GitCredentialManager.Interop.Linux.Native.Glib;
+using static GitCredentialManager.Interop.Linux.Native.Libsecret;
+using static GitCredentialManager.Interop.Linux.Native.Libsecret.SecretSchemaAttributeType;
+using static GitCredentialManager.Interop.Linux.Native.Libsecret.SecretSchemaFlags;
+
+namespace GitCredentialManager.Interop.Linux
+{
+    public class SecretServiceCollection : ICredentialStore
+    {
+        private const string SchemaName = "com.microsoft.GitCredentialManager";
+        private const string ServiceAttributeName = "service";
+        private const string AccountAttributeName = "account";
+        private const string PlainTextContentType = "plain/text";
+
+        private readonly string _namespace;
+
+        #region Constructors
+
+        /// <summary>
+        /// Open the default secret collection for the current user.
+        /// </summary>
+        /// <param name="namespace">Optional namespace to scope credential operations.</param>
+        /// <returns>Default secret collection.</returns>
+        public SecretServiceCollection(string @namespace)
+        {
+            PlatformUtils.EnsureLinux();
+            _namespace = @namespace;
+        }
+
+        #endregion
+
+        #region ICredentialStore
+
+        public IList<string> GetAccounts(string service)
+        {
+            return Enumerate(service, null).Select(x => x.Account).Distinct().ToList();
+        }
+
+        public ICredential Get(string service, string account)
+        {
+            return Enumerate(service, account).FirstOrDefault();
+        }
+
+        private unsafe IEnumerable<ICredential> Enumerate(string service, string account)
+        {
+            GHashTable* queryAttrs = null;
+            GList* results = null;
+            GError* error = null;
+
+            try
+            {
+                SecretService* secService = GetSecretService();
+
+                queryAttrs = CreateSearchQuery(service, account);
+
+                SecretSchema schema = GetSchema();
+
+                // Execute search query and return all results
+                results = secret_service_search_sync(
+                    secService,
+                    ref schema,
+                    queryAttrs,
+                    SecretSearchFlags.SECRET_SEARCH_UNLOCK,
+                    IntPtr.Zero,
+                    out error);
+
+                if (error != null)
+                {
+                    int code = error->code;
+                    string message = Marshal.PtrToStringAuto(error->message)!;
+                    throw new InteropException("Failed to search for credentials", code, new Exception(message));
+                }
+
+                var credentials = new List<ICredential>();
+
+                GList* itemPtr = results;
+                while (itemPtr != null && itemPtr->data != IntPtr.Zero)
+                {
+                    SecretItem* item = (SecretItem*) itemPtr->data;
+
+                    // Although we've unlocked the collection during the search call,
+                    // an item can also be individually locked within a collection.
+                    // If the item is locked we should try and unlock it.
+                    if (secret_item_get_locked(item))
+                    {
+                        var toUnlockList = new GList
+                        {
+                            data = (IntPtr) item,
+                            next = IntPtr.Zero,
+                            prev = IntPtr.Zero
+                        };
+
+                        int numUnlocked = secret_service_unlock_sync(
+                            secService,
+                            &toUnlockList,
+                            IntPtr.Zero,
+                            out _,
+                            out error
+                        );
+
+                        if (numUnlocked != 1)
+                        {
+                            throw new InteropException("Failed to unlock item", numUnlocked);
+                        }
+                    }
+
+                    credentials.Add(CreateCredentialFromItem(item));
+
+                    itemPtr = (GList*)itemPtr->next;
+                }
+
+                return credentials;
+            }
+            finally
+            {
+                if (queryAttrs != null) g_hash_table_destroy(queryAttrs);
+                if (error != null) g_error_free(error);
+                if (results != null) g_list_free_full(results, g_object_unref);
+            }
+        }
+
+        public unsafe void AddOrUpdate(string service, string account, string secret)
+        {
+            GHashTable* attributes = null;
+            SecretValue* secretValue = null;
+            GError *error = null;
+
+            // If there is an existing credential that matches the same account and password
+            // then don't bother writing out anything because they're the same!
+            ICredential existingCred = Get(service, account);
+            if (existingCred != null &&
+                StringComparer.Ordinal.Equals(existingCred.Account, account) &&
+                StringComparer.Ordinal.Equals(existingCred.Password, secret))
+            {
+                return;
+            }
+
+            try
+            {
+                SecretService* secService = GetSecretService();
+
+                // Create attributes for the key and user
+                attributes = g_hash_table_new_full(g_str_hash, g_str_equal,
+                    Marshal.FreeHGlobal, Marshal.FreeHGlobal);
+
+                string fullServiceName = CreateServiceName(service);
+                IntPtr serviceKeyPtr = Marshal.StringToHGlobalAnsi(ServiceAttributeName);
+                IntPtr serviceValuePtr = Marshal.StringToHGlobalAnsi(fullServiceName);
+                g_hash_table_insert(attributes, serviceKeyPtr, serviceValuePtr);
+
+                if (!string.IsNullOrWhiteSpace(account))
+                {
+                    IntPtr accountKeyPtr = Marshal.StringToHGlobalAnsi(AccountAttributeName);
+                    IntPtr accountValuePtr = Marshal.StringToHGlobalAnsi(account);
+                    g_hash_table_insert(attributes, accountKeyPtr, accountValuePtr);
+                }
+
+                // Create the secret value object from the secret string
+                byte[] secretBytes = Encoding.UTF8.GetBytes(secret);
+                secretValue = secret_value_new(secretBytes, secretBytes.Length, PlainTextContentType);
+
+                SecretSchema schema = GetSchema();
+
+                // Store the secret with the associated attributes
+                bool result = secret_service_store_sync(
+                    secService,
+                    ref schema,
+                    attributes,
+                    null,
+                    fullServiceName, // Use full service name as label
+                    secretValue,
+                    IntPtr.Zero,
+                    out error);
+
+                if (error != null)
+                {
+                    int code = error->code;
+                    string message = Marshal.PtrToStringAuto(error->message)!;
+                    throw new InteropException("Failed to store credentials", code, new Exception(message));
+                }
+
+                if (!result)
+                {
+                    throw new InteropException("Failed to store credentials", -1);
+                }
+            }
+            finally
+            {
+                if (attributes != null) g_hash_table_destroy(attributes);
+                if (secretValue != null) secret_value_unref(secretValue);
+                if (error != null) g_error_free(error);
+            }
+        }
+
+        public unsafe bool Remove(string service, string account)
+        {
+            GHashTable* attributes = null;
+            GError* error = null;
+
+            try
+            {
+                SecretService* secService = GetSecretService();
+
+                // Create search query
+                attributes = CreateSearchQuery(service, account);
+
+                SecretSchema schema = GetSchema();
+
+                // Erase the secret with the specified key
+                bool result = secret_service_clear_sync(
+                    secService,
+                    ref schema,
+                    attributes,
+                    IntPtr.Zero,
+                    out error);
+
+                if (error != null)
+                {
+                    int code = error->code;
+                    string message = Marshal.PtrToStringAuto(error->message)!;
+                    throw new InteropException("Failed to erase credentials", code, new Exception(message));
+                }
+
+                return result;
+            }
+            finally
+            {
+                if (attributes != null) g_hash_table_destroy(attributes);
+                if (error != null) g_error_free(error);
+            }
+        }
+
+        #endregion
+
+        private unsafe GHashTable* CreateSearchQuery(string service, string account)
+        {
+            // Build search query
+            GHashTable* queryAttrs = g_hash_table_new_full(
+                g_str_hash, g_str_equal,
+                Marshal.FreeHGlobal, Marshal.FreeHGlobal);
+
+            // If we've be given a service then filter on the service attribute
+            if (!string.IsNullOrWhiteSpace(service))
+            {
+                string fullServiceName = CreateServiceName(service);
+                IntPtr keyPtr = Marshal.StringToHGlobalAnsi(ServiceAttributeName);
+                IntPtr valuePtr = Marshal.StringToHGlobalAnsi(fullServiceName);
+                g_hash_table_insert(queryAttrs, keyPtr, valuePtr);
+            }
+
+            // If we've be given a username then filter on the account attribute
+            if (!string.IsNullOrWhiteSpace(account))
+            {
+                IntPtr keyPtr = Marshal.StringToHGlobalAnsi(AccountAttributeName);
+                IntPtr valuePtr = Marshal.StringToHGlobalAnsi(account);
+                g_hash_table_insert(queryAttrs, keyPtr, valuePtr);
+            }
+
+            return queryAttrs;
+        }
+
+        private static unsafe ICredential CreateCredentialFromItem(SecretItem* item)
+        {
+            GHashTable* secretAttrs = null;
+            IntPtr serviceKeyPtr = IntPtr.Zero;
+            IntPtr accountKeyPtr = IntPtr.Zero;
+            SecretValue* value = null;
+            IntPtr passwordPtr = IntPtr.Zero;
+            GError* error = null;
+
+            try
+            {
+                secretAttrs = secret_item_get_attributes(item);
+
+                // Extract the service attribute
+                serviceKeyPtr = Marshal.StringToHGlobalAnsi(ServiceAttributeName);
+                IntPtr serviceValuePtr = g_hash_table_lookup(secretAttrs, serviceKeyPtr);
+                string service = Marshal.PtrToStringAuto(serviceValuePtr);
+
+                // Extract the account attribute
+                accountKeyPtr = Marshal.StringToHGlobalAnsi(AccountAttributeName);
+                IntPtr accountValuePtr = g_hash_table_lookup(secretAttrs, accountKeyPtr);
+                string account = Marshal.PtrToStringAuto(accountValuePtr);
+
+                // Load the secret value
+                secret_item_load_secret_sync(item, IntPtr.Zero, out error);
+                value = secret_item_get_secret(item);
+                if (value == null)
+                {
+                    throw new InteropException("Failed to load secret", -1);
+                }
+
+                // Extract the secret/password
+                passwordPtr = secret_value_get(value, out int passwordLength);
+                string password = Marshal.PtrToStringAuto(passwordPtr, passwordLength);
+
+                return new SecretServiceCredential(service, account, password);
+            }
+            finally
+            {
+                if (secretAttrs != null) g_hash_table_unref(secretAttrs);
+                if (accountKeyPtr != IntPtr.Zero) Marshal.FreeHGlobal(accountKeyPtr);
+                if (serviceKeyPtr != IntPtr.Zero) Marshal.FreeHGlobal(serviceKeyPtr);
+                if (value != null) secret_value_unref(value);
+                if (error != null) g_error_free(error);
+            }
+        }
+
+        private string CreateServiceName(string service)
+        {
+            var sb = new StringBuilder();
+            if (!string.IsNullOrWhiteSpace(_namespace))
+            {
+                sb.AppendFormat("{0}:", _namespace);
+            }
+
+            sb.Append(service);
+            return sb.ToString();
+        }
+
+        private static unsafe SecretService* GetSecretService()
+        {
+            // Get a handle to the default secret service, open a session,
+            // and load all collections
+            SecretService* service = secret_service_get_sync(
+                SecretServiceFlags.SECRET_SERVICE_OPEN_SESSION | SecretServiceFlags.SECRET_SERVICE_LOAD_COLLECTIONS,
+                IntPtr.Zero, out GError* error);
+
+            if (error != null)
+            {
+                int code = error->code;
+                string message = Marshal.PtrToStringAuto(error->message)!;
+                g_error_free(error);
+                throw new InteropException("Failed to open secret service session", code, new Exception(message));
+            }
+
+            return service;
+        }
+
+        private static SecretSchema GetSchema()
+        {
+            var schema = new SecretSchema
+            {
+                name = SchemaName,
+                flags = SECRET_SCHEMA_DONT_MATCH_NAME,
+                attributes = new SecretSchemaAttribute[32]
+            };
+
+            schema.attributes[0] = new SecretSchemaAttribute
+            {
+                name = ServiceAttributeName,
+                type = SECRET_SCHEMA_ATTRIBUTE_STRING
+            };
+
+            schema.attributes[1] = new SecretSchemaAttribute
+            {
+                name = AccountAttributeName,
+                type = SECRET_SCHEMA_ATTRIBUTE_STRING
+            };
+
+            return schema;
+        }
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Linux/SecretServiceCredential.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Linux/SecretServiceCredential.cs
@@ -1,0 +1,23 @@
+using System.Diagnostics;
+
+namespace GitCredentialManager.Interop.Linux
+{
+    [DebuggerDisplay("{DebuggerDisplay}")]
+    public class SecretServiceCredential : ICredential
+    {
+        internal SecretServiceCredential(string service, string account, string password)
+        {
+            Service = service;
+            Account = account;
+            Password = password;
+        }
+
+        public string Service { get; }
+
+        public string Account { get; }
+
+        public string Password { get; }
+
+        private string DebuggerDisplay => $"[Service: {Service}, Account: {Account}]";
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/MacOS/MacOSEnvironment.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/MacOS/MacOSEnvironment.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using GitCredentialManager.Interop.Posix;
+
+namespace GitCredentialManager.Interop.MacOS
+{
+    public class MacOSEnvironment : PosixEnvironment
+    {
+        private ICollection<string> _pathsToIgnore;
+
+        public MacOSEnvironment(IFileSystem fileSystem)
+            : base(fileSystem) { }
+
+        internal MacOSEnvironment(IFileSystem fileSystem, IReadOnlyDictionary<string, string> variables)
+            : base(fileSystem, variables) { }
+
+        public override bool TryLocateExecutable(string program, out string path)
+        {
+            if (_pathsToIgnore is null)
+            {
+                _pathsToIgnore = new List<string>();
+                if (Variables.TryGetValue("HOMEBREW_PREFIX", out string homebrewPrefix))
+                {
+                    string homebrewGit = Path.Combine(homebrewPrefix, "Homebrew/Library/Homebrew/shims/shared/git");
+                    _pathsToIgnore.Add(homebrewGit);
+                }
+            }
+            return TryLocateExecutable(program, _pathsToIgnore, out path);
+        }
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/MacOS/MacOSFileSystem.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/MacOS/MacOSFileSystem.cs
@@ -1,0 +1,29 @@
+using System;
+using System.IO;
+using GitCredentialManager.Interop.Posix;
+
+namespace GitCredentialManager.Interop.MacOS
+{
+    public class MacOSFileSystem : PosixFileSystem
+    {
+        public override bool IsSamePath(string a, string b)
+        {
+            if (string.IsNullOrWhiteSpace(a) || string.IsNullOrWhiteSpace(b))
+            {
+                return false;
+            }
+
+            // Normalize paths
+            a = Path.GetFullPath(a);
+            b = Path.GetFullPath(b);
+
+            // Resolve symbolic links
+            a = ResolveSymbolicLinks(a);
+            b = ResolveSymbolicLinks(b);
+
+            // TODO: determine if file system is case-sensitive
+            // By default HFS+/APFS is NOT case-sensitive...
+            return StringComparer.OrdinalIgnoreCase.Equals(a, b);
+        }
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/MacOS/MacOSKeychain.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/MacOS/MacOSKeychain.cs
@@ -1,0 +1,352 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using GitCredentialManager.Interop.MacOS.Native;
+using static GitCredentialManager.Interop.MacOS.Native.CoreFoundation;
+using static GitCredentialManager.Interop.MacOS.Native.SecurityFramework;
+
+namespace GitCredentialManager.Interop.MacOS
+{
+    public class MacOSKeychain : ICredentialStore
+    {
+        private readonly string _namespace;
+
+        #region Constructors
+
+        /// <summary>
+        /// Open the default keychain (current user's login keychain).
+        /// </summary>
+        /// <param name="namespace">Optional namespace to scope credential operations.</param>
+        /// <returns>Default keychain.</returns>
+        public MacOSKeychain(string @namespace = null)
+        {
+            PlatformUtils.EnsureMacOS();
+            _namespace = @namespace;
+        }
+
+        #endregion
+
+        #region ICredentialStore
+
+        public IList<string> GetAccounts(string service)
+        {
+            IntPtr query = IntPtr.Zero;
+            IntPtr resultPtr = IntPtr.Zero;
+            IntPtr servicePtr = IntPtr.Zero;
+            IntPtr accountPtr = IntPtr.Zero;
+
+            try
+            {
+                query = CFDictionaryCreateMutable(
+                    IntPtr.Zero,
+                    0,
+                    IntPtr.Zero, IntPtr.Zero);
+
+                CFDictionaryAddValue(query, kSecClass, kSecClassGenericPassword);
+                CFDictionaryAddValue(query, kSecMatchLimit, kSecMatchLimitAll);
+                CFDictionaryAddValue(query, kSecReturnAttributes, kCFBooleanTrue);
+
+                if (!string.IsNullOrWhiteSpace(service))
+                {
+                    string fullService = CreateServiceName(service);
+                    servicePtr = CreateCFStringUtf8(fullService);
+                    CFDictionaryAddValue(query, kSecAttrService, servicePtr);
+                }
+
+                int searchResult = SecItemCopyMatching(query, out resultPtr);
+
+                switch (searchResult)
+                {
+                    case OK:
+                        int typeId = CFGetTypeID(resultPtr);
+                        Debug.Assert(typeId == CFArrayGetTypeID(), "Returned unknown item from account query");
+                        if (typeId == CFArrayGetTypeID())
+                        {
+                            int len = (int)CFArrayGetCount(resultPtr);
+                            var accounts = new HashSet<string>();
+                            for (int i = 0; i < len; i++)
+                            {
+                                IntPtr dict = CFArrayGetValueAtIndex(resultPtr, i);
+                                string account = GetStringAttribute(dict, kSecAttrAccount);
+                                accounts.Add(account);
+                            }
+
+                            return accounts.ToList();
+                        }
+
+                        throw new InteropException($"Unknown keychain search result type CFTypeID: {typeId}.", -1);
+
+                    case ErrorSecItemNotFound:
+                        return Array.Empty<string>();
+
+                    default:
+                        ThrowIfError(searchResult);
+                        return null;
+                }
+            }
+            finally
+            {
+                if (query != IntPtr.Zero) CFRelease(query);
+                if (servicePtr != IntPtr.Zero) CFRelease(servicePtr);
+                if (accountPtr != IntPtr.Zero) CFRelease(accountPtr);
+                if (resultPtr != IntPtr.Zero) CFRelease(resultPtr);
+            }
+        }
+
+        public ICredential Get(string service, string account)
+        {
+            IntPtr query = IntPtr.Zero;
+            IntPtr resultPtr = IntPtr.Zero;
+            IntPtr servicePtr = IntPtr.Zero;
+            IntPtr accountPtr = IntPtr.Zero;
+
+            try
+            {
+                query = CFDictionaryCreateMutable(
+                    IntPtr.Zero,
+                    0,
+                    IntPtr.Zero, IntPtr.Zero);
+
+                CFDictionaryAddValue(query, kSecClass, kSecClassGenericPassword);
+                CFDictionaryAddValue(query, kSecMatchLimit, kSecMatchLimitOne);
+                CFDictionaryAddValue(query, kSecReturnData, kCFBooleanTrue);
+                CFDictionaryAddValue(query, kSecReturnAttributes, kCFBooleanTrue);
+
+                if (!string.IsNullOrWhiteSpace(service))
+                {
+                    string fullService = CreateServiceName(service);
+                    servicePtr = CreateCFStringUtf8(fullService);
+                    CFDictionaryAddValue(query, kSecAttrService, servicePtr);
+                }
+
+                if (!string.IsNullOrWhiteSpace(account))
+                {
+                    accountPtr = CreateCFStringUtf8(account);
+                    CFDictionaryAddValue(query, kSecAttrAccount, accountPtr);
+                }
+
+                int searchResult = SecItemCopyMatching(query, out resultPtr);
+
+                switch (searchResult)
+                {
+                    case OK:
+                        int typeId = CFGetTypeID(resultPtr);
+                        Debug.Assert(typeId != CFArrayGetTypeID(), "Returned more than one keychain item in search");
+                        if (typeId == CFDictionaryGetTypeID())
+                        {
+                            return CreateCredentialFromAttributes(resultPtr);
+                        }
+
+                        throw new InteropException($"Unknown keychain search result type CFTypeID: {typeId}.", -1);
+
+                    case ErrorSecItemNotFound:
+                        return null;
+
+                    default:
+                        ThrowIfError(searchResult);
+                        return null;
+                }
+            }
+            finally
+            {
+                if (query != IntPtr.Zero) CFRelease(query);
+                if (servicePtr != IntPtr.Zero) CFRelease(servicePtr);
+                if (accountPtr != IntPtr.Zero) CFRelease(accountPtr);
+                if (resultPtr != IntPtr.Zero) CFRelease(resultPtr);
+            }
+        }
+
+        public void AddOrUpdate(string service, string account, string secret)
+        {
+            EnsureArgument.NotNullOrWhiteSpace(service, nameof(service));
+
+            byte[] secretBytes = Encoding.UTF8.GetBytes(secret);
+
+            IntPtr passwordData = IntPtr.Zero;
+            IntPtr itemRef = IntPtr.Zero;
+
+            string serviceName = CreateServiceName(service);
+
+            uint serviceNameLength = (uint) serviceName.Length;
+            uint accountLength = (uint) (account?.Length ?? 0);
+
+            try
+            {
+                // Check if an entry already exists in the keychain
+                int findResult = SecKeychainFindGenericPassword(
+                    IntPtr.Zero, serviceNameLength, serviceName, accountLength, account,
+                    out uint passwordDataLength, out passwordData, out itemRef);
+
+                switch (findResult)
+                {
+                    // Update existing entry only if the password/secret is different
+                    case OK when !InteropUtils.AreEqual(secretBytes, passwordData, passwordDataLength):
+                        ThrowIfError(
+                            SecKeychainItemModifyAttributesAndData(itemRef, IntPtr.Zero, (uint) secretBytes.Length, secretBytes),
+                            "Could not update existing item"
+                        );
+                        break;
+
+                    // Create new entry
+                    case ErrorSecItemNotFound:
+                        ThrowIfError(
+                            SecKeychainAddGenericPassword(IntPtr.Zero, serviceNameLength, serviceName, accountLength,
+                                account, (uint) secretBytes.Length, secretBytes, out itemRef),
+                            "Could not create new item"
+                        );
+                        break;
+
+                    default:
+                        ThrowIfError(findResult);
+                        break;
+                }
+            }
+            finally
+            {
+                if (passwordData != IntPtr.Zero)
+                {
+                    SecKeychainItemFreeContent(IntPtr.Zero, passwordData);
+                }
+
+                if (itemRef != IntPtr.Zero)
+                {
+                    CFRelease(itemRef);
+                }
+            }
+        }
+
+        public bool Remove(string service, string account)
+        {
+            IntPtr query = IntPtr.Zero;
+            IntPtr itemRefPtr = IntPtr.Zero;
+            IntPtr servicePtr = IntPtr.Zero;
+            IntPtr accountPtr = IntPtr.Zero;
+
+            try
+            {
+                query = CFDictionaryCreateMutable(
+                    IntPtr.Zero,
+                    0,
+                    IntPtr.Zero, IntPtr.Zero);
+
+                CFDictionaryAddValue(query, kSecClass, kSecClassGenericPassword);
+                CFDictionaryAddValue(query, kSecMatchLimit, kSecMatchLimitOne);
+                CFDictionaryAddValue(query, kSecReturnRef, kCFBooleanTrue);
+
+                if (!string.IsNullOrWhiteSpace(service))
+                {
+                    string fullService = CreateServiceName(service);
+                    servicePtr = CreateCFStringUtf8(fullService);
+                    CFDictionaryAddValue(query, kSecAttrService, servicePtr);
+                }
+
+                if (!string.IsNullOrWhiteSpace(account))
+                {
+                    accountPtr = CreateCFStringUtf8(account);
+                    CFDictionaryAddValue(query, kSecAttrAccount, accountPtr);
+                }
+
+                // Search for the credential to delete and get the SecKeychainItem ref.
+                int searchResult = SecItemCopyMatching(query, out itemRefPtr);
+                switch (searchResult)
+                {
+                    case OK:
+                        // Delete the item
+                        ThrowIfError(
+                            SecKeychainItemDelete(itemRefPtr)
+                        );
+                        return true;
+
+                    case ErrorSecItemNotFound:
+                        return false;
+
+                    default:
+                        ThrowIfError(searchResult);
+                        return false;
+                }
+            }
+            finally
+            {
+                if (query != IntPtr.Zero) CFRelease(query);
+                if (itemRefPtr != IntPtr.Zero) CFRelease(itemRefPtr);
+                if (servicePtr != IntPtr.Zero) CFRelease(servicePtr);
+                if (accountPtr != IntPtr.Zero) CFRelease(accountPtr);
+            }
+        }
+
+        #endregion
+
+        private static IntPtr CreateCFStringUtf8(string str)
+        {
+            byte[] bytes = Encoding.UTF8.GetBytes(str);
+            return CFStringCreateWithBytes(IntPtr.Zero,
+                bytes, bytes.Length, CFStringEncoding.kCFStringEncodingUTF8, false);
+        }
+
+        private static ICredential CreateCredentialFromAttributes(IntPtr attributes)
+        {
+            string service = GetStringAttribute(attributes, kSecAttrService);
+            string account = GetStringAttribute(attributes, kSecAttrAccount);
+            string password = GetStringAttribute(attributes, kSecValueData);
+            string label = GetStringAttribute(attributes, kSecAttrLabel);
+            return new MacOSKeychainCredential(service, account, password, label);
+        }
+
+        private static string GetStringAttribute(IntPtr dict, IntPtr key)
+        {
+            if (dict == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            IntPtr buffer = IntPtr.Zero;
+            try
+            {
+                if (CFDictionaryGetValueIfPresent(dict, key, out IntPtr value) && value != IntPtr.Zero)
+                {
+                    if (CFGetTypeID(value) == CFStringGetTypeID())
+                    {
+                        int stringLength = (int)CFStringGetLength(value);
+                        int bufferSize = stringLength + 1;
+                        buffer = Marshal.AllocHGlobal(bufferSize);
+                        if (CFStringGetCString(value, buffer, bufferSize, CFStringEncoding.kCFStringEncodingUTF8))
+                        {
+                            return Marshal.PtrToStringAuto(buffer, stringLength);
+                        }
+                    }
+
+                    if (CFGetTypeID(value) == CFDataGetTypeID())
+                    {
+                        int length = CFDataGetLength(value);
+                        IntPtr ptr = CFDataGetBytePtr(value);
+                        return Marshal.PtrToStringAuto(ptr, length);
+                    }
+                }
+            }
+            finally
+            {
+                if (buffer != IntPtr.Zero)
+                {
+                    Marshal.FreeHGlobal(buffer);
+                }
+            }
+
+            return null;
+        }
+
+        private string CreateServiceName(string service)
+        {
+            var sb = new StringBuilder();
+            if (!string.IsNullOrWhiteSpace(_namespace))
+            {
+                sb.AppendFormat("{0}:", _namespace);
+            }
+
+            sb.Append(service);
+            return sb.ToString();
+        }
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/MacOS/MacOSKeychainCredential.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/MacOS/MacOSKeychainCredential.cs
@@ -1,0 +1,26 @@
+using System.Diagnostics;
+
+namespace GitCredentialManager.Interop.MacOS
+{
+    [DebuggerDisplay("{DebuggerDisplay}")]
+    public class MacOSKeychainCredential : ICredential
+    {
+        internal MacOSKeychainCredential(string service, string account, string password, string label)
+        {
+            Service = service;
+            Account = account;
+            Password = password;
+            Label = label;
+        }
+
+        public string Service  { get; }
+
+        public string Account { get; }
+
+        public string Label { get; }
+
+        public string Password { get; }
+
+        private string DebuggerDisplay => $"{Label} [Service: {Service}, Account: {Account}]";
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/MacOS/MacOSSessionManager.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/MacOS/MacOSSessionManager.cs
@@ -1,0 +1,31 @@
+using GitCredentialManager.Interop.MacOS.Native;
+using GitCredentialManager.Interop.Posix;
+
+namespace GitCredentialManager.Interop.MacOS
+{
+    public class MacOSSessionManager : PosixSessionManager
+    {
+        public MacOSSessionManager(IEnvironment env, IFileSystem fs) : base(env, fs)
+        {
+            PlatformUtils.EnsureMacOS();
+        }
+
+        public override bool IsDesktopSession
+        {
+            get
+            {
+                // Get information about the current session
+                int error = SecurityFramework.SessionGetInfo(SecurityFramework.CallerSecuritySession, out int id, out var sessionFlags);
+
+                // Check if the session supports Quartz
+                if (error == 0 && (sessionFlags & SessionAttributeBits.SessionHasGraphicAccess) != 0)
+                {
+                    return true;
+                }
+
+                // Fall-through and check if X11 is available on macOS
+                return base.IsDesktopSession;
+            }
+        }
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/MacOS/MacOSTerminal.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/MacOS/MacOSTerminal.cs
@@ -1,0 +1,76 @@
+using System;
+using GitCredentialManager.Interop.MacOS.Native;
+using GitCredentialManager.Interop.Posix;
+using GitCredentialManager.Interop.Posix.Native;
+
+namespace GitCredentialManager.Interop.MacOS
+{
+    public class MacOSTerminal : PosixTerminal
+    {
+        public MacOSTerminal(ITrace trace, ITrace2 trace2)
+            : base(trace, trace2) { }
+
+        protected override IDisposable CreateTtyContext(int fd, bool echo)
+        {
+            return new TtyContext(Trace, Trace2, fd, echo);
+        }
+
+        private class TtyContext : IDisposable
+        {
+            private readonly ITrace _trace;
+            private readonly int _fd;
+
+            private termios_MacOS _originalTerm;
+            private bool _isDisposed;
+
+            public TtyContext(ITrace trace, ITrace2 trace2, int fd, bool echo)
+            {
+                EnsureArgument.NotNull(trace, nameof(trace));
+                EnsureArgument.PositiveOrZero(fd, nameof(fd));
+
+                _trace = trace;
+                _fd = fd;
+
+                int error = 0;
+
+                // Capture current terminal settings so we can restore them later
+                if ((error = Termios_MacOS.tcgetattr(_fd, out termios_MacOS t)) != 0)
+                {
+                    throw new Trace2InteropException(trace2, "Failed to get initial terminal settings", error);
+                }
+
+                _originalTerm = t;
+
+                // Set desired echo state
+                _trace.WriteLine($"Setting terminal echo state to '{echo}'");
+                if (echo)
+                    t.c_lflag |= LocalFlags.ECHO;
+                else
+                    t.c_lflag &= ~LocalFlags.ECHO;
+
+                if ((error = Termios_MacOS.tcsetattr(_fd, SetActionFlags.TCSAFLUSH, ref t)) != 0)
+                {
+                    throw new Trace2InteropException(trace2, "Failed to set terminal settings", error);
+                }
+            }
+
+            public void Dispose()
+            {
+                if (_isDisposed)
+                {
+                    return;
+                }
+
+                int error = 0;
+
+                // Restore original terminal settings
+                if ((error = Termios_MacOS.tcsetattr(_fd, SetActionFlags.TCSAFLUSH, ref _originalTerm)) != 0)
+                {
+                    _trace.WriteLine($"Failed to get restore terminal settings (error: {error:x}");
+                }
+
+                _isDisposed = true;
+            }
+        }
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/MacOS/Native/CoreFoundation.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/MacOS/Native/CoreFoundation.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Runtime.InteropServices;
+using static GitCredentialManager.Interop.MacOS.Native.LibSystem;
+
+namespace GitCredentialManager.Interop.MacOS.Native
+{
+    public static class CoreFoundation
+    {
+        private const string CoreFoundationFrameworkLib = "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation";
+
+        public static readonly IntPtr Handle;
+        public static readonly IntPtr kCFBooleanTrue;
+        public static readonly IntPtr kCFBooleanFalse;
+
+        static CoreFoundation()
+        {
+            Handle = dlopen(CoreFoundationFrameworkLib, 0);
+
+            kCFBooleanTrue  = GetGlobal(Handle, "kCFBooleanTrue");
+            kCFBooleanFalse = GetGlobal(Handle, "kCFBooleanFalse");
+        }
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr CFArrayCreateMutable(IntPtr allocator, long capacity, IntPtr callbacks);
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void CFArrayInsertValueAtIndex(IntPtr theArray, long idx, IntPtr value);
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern long CFArrayGetCount(IntPtr theArray);
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr CFArrayGetValueAtIndex(IntPtr theArray, long idx);
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr CFDictionaryCreateMutable(
+            IntPtr allocator,
+            long capacity,
+            IntPtr keyCallBacks,
+            IntPtr valueCallBacks);
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void CFDictionaryAddValue(
+            IntPtr theDict,
+            IntPtr key,
+            IntPtr value);
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr CFDictionaryGetValue(IntPtr theDict, IntPtr key);
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern bool CFDictionaryGetValueIfPresent(IntPtr theDict, IntPtr key, out IntPtr value);
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr CFStringCreateWithBytes(IntPtr alloc, byte[] bytes, long numBytes,
+            CFStringEncoding encoding, bool isExternalRepresentation);
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern long CFStringGetLength(IntPtr theString);
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern bool CFStringGetCString(IntPtr theString, IntPtr buffer, long bufferSize, CFStringEncoding encoding);
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void CFRetain(IntPtr cf);
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void CFRelease(IntPtr cf);
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int CFGetTypeID(IntPtr cf);
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int CFStringGetTypeID();
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int CFDataGetTypeID();
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int CFDictionaryGetTypeID();
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int CFArrayGetTypeID();
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr CFDataGetBytePtr(IntPtr theData);
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int CFDataGetLength(IntPtr theData);
+    }
+
+    public enum CFStringEncoding
+    {
+        kCFStringEncodingUTF8 = 0x08000100,
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/MacOS/Native/LibC.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/MacOS/Native/LibC.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace GitCredentialManager.Interop.MacOS.Native
+{
+    public static class LibC
+    {
+        private const string LibCLib = "libc";
+
+        [DllImport(LibCLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int _NSGetExecutablePath(IntPtr buf, out int bufsize);
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/MacOS/Native/LibSystem.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/MacOS/Native/LibSystem.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace GitCredentialManager.Interop.MacOS.Native
+{
+    public static class LibSystem
+    {
+        private const string LibSystemLib = "/System/Library/Frameworks/System.framework/System";
+
+        [DllImport(LibSystemLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr dlopen(string name, int flags);
+
+        [DllImport(LibSystemLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr dlsym(IntPtr handle, string symbol);
+
+        public static IntPtr GetGlobal(IntPtr handle, string symbol)
+        {
+            IntPtr ptr = dlsym(handle, symbol);
+            return Marshal.PtrToStructure<IntPtr>(ptr);
+        }
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/MacOS/Native/SecurityFramework.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/MacOS/Native/SecurityFramework.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Runtime.InteropServices;
+using static GitCredentialManager.Interop.MacOS.Native.LibSystem;
+
+namespace GitCredentialManager.Interop.MacOS.Native
+{
+    // https://developer.apple.com/documentation/security/keychain_services/keychain_items
+    public static class SecurityFramework
+    {
+        private const string SecurityFrameworkLib = "/System/Library/Frameworks/Security.framework/Security";
+
+        public static readonly IntPtr Handle;
+        public static readonly IntPtr kSecClass;
+        public static readonly IntPtr kSecMatchLimit;
+        public static readonly IntPtr kSecReturnAttributes;
+        public static readonly IntPtr kSecReturnRef;
+        public static readonly IntPtr kSecReturnPersistentRef;
+        public static readonly IntPtr kSecClassGenericPassword;
+        public static readonly IntPtr kSecMatchLimitAll;
+        public static readonly IntPtr kSecMatchLimitOne;
+        public static readonly IntPtr kSecMatchItemList;
+        public static readonly IntPtr kSecAttrLabel;
+        public static readonly IntPtr kSecAttrAccount;
+        public static readonly IntPtr kSecAttrService;
+        public static readonly IntPtr kSecValueRef;
+        public static readonly IntPtr kSecValueData;
+        public static readonly IntPtr kSecReturnData;
+
+        static SecurityFramework()
+        {
+            Handle = dlopen(SecurityFrameworkLib, 0);
+
+            kSecClass                = GetGlobal(Handle, "kSecClass");
+            kSecMatchLimit           = GetGlobal(Handle, "kSecMatchLimit");
+            kSecReturnAttributes     = GetGlobal(Handle, "kSecReturnAttributes");
+            kSecReturnRef            = GetGlobal(Handle, "kSecReturnRef");
+            kSecReturnPersistentRef  = GetGlobal(Handle, "kSecReturnPersistentRef");
+            kSecClassGenericPassword = GetGlobal(Handle, "kSecClassGenericPassword");
+            kSecMatchLimitAll        = GetGlobal(Handle, "kSecMatchLimitAll");
+            kSecMatchLimitOne        = GetGlobal(Handle, "kSecMatchLimitOne");
+            kSecMatchItemList        = GetGlobal(Handle, "kSecMatchItemList");
+            kSecAttrLabel            = GetGlobal(Handle, "kSecAttrLabel");
+            kSecAttrAccount          = GetGlobal(Handle, "kSecAttrAccount");
+            kSecAttrService          = GetGlobal(Handle, "kSecAttrService");
+            kSecValueRef             = GetGlobal(Handle, "kSecValueRef");
+            kSecValueData            = GetGlobal(Handle, "kSecValueData");
+            kSecReturnData           = GetGlobal(Handle, "kSecReturnData");
+        }
+
+        [DllImport(SecurityFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SessionGetInfo(int session, out int sessionId, out SessionAttributeBits attributes);
+
+        [DllImport(SecurityFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SecAccessCreate(IntPtr descriptor, IntPtr trustedList, out IntPtr accessRef);
+
+        [DllImport(SecurityFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SecKeychainItemCreateFromContent(IntPtr itemClass, IntPtr attrList, uint length,
+            IntPtr data, IntPtr keychainRef, IntPtr initialAccess, out IntPtr itemRef);
+
+        [DllImport(SecurityFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SecKeychainAddGenericPassword(
+            IntPtr keychain,
+            uint serviceNameLength,
+            string serviceName,
+            uint accountNameLength,
+            string accountName,
+            uint passwordLength,
+            byte[] passwordData,
+            out IntPtr itemRef);
+
+        [DllImport(SecurityFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SecKeychainFindGenericPassword(
+            IntPtr keychainOrArray,
+            uint serviceNameLength,
+            string serviceName,
+            uint accountNameLength,
+            string accountName,
+            out uint passwordLength,
+            out IntPtr passwordData,
+            out IntPtr itemRef);
+
+        [DllImport(SecurityFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern unsafe int SecKeychainItemCopyAttributesAndData(
+            IntPtr itemRef,
+            IntPtr info,
+            IntPtr itemClass,
+            SecKeychainAttributeList** attrList,
+            uint* dataLength,
+            void** data);
+
+        [DllImport(SecurityFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SecKeychainItemModifyAttributesAndData(
+            IntPtr itemRef,
+            IntPtr attrList, // SecKeychainAttributeList*
+            uint length,
+            byte[] data);
+
+        [DllImport(SecurityFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SecKeychainItemDelete(
+            IntPtr itemRef);
+
+        [DllImport(SecurityFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SecKeychainItemFreeContent(
+            IntPtr attrList, // SecKeychainAttributeList*
+            IntPtr data);
+
+        [DllImport(SecurityFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SecKeychainItemFreeAttributesAndData(
+            IntPtr attrList, // SecKeychainAttributeList*
+            IntPtr data);
+
+        [DllImport(SecurityFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SecItemCopyMatching(IntPtr query, out IntPtr result);
+
+        [DllImport(SecurityFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SecKeychainItemCopyFromPersistentReference(IntPtr persistentItemRef, out IntPtr itemRef);
+
+        [DllImport(SecurityFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SecKeychainItemCopyContent(IntPtr itemRef, IntPtr itemClass, IntPtr attrList,
+            out uint length, out IntPtr outData);
+
+        public const int CallerSecuritySession = -1;
+
+        // https://developer.apple.com/documentation/security/1542001-security_framework_result_codes
+        public const int OK = 0;
+        public const int ErrorSecNoSuchKeychain = -25294;
+        public const int ErrorSecInvalidKeychain = -25295;
+        public const int ErrorSecAuthFailed = -25293;
+        public const int ErrorSecDuplicateItem = -25299;
+        public const int ErrorSecItemNotFound = -25300;
+        public const int ErrorSecInteractionNotAllowed = -25308;
+        public const int ErrorSecInteractionRequired = -25315;
+        public const int ErrorSecNoSuchAttr = -25303;
+
+        public static void ThrowIfError(int error, string defaultErrorMessage = "Unknown error.")
+        {
+            switch (error)
+            {
+                case OK:
+                    return;
+                case ErrorSecNoSuchKeychain:
+                    throw new InteropException("The keychain does not exist.", error);
+                case ErrorSecInvalidKeychain:
+                    throw new InteropException("The keychain is not valid.", error);
+                case ErrorSecAuthFailed:
+                    throw new InteropException("Authorization/Authentication failed.", error);
+                case ErrorSecDuplicateItem:
+                    throw new InteropException("The item already exists.", error);
+                case ErrorSecItemNotFound:
+                    throw new InteropException("The item cannot be found.", error);
+                case ErrorSecInteractionNotAllowed:
+                    throw new InteropException("Interaction with the Security Server is not allowed.", error);
+                case ErrorSecInteractionRequired:
+                    throw new InteropException("User interaction is required.", error);
+                case ErrorSecNoSuchAttr:
+                    throw new InteropException("The attribute does not exist.", error);
+                default:
+                    throw new InteropException(defaultErrorMessage, error);
+            }
+        }
+    }
+
+    [Flags]
+    public enum SessionAttributeBits
+    {
+        SessionIsRoot = 0x0001,
+        SessionHasGraphicAccess = 0x0010,
+        SessionHasTty = 0x0020,
+        SessionIsRemote = 0x1000,
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct SecKeychainAttributeInfo
+    {
+        public uint Count;
+        public IntPtr Tag; // uint* (SecKeychainAttrType*)
+        public IntPtr Format; // uint* (CssmDbAttributeFormat*)
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct SecKeychainAttributeList
+    {
+        public uint Count;
+        public IntPtr Attributes; // SecKeychainAttribute*
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct SecKeychainAttribute
+    {
+        public SecKeychainAttrType Tag;
+        public uint Length;
+        public IntPtr Data;
+    }
+
+    public enum CssmDbAttributeFormat : uint
+    {
+        String = 0,
+        SInt32 = 1,
+        UInt32 = 2,
+        BigNum = 3,
+        Real = 4,
+        TimeDate = 5,
+        Blob = 6,
+        MultiUInt32 = 7,
+        Complex = 8
+    };
+
+    public enum SecKeychainAttrType : uint
+    {
+        // https://developer.apple.com/documentation/security/secitemattr/accountitemattr
+        AccountItem = 1633903476,
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/MacOS/Native/termios_MacOS.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/MacOS/Native/termios_MacOS.cs
@@ -1,0 +1,33 @@
+using System.Runtime.InteropServices;
+using GitCredentialManager.Interop.Posix.Native;
+
+namespace GitCredentialManager.Interop.MacOS.Native
+{
+    public static class Termios_MacOS
+    {
+        [DllImport("libc", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        public static extern int tcgetattr(int fd, out termios_MacOS termios);
+
+        [DllImport("libc", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        public static extern int tcsetattr(int fd, SetActionFlags optActions, ref termios_MacOS termios);
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    public struct termios_MacOS
+    {
+        // macOS has an array of 20 elements
+        private const int NCCS = 20;
+
+        // macOS uses unsigned 64-bit sized flags
+        [FieldOffset(0)]  public InputFlags   c_iflag;
+        [FieldOffset(8)]  public OutputFlags  c_oflag;
+        [FieldOffset(16)] public ControlFlags c_cflag;
+        [FieldOffset(24)] public LocalFlags   c_lflag;
+
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = NCCS)]
+        [FieldOffset(32)] public byte[] c_cc;
+
+        [FieldOffset(32 + NCCS)]     public ulong c_ispeed;
+        [FieldOffset(32 + NCCS + 8)] public ulong c_ospeed;
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Posix/GpgPassCredentialStore.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Posix/GpgPassCredentialStore.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace GitCredentialManager.Interop.Posix
+{
+    public class GpgPassCredentialStore : PlaintextCredentialStore
+    {
+        public const string PasswordStoreDirEnvar = "PASSWORD_STORE_DIR";
+
+        private readonly IGpg _gpg;
+
+        public GpgPassCredentialStore(IFileSystem fileSystem, IGpg gpg, string storeRoot, string @namespace = null)
+            : base(fileSystem, storeRoot, @namespace)
+        {
+            PlatformUtils.EnsurePosix();
+            EnsureArgument.NotNull(gpg, nameof(gpg));
+            _gpg = gpg;
+        }
+
+        protected override string CredentialFileExtension => ".gpg";
+
+        private string GetGpgId()
+        {
+            string gpgIdPath = Path.Combine(StoreRoot, ".gpg-id");
+            if (!FileSystem.FileExists(gpgIdPath))
+            {
+                throw new Exception($"Cannot find GPG ID in '{gpgIdPath}'; password store has not been initialized");
+            }
+
+            using (var stream = FileSystem.OpenFileStream(gpgIdPath, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var reader = new StreamReader(stream))
+            {
+                return reader.ReadLine();
+            }
+        }
+
+        protected override bool TryDeserializeCredential(string path, out FileCredential credential)
+        {
+            string text = _gpg.DecryptFile(path);
+
+            int line1Idx = text.IndexOf(Environment.NewLine, StringComparison.OrdinalIgnoreCase);
+            if (line1Idx > 0)
+            {
+                // Password is the first line
+                string password = text.Substring(0, line1Idx);
+
+                // All subsequent lines are metadata/attributes
+                string attrText = text.Substring(line1Idx + Environment.NewLine.Length);
+                using var attrReader = new StringReader(attrText);
+                IDictionary<string, string> attrs = attrReader.ReadDictionary(StringComparer.OrdinalIgnoreCase);
+
+                // Account is optional
+                attrs.TryGetValue("account", out string account);
+
+                // Service is required
+                if (attrs.TryGetValue("service", out string service))
+                {
+                    credential = new FileCredential(path, service, account, password);
+                    return true;
+                }
+            }
+
+            credential = null;
+            return false;
+        }
+
+        protected override void SerializeCredential(FileCredential credential)
+        {
+            string gpgId = GetGpgId();
+
+            var sb = new StringBuilder(credential.Password);
+            sb.AppendFormat("{1}service={0}{1}", credential.Service, Environment.NewLine);
+            sb.AppendFormat("account={0}{1}", credential.Account, Environment.NewLine);
+            string fileContents = sb.ToString();
+
+            // Ensure the parent directory exists
+            string parentDir = Path.GetDirectoryName(credential.FullPath);
+            if (!FileSystem.DirectoryExists(parentDir))
+            {
+                FileSystem.CreateDirectory(parentDir);
+            }
+
+            // Delete any existing file
+            if (FileSystem.FileExists(credential.FullPath))
+            {
+                FileSystem.DeleteFile(credential.FullPath);
+            }
+
+            // Encrypt!
+            _gpg.EncryptFile(credential.FullPath, gpgId, fileContents);
+        }
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Posix/Native/Fcntl.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Posix/Native/Fcntl.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace GitCredentialManager.Interop.Posix.Native
+{
+    public static class Fcntl
+    {
+        [DllImport("libc", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        public static extern int open(string pathname, OpenFlags flags);
+    }
+
+    [Flags]
+    public enum OpenFlags
+    {
+        O_RDONLY    = 0,
+        O_WRONLY    = 1,
+        O_RDWR      = 2,
+        O_CREAT     = 64,
+        O_EXCL      = 128,
+        O_NOCTTY    = 256,
+        O_TRUNC     = 512,
+        O_APPEND    = 1024,
+        O_NONBLOCK  = 2048,
+        O_SYNC      = 4096,
+        O_NOFOLLOW  = 131072,
+        O_DIRECTORY = 65536,
+        O_DIRECT    = 16384,
+        O_ASYNC     = 8192,
+        O_LARGEFILE = 32768,
+        O_CLOEXEC   = 524288,
+        O_PATH      = 2097152,
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Posix/Native/Signal.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Posix/Native/Signal.cs
@@ -1,0 +1,35 @@
+using System.Runtime.InteropServices;
+
+namespace GitCredentialManager.Interop.Posix.Native
+{
+    public static class Signal
+    {
+        /// <summary>
+        /// Interrupt.
+        /// </summary>
+        public const int SIGINT  = 2;
+
+        /// <summary>
+        /// Quit.
+        /// </summary>
+        public const int SIGQUIT = 3;
+
+        /// <summary>
+        /// Abort.
+        /// </summary>
+        public const int SIGABRT = 6;
+
+        /// <summary>
+        /// Kill (cannot be caught or ignored).
+        /// </summary>
+        public const int SIGKILL = 9;
+
+        /// <summary>
+        /// Software termination signal from kill.
+        /// </summary>
+        public const int SIGTERM = 15;
+
+        [DllImport("libc", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        public static extern void kill(int pid, int sig);
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Posix/Native/Stat.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Posix/Native/Stat.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace GitCredentialManager.Interop.Posix.Native
+{
+    public static class Stat
+    {
+        [DllImport("libc", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        public static extern int chmod(string path, NativeFileMode mode);
+    }
+    [Flags]
+    public enum NativeFileMode
+    {
+        NONE = 0,
+
+        // Default permissions (RW for owner, RW for group, RW for other)
+        DEFAULT = S_IWOTH | S_IROTH | S_IWGRP | S_IRGRP | S_IWUSR | S_IRUSR,
+
+        // All file access permissions (RWX for owner, group, and other)
+        ACCESSPERMS = S_IRWXO | S_IRWXU | S_IRWXG,
+
+        // Read for owner (0000400)
+        S_IRUSR = 0x100,
+        // Write for owner (0000200)
+        S_IWUSR = 0x080,
+        // Execute for owner (0000100)
+        S_IXUSR = 0x040,
+        // Access permissions for owner
+        S_IRWXU = S_IRUSR | S_IWUSR | S_IXUSR,
+
+        // Read for group (0000040)
+        S_IRGRP = 0x020,
+        // Write for group (0000020)
+        S_IWGRP = 0x010,
+        // Execute for group (0000010)
+        S_IXGRP = 0x008,
+        // Access permissions for group
+        S_IRWXG = S_IRGRP | S_IWGRP | S_IXGRP,
+
+        // Read for other (0000004)
+        S_IROTH = 0x004,
+        // Write for other (0000002)
+        S_IWOTH = 0x002,
+        // Execute for other (0000001)
+        S_IXOTH = 0x001,
+        // Access permissions for other
+        S_IRWXO = S_IROTH | S_IWOTH | S_IXOTH,
+
+        // Set user ID on execution (0004000)
+        S_ISUID = 0x800,
+        // Set group ID on execution (0002000)
+        S_ISGID = 0x400,
+        // Sticky bit (0001000)
+        S_ISVTX = 0x200,
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Posix/Native/Stdio.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Posix/Native/Stdio.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace GitCredentialManager.Interop.Posix.Native
+{
+    public static class Stdio
+    {
+        public const int EOF = -1;
+
+        [DllImport("libc", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        public static extern IntPtr fgets(StringBuilder sb, int size, IntPtr stream);
+
+        [DllImport("libc", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        public static extern int fputc(int c, IntPtr stream);
+
+        [DllImport("libc", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        public static extern int fprintf(IntPtr stream, string format, string message);
+
+        [DllImport("libc", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        public static extern int fgetc(IntPtr stream);
+
+        [DllImport("libc", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        public static extern int fputs(string str, IntPtr stream);
+
+        [DllImport("libc", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        public static extern void setbuf(IntPtr stream, int size);
+
+        [DllImport("libc", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        public static extern IntPtr fdopen(int fd, string mode);
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Posix/Native/Stdlib.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Posix/Native/Stdlib.cs
@@ -1,0 +1,10 @@
+using System.Runtime.InteropServices;
+
+namespace GitCredentialManager.Interop.Posix.Native
+{
+    public static class Stdlib
+    {
+        [DllImport("libc", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        public static extern unsafe byte* realpath(byte* path, byte* resolved_path);
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Posix/Native/Termios.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Posix/Native/Termios.cs
@@ -1,0 +1,108 @@
+using System;
+
+namespace GitCredentialManager.Interop.Posix.Native
+{
+    [Flags]
+    public enum SetActionFlags
+    {
+        /// <summary>
+        /// Make change immediately.
+        /// </summary>
+        TCSANOW = 0,
+
+        /// <summary>
+        /// Drain output, then change.
+        /// </summary>
+        TCSADRAIN = 1,
+
+        /// <summary>
+        /// Drain output, flush input.
+        /// </summary>
+        TCSAFLUSH = 2,
+    }
+
+    [Flags]
+    public enum InputFlags : uint
+    {
+        IGNBRK  = 0x00000001, // ignore BREAK condition
+        BRKINT  = 0x00000002, // map BREAK to SIGINTR
+        IGNPAR  = 0x00000004, // ignore (discard) parity errors
+        PARMRK  = 0x00000008, // mark parity and framing errors
+        INPCK   = 0x00000010, // enable checking of parity errors
+        ISTRIP  = 0x00000020, // strip 8th bit off chars
+        INLCR   = 0x00000040, // map NL into CR
+        IGNCR   = 0x00000080, // ignore CR
+        ICRNL   = 0x00000100, // map CR to NL (ala CRMOD)
+        IXON    = 0x00000200, // enable output flow control
+        IXOFF   = 0x00000400, // enable input flow control
+        IXANY   = 0x00000800, // any char will restart after stop
+        IMAXBEL = 0x00002000, // ring bell on input queue full
+        IUTF8   = 0x00004000, // maintain state for UTF-8 VERASE
+    }
+
+    [Flags]
+    public enum OutputFlags : uint
+    {
+        OPOST  = 0x00000001, // enable following output processing
+        ONLCR  = 0x00000002, // map NL to CR-NL (ala CRMOD)
+        OXTABS = 0x00000004, // expand tabs to spaces
+        ONOEOT = 0x00000008, // discard EOT's (^D) on output)
+        OCRNL  = 0x00000010, // map CR to NL on output
+        ONOCR  = 0x00000020, // no CR output at column 0
+        ONLRET = 0x00000040, // NL performs CR function
+        OFILL  = 0x00000080, // use fill characters for delay
+        NLDLY  = 0x00000300, // \n delay
+        TABDLY = 0x00000c04, // horizontal tab delay
+        CRDLY  = 0x00003000, // \r delay
+        FFDLY  = 0x00004000, // form feed delay
+        BSDLY  = 0x00008000, // \b delay
+        VTDLY  = 0x00010000, // vertical tab delay
+        OFDEL  = 0x00020000, // fill is DEL, else NUL
+    }
+
+    [Flags]
+    public enum ControlFlags : uint
+    {
+        CIGNORE    = 0x00000001, // ignore control flags
+        CSIZE      = 0x00000300, // character size mask
+        CS5        = 0x00000000, // 5 bits (pseudo)
+        CS6        = 0x00000100, // 6 bits
+        CS7        = 0x00000200, // 7 bits
+        CS8        = 0x00000300, // 8 bits
+        CSTOPB     = 0x00000400, // send 2 stop bits
+        CREAD      = 0x00000800, // enable receiver
+        PARENB     = 0x00001000, // parity enable
+        PARODD     = 0x00002000, // odd parity, else even
+        HUPCL      = 0x00004000, // hang up on last close
+        CLOCAL     = 0x00008000, // ignore modem status lines
+        CCTS_OFLOW = 0x00010000, // CTS flow control of output
+        CRTSCTS    = (CCTS_OFLOW | CRTS_IFLOW),
+        CRTS_IFLOW = 0x00020000, // RTS flow control of input
+        CDTR_IFLOW = 0x00040000, // DTR flow control of input
+        CDSR_OFLOW = 0x00080000, // DSR flow control of output
+        CCAR_OFLOW = 0x00100000, // DCD flow control of output
+        MDMBUF     = 0x00100000, // old name for CCAR_OFLOW
+    }
+
+    [Flags]
+    public enum LocalFlags : uint
+    {
+        ECHOKE     = 0x00000001, // visual erase for line kill
+        ECHOE      = 0x00000002, // visually erase chars
+        ECHOK      = 0x00000004, // echo NL after line kill
+        ECHO       = 0x00000008, // enable echoing
+        ECHONL     = 0x00000010, // echo NL even if ECHO is off
+        ECHOPRT    = 0x00000020, // visual erase mode for hardcopy
+        ECHOCTL    = 0x00000040, // echo control chars as ^(Char)
+        ISIG       = 0x00000080, // enable signals INTR, QUIT, [D]SUSP
+        ICANON     = 0x00000100, // canonicalize input lines
+        ALTWERASE  = 0x00000200, // use alternate WERASE algorithm
+        IEXTEN     = 0x00000400, // enable DISCARD and LNEXT
+        EXTPROC    = 0x00000800, // external processing
+        TOSTOP     = 0x00400000, // stop background jobs from output
+        FLUSHO     = 0x00800000, // output being flushed (state)
+        NOKERNINFO = 0x02000000, // no kernel output from VSTATUS
+        PENDIN     = 0x20000000, // XXX retype pending input (state)
+        NOFLSH     = 0x80000000, // don't flush after interrupt
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Posix/Native/Unistd.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Posix/Native/Unistd.cs
@@ -1,0 +1,25 @@
+using System.Runtime.InteropServices;
+
+namespace GitCredentialManager.Interop.Posix.Native
+{
+    public static class Unistd
+    {
+        [DllImport("libc", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        public static extern int read(int fd, byte[] buf, int count);
+
+        [DllImport("libc", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        public static extern int write(int fd, byte[] buf, int size);
+
+        [DllImport("libc", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        public static extern int close(int fd);
+
+        [DllImport("libc", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        public static extern int getpid();
+
+        [DllImport("libc", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        public static extern int getppid();
+
+        [DllImport("libc", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        public static extern int geteuid();
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Posix/PosixEnvironment.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Posix/PosixEnvironment.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace GitCredentialManager.Interop.Posix
+{
+    public class PosixEnvironment : EnvironmentBase
+    {
+        public PosixEnvironment(IFileSystem fileSystem)
+            : base(fileSystem) { }
+
+        internal PosixEnvironment(IFileSystem fileSystem, IReadOnlyDictionary<string, string> variables)
+            : base(fileSystem, variables) { }
+
+        #region EnvironmentBase
+
+        public override void AddDirectoryToPath(string directoryPath, EnvironmentVariableTarget target)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void RemoveDirectoryFromPath(string directoryPath, EnvironmentVariableTarget target)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override string[] SplitPathVariable(string value)
+        {
+            return value.Split(':');
+        }
+
+        #endregion
+
+        protected override IReadOnlyDictionary<string, string> GetCurrentVariables()
+        {
+            var dict = new Dictionary<string, string>();
+            var variables = Environment.GetEnvironmentVariables();
+
+            foreach (var key in variables.Keys)
+            {
+                if (key is string name && variables[key] is string value)
+                {
+                    dict[name] = value;
+                }
+            }
+
+            return dict;
+        }
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Posix/PosixFileDescriptor.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Posix/PosixFileDescriptor.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Text;
+using GitCredentialManager.Interop.Posix.Native;
+
+namespace GitCredentialManager.Interop.Posix
+{
+    /// <summary>
+    /// Represents a thin wrapper over a POSIX file descriptor.
+    /// </summary>
+    public class PosixFileDescriptor : DisposableObject
+    {
+        private readonly int _fd;
+
+        private PosixFileDescriptor()
+        {
+            PlatformUtils.EnsurePosix();
+        }
+
+        public PosixFileDescriptor(string filename, OpenFlags mode) : this()
+        {
+            _fd = Fcntl.open(filename, mode);
+        }
+
+        /// <summary>
+        /// True if the file descriptor is invalid (-1), false otherwise.
+        /// </summary>
+        public bool IsInvalid => _fd == -1;
+
+        public static implicit operator int(PosixFileDescriptor fd)
+        {
+            return fd._fd;
+        }
+
+        /// <summary>
+        /// Read <paramref name="count"/> number of bytes into the buffer <paramref name="buf"/> from the file.
+        /// </summary>
+        /// <param name="buf">Buffer into which to read bytes will be placed.</param>
+        /// <param name="count">Maximum number of bytes to read.</param>
+        /// <returns>Number of bytes actually read. A value of -1 indicates failure.</returns>
+        public int Read(byte[] buf, int count)
+        {
+            ThrowIfDisposed();
+            ThrowIfInvalid();
+            return Unistd.read(_fd, buf, count);
+        }
+
+        /// <summary>
+        /// Write <paramref name="size"/> number of bytes from the buffer <paramref name="buf"/> to the file.
+        /// </summary>
+        /// <param name="buf">Buffer into which to read bytes will be placed.</param>
+        /// <param name="size">Number of bytes from buffer <paramref name="buf"/> to write.</param>
+        /// <returns>Number of bytes actually written. A value of -1 indicates failure.</returns>
+        public int Write(byte[] buf, int size)
+        {
+            ThrowIfDisposed();
+            ThrowIfInvalid();
+            return Unistd.write(_fd, buf, size);
+        }
+
+        /// <summary>
+        /// Write <paramref name="str"/> as a UTF8 encoded string to the file.
+        /// </summary>
+        /// <param name="str">String value to write to the file.</param>
+        /// <returns>Number of UTF8 bytes written. A value of -1 indicates failure.</returns>
+        public int Write(string str)
+        {
+            byte[] buf = Encoding.UTF8.GetBytes(str);
+            return Write(buf, buf.Length);
+        }
+
+        protected override void ReleaseUnmanagedResources()
+        {
+            if (!IsInvalid)
+            {
+                Unistd.close(_fd);
+            }
+
+            base.ReleaseUnmanagedResources();
+        }
+
+        private void ThrowIfInvalid()
+        {
+            if (IsInvalid)
+            {
+                throw new InvalidOperationException("File descriptor is invalid");
+            }
+        }
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Posix/PosixFileSystem.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Posix/PosixFileSystem.cs
@@ -1,0 +1,88 @@
+using System;
+using System.IO;
+
+namespace GitCredentialManager.Interop.Posix
+{
+    public abstract class PosixFileSystem : FileSystem
+    {
+        /// <summary>
+        /// Recursively resolve a symbolic link.
+        /// </summary>
+        /// <param name="path">Path to resolve.</param>
+        /// <returns>Resolved symlink, or original path if not a link.</returns>
+        /// <exception cref="ArgumentException">Path is not absolute.</exception>
+        protected internal static string ResolveSymbolicLinks(string path)
+        {
+#if NETFRAMEWORK
+            // Support for symlinks only exists in .NET 6+.
+            // Since we're still targeting .NET Framework on Windows it
+            // doesn't matter if we don't resolve symlinks for POSIX here
+            // (unless we're running on Mono.. but why do that?)
+            return path;
+#else
+            if (!Path.IsPathRooted(path))
+            {
+                throw new ArgumentException("Path must be absolute", nameof(path));
+            }
+
+            // If the file or directory doesn't actually exist we cannot resolve
+            // any symlinks, so just return the original input path.
+            if (!File.Exists(path) && !Directory.Exists(path))
+            {
+                return path;
+            }
+
+            // If the file is a symlink then resolve it!
+            string realPath = TryResolveFileLink(path, out string resolvedFile)
+                ? resolvedFile
+                : path;
+
+            // Work backwards from the file name resolving directories symlinks
+            string partialPath = Path.GetFileName(realPath);
+            string dirPath = Path.GetDirectoryName(realPath);
+            while (dirPath != null)
+            {
+                // Try to resolve directory symlinks
+                if (TryResolveDirectoryLink(dirPath, out string resolvedDir))
+                {
+                    dirPath = resolvedDir;
+                }
+
+                string dirName = Path.GetFileName(dirPath);
+                partialPath = Path.Combine(dirName, partialPath);
+                dirPath = Path.GetDirectoryName(dirPath);
+            }
+
+            return Path.Combine("/", partialPath);
+#endif
+        }
+
+#if NETSTANDARD2_0
+        private static bool TryResolveFileLink(string path, out string target)
+        {
+            target = null;
+            return false;
+        }
+
+        private static bool TryResolveDirectoryLink(string path, out string target)
+        {
+            target = null;
+            return false;
+        }
+#elif !NETFRAMEWORK
+        private static bool TryResolveFileLink(string path, out string target)
+        {
+            FileSystemInfo fsi = File.ResolveLinkTarget(path, true);
+            target = fsi?.FullName;
+            return fsi != null;
+        }
+
+        private static bool TryResolveDirectoryLink(string path, out string target)
+        {
+            FileSystemInfo fsi = Directory.ResolveLinkTarget(path, true);
+            target = fsi?.FullName;
+            return fsi != null;
+        }
+#endif
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Posix/PosixSessionManager.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Posix/PosixSessionManager.cs
@@ -1,0 +1,15 @@
+namespace GitCredentialManager.Interop.Posix
+{
+    public abstract class PosixSessionManager : SessionManager
+    {
+        protected PosixSessionManager(IEnvironment env, IFileSystem fs) : base(env, fs)
+        {
+            PlatformUtils.EnsurePosix();
+        }
+
+        // Check if we have an X11 or Wayland display environment available
+        public override bool IsDesktopSession =>
+            !string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable("DISPLAY")) ||
+            !string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable("WAYLAND_DISPLAY"));
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Posix/PosixTerminal.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Posix/PosixTerminal.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Text;
+using GitCredentialManager.Interop.Posix.Native;
+
+namespace GitCredentialManager.Interop.Posix
+{
+    /// <summary>
+    /// Represents a thin wrapper around the POSIX TTY device (/dev/tty).
+    /// </summary>
+    public abstract class PosixTerminal : ITerminal
+    {
+        private const string TtyDeviceName = "/dev/tty";
+        private const byte DeleteChar = 127;
+
+        protected readonly ITrace Trace;
+        protected readonly ITrace2 Trace2;
+
+        public PosixTerminal(ITrace trace, ITrace2 trace2)
+        {
+            PlatformUtils.EnsurePosix();
+            EnsureArgument.NotNull(trace, nameof(trace));
+
+            Trace = trace;
+        }
+
+        public void WriteLine(string format, params object[] args)
+        {
+            using (var fd = new PosixFileDescriptor(TtyDeviceName, OpenFlags.O_RDWR))
+            {
+                if (fd.IsInvalid)
+                {
+                    Trace.WriteLine("Not a TTY, abandoning write line.");
+                    return;
+                }
+
+                fd.Write(string.Format(format, args));
+                fd.Write("\n");
+            }
+        }
+
+        public string Prompt(string prompt)
+        {
+            return Prompt(prompt, echo: true);
+        }
+
+        public string PromptSecret(string prompt)
+        {
+            return Prompt(prompt, echo: false);
+        }
+
+        protected abstract IDisposable CreateTtyContext(int fd, bool echo);
+
+        private string Prompt(string prompt, bool echo)
+        {
+            using (var fd = new PosixFileDescriptor(TtyDeviceName, OpenFlags.O_RDWR))
+            {
+                if (fd.IsInvalid)
+                {
+                    Trace.WriteLine("Not a TTY, abandoning prompt.");
+                    return null;
+                }
+
+                fd.Write($"{prompt}: ");
+
+                var sb = new StringBuilder();
+
+                using (CreateTtyContext(fd, echo))
+                {
+                    var readBuf = new byte[1];
+                    bool eol = false;
+                    while (!eol)
+                    {
+                        int nr;
+                        // Read one byte at a time
+                        if ((nr = fd.Read(readBuf, 1)) != 1)
+                        {
+                            // Either we reached end of file or an error occured.
+                            // We don't care which so let's just trace and terminate further reading.
+                            Trace.WriteLine($"Exiting POSIX terminal prompt read-loop unexpectedly (nr={nr})");
+                            eol = true;
+                            break;
+                        }
+
+                        int c = readBuf[0];
+                        switch (c)
+                        {
+                            case 3: // CTRL + C
+                                // Since `read` is a blocking call we must manually raise the SIGINT signal
+                                // when the user types CTRL+C into the terminal window.
+                                int pid = Unistd.getpid();
+                                Trace.WriteLine($"Intercepted SIGINT during terminal prompt read-loop - sending SIGINT to self (pid={pid})");
+                                Signal.kill(pid, Signal.SIGINT);
+                                break;
+
+                            case '\n':
+                                eol = true;
+                                // Only need to echo the newline to move the terminal cursor down when
+                                // echo is disabled. When echo is enabled the newline is written for us.
+                                if (!echo)
+                                {
+                                    fd.Write("\n");
+                                }
+                                break;
+
+                            case '\b':
+                            case DeleteChar:
+                                if (sb.Length > 0)
+                                {
+                                    sb.Remove(sb.Length - 1, 1);
+                                    fd.Write("\b \b");
+                                }
+                                break;
+
+                            default:
+                                sb.Append((char) c);
+                                break;
+                        }
+                    }
+                    return sb.ToString();
+                }
+            }
+        }
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/U8StringConverter.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/U8StringConverter.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace GitCredentialManager.Interop
+{
+    /// <summary>
+    /// Conversion utilities to convert between .NET strings (UTF-16) and byte arrays (UTF-8).
+    /// </summary>
+    public static class U8StringConverter
+    {
+        private const byte NULL = (byte) '\0';
+
+        // Throw only on invalid bytes when converting from managed to native.
+        // We shouldn't have invalid managed strings so this would be an error condition.
+        // We continue to accept potentially malformed native strings however, because they may come from Git which
+        // doesn't technically care about Unicode encoding format compliance.
+        private static readonly Encoding NativeEncoding = new UTF8Encoding(false, throwOnInvalidBytes: true);
+        private static readonly Encoding ManagedEncoding = new UTF8Encoding(false, throwOnInvalidBytes: false);
+
+        public static unsafe IntPtr ToNative(string str)
+        {
+            if (str == null)
+            {
+                return IntPtr.Zero;
+            }
+
+            int length = NativeEncoding.GetByteCount(str);
+
+            // +1 for the null terminator byte
+            var buffer = (byte*)Marshal.AllocHGlobal(length + 1).ToPointer();
+
+            if (length > 0)
+            {
+                fixed (char* pValue = str)
+                {
+                    NativeEncoding.GetBytes(pValue, str.Length, buffer, length);
+                }
+            }
+            buffer[length] = NULL;
+
+            return new IntPtr(buffer);
+        }
+
+        public static unsafe string ToManaged(byte* buf)
+        {
+            byte* end = buf;
+
+            if (buf == null)
+            {
+                return null;
+            }
+
+            if (*buf == NULL)
+            {
+                return string.Empty;
+            }
+
+            while (*end != NULL)
+            {
+                end++;
+            }
+
+            return new string((sbyte*)buf, 0, (int)(end - buf), ManagedEncoding);
+        }
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/U8StringMarshaler.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/U8StringMarshaler.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace GitCredentialManager.Interop
+{
+    /// <summary>
+    /// Marshaler for converting between .NET strings (UTF-16) and byte arrays (UTF-8).
+    /// Uses <seealso cref="U8StringConverter"/> internally.
+    /// </summary>
+    public class U8StringMarshaler : ICustomMarshaler
+    {
+        // We need to clean up strings that we marshal to native, but should not clean up strings that
+        // we marshal to managed.
+        private static readonly U8StringMarshaler NativeInstance = new U8StringMarshaler(true);
+        private static readonly U8StringMarshaler ManagedInstance = new U8StringMarshaler(false);
+
+        private readonly bool _cleanup;
+
+        public const string NativeCookie  = "U8StringMarshaler.Native";
+        public const string ManagedCookie = "U8StringMarshaler.Managed";
+
+        public static ICustomMarshaler GetInstance(string cookie)
+        {
+            switch (cookie)
+            {
+                case NativeCookie:
+                    return NativeInstance;
+                case ManagedCookie:
+                    return ManagedInstance;
+                default:
+                    throw new ArgumentException("Invalid marshaler cookie");
+            }
+        }
+
+        private U8StringMarshaler(bool cleanup)
+        {
+            _cleanup = cleanup;
+        }
+
+        public int GetNativeDataSize()
+        {
+            return -1;
+        }
+
+        public IntPtr MarshalManagedToNative(object value)
+        {
+            switch (value)
+            {
+                case null:
+                    return IntPtr.Zero;
+                case string str:
+                    return U8StringConverter.ToNative(str);
+                default:
+                    throw new MarshalDirectiveException("Cannot marshal a non-string");
+            }
+        }
+
+        public unsafe object MarshalNativeToManaged(IntPtr ptr)
+        {
+            return U8StringConverter.ToManaged((byte*) ptr);
+        }
+
+        public void CleanUpManagedData(object value)
+        {
+        }
+
+        public virtual void CleanUpNativeData(IntPtr ptr)
+        {
+            if (ptr != IntPtr.Zero && _cleanup)
+            {
+                Marshal.FreeHGlobal(ptr);
+            }
+        }
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/DpapiCredentialStore.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/DpapiCredentialStore.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace GitCredentialManager.Interop.Windows
+{
+    public class DpapiCredentialStore : PlaintextCredentialStore
+    {
+        public DpapiCredentialStore(IFileSystem fileSystem, string storeRoot, string @namespace = null)
+            : base(fileSystem, storeRoot, @namespace)
+        {
+            PlatformUtils.EnsureWindows();
+        }
+
+        protected override bool TryDeserializeCredential(string path, out FileCredential credential)
+        {
+            string text;
+            using (var stream = FileSystem.OpenFileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var reader = new StreamReader(stream))
+            {
+                text = reader.ReadToEnd();
+            }
+
+            int line1Idx = text.IndexOf(Environment.NewLine, StringComparison.OrdinalIgnoreCase);
+            if (line1Idx > 0)
+            {
+                // The first line is a base64 encoded set of bytes that need to be decrypted by DPAPI
+                string cryptoBase64 = text.Substring(0, line1Idx);
+                byte[] cryptoBytes = Convert.FromBase64String(cryptoBase64);
+                byte[] plainBytes = ProtectedData.Unprotect(
+                    cryptoBytes, null, DataProtectionScope.CurrentUser);
+                string password = Encoding.UTF8.GetString(plainBytes);
+
+                // All subsequent lines are metadata/attributes
+                string attrText = text.Substring(line1Idx + Environment.NewLine.Length);
+                using var attrReader = new StringReader(attrText);
+                IDictionary<string, string> attrs = attrReader.ReadDictionary(StringComparer.OrdinalIgnoreCase);
+
+                // Account is optional
+                attrs.TryGetValue("account", out string account);
+
+                // Service is required
+                if (attrs.TryGetValue("service", out string service))
+                {
+                    credential = new FileCredential(path, service, account, password);
+                    return true;
+                }
+            }
+
+            credential = null;
+            return false;
+        }
+
+        protected override void SerializeCredential(FileCredential credential)
+        {
+            // Ensure the parent directory exists
+            string parentDir = Path.GetDirectoryName(credential.FullPath);
+            if (!FileSystem.DirectoryExists(parentDir))
+            {
+                FileSystem.CreateDirectory(parentDir);
+            }
+
+            // Use DPAPI to encrypt the password value, and then store the base64 encoding of the resulting bytes
+            byte[] plainBytes = Encoding.UTF8.GetBytes(credential.Password);
+            byte[] cryptoBytes = ProtectedData.Protect(
+                plainBytes, null, DataProtectionScope.CurrentUser);
+            string cryptoBase64 = Convert.ToBase64String(cryptoBytes);
+
+            using (var stream = FileSystem.OpenFileStream(credential.FullPath, FileMode.Create, FileAccess.Write, FileShare.None))
+            using (var writer = new StreamWriter(stream))
+            {
+                writer.WriteLine(cryptoBase64);
+                writer.WriteLine("service={0}", credential.Service);
+                writer.WriteLine("account={0}", credential.Account);
+                writer.Flush();
+            }
+        }
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/Native/Advapi32.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/Native/Advapi32.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+using FILETIME = System.Runtime.InteropServices.ComTypes.FILETIME;
+
+namespace GitCredentialManager.Interop.Windows.Native
+{
+    // https://docs.microsoft.com/en-us/windows/desktop/api/wincred/
+    public static class Advapi32
+    {
+        private const string LibraryName = "advapi32.dll";
+
+        [DllImport(LibraryName, EntryPoint = "CredReadW", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern bool CredRead(
+            string target,
+            CredentialType type,
+            int reserved,
+            out IntPtr credential);
+
+        [DllImport(LibraryName, EntryPoint = "CredWriteW", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern bool CredWrite(
+            ref Win32Credential credential,
+            int flags);
+
+        [DllImport(LibraryName, EntryPoint = "CredDeleteW", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern bool CredDelete(
+            string target,
+            CredentialType type,
+            int flags);
+
+        [DllImport(LibraryName, EntryPoint = "CredFree", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern void CredFree(
+            IntPtr credential);
+
+        [DllImport(LibraryName, EntryPoint = "CredEnumerateW", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern bool CredEnumerate(
+            string filter,
+            CredentialEnumerateFlags flags,
+            out int count,
+            out IntPtr credentialsList);
+
+        [DllImport(LibraryName, EntryPoint = "CredGetSessionTypes", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern bool CredGetSessionTypes(
+            uint maximumPersistCount,
+            [In, Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 0)] CredentialPersist[] maximumPersist);
+
+        // Values from wincred.h
+        public const uint CRED_TYPE_MAXIMUM = 7;
+        public const uint CRED_TYPE_MAXIMUM_EX = CRED_TYPE_MAXIMUM + 1000;
+    }
+
+    // Enum values from wincred.h
+    public enum CredentialType
+    {
+        Generic = 1,
+        DomainPassword = 2,
+        DomainCertificate = 3,
+        DomainVisiblePassword = 4,
+        GenericCertificate = 5,
+        DomainExtended = 6
+    }
+
+    public enum CredentialPersist
+    {
+        None = 0,
+        Session = 1,
+        LocalMachine = 2,
+        Enterprise = 3,
+    }
+
+    [Flags]
+    public enum CredentialEnumerateFlags
+    {
+        None = 0,
+        AllCredentials = 0x1
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    public struct Win32Credential
+    {
+        public int Flags;
+        public CredentialType Type;
+        [MarshalAs(UnmanagedType.LPWStr)]
+        public string TargetName;
+        [MarshalAs(UnmanagedType.LPWStr)]
+        public string Comment;
+        public FILETIME LastWritten;
+        public int CredentialBlobSize;
+        public IntPtr CredentialBlob;
+        public CredentialPersist Persist;
+        public int AttributeCount;
+        public IntPtr Attributes;
+        [MarshalAs(UnmanagedType.LPWStr)]
+        public string TargetAlias;
+        [MarshalAs(UnmanagedType.LPWStr)]
+        public string UserName;
+
+        public string GetCredentialBlobAsString()
+        {
+            if (CredentialBlobSize != 0 && CredentialBlob != IntPtr.Zero)
+            {
+                byte[] passwordBytes = InteropUtils.ToByteArray(CredentialBlob, CredentialBlobSize);
+                return Encoding.Unicode.GetString(passwordBytes);
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/Native/CredUi.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/Native/CredUi.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace GitCredentialManager.Interop.Windows.Native
+{
+    // https://docs.microsoft.com/en-us/windows/desktop/api/wincred/
+    public static class CredUi
+    {
+        private const string LibraryName = "credui.dll";
+
+        [Flags]
+        public enum CredentialPackFlags : uint
+        {
+            None = 0,
+            ProtectedCredentials = 0x1,
+            WowBuffer = 0x2,
+            GenericCredentials = 0x4,
+        }
+
+        [Flags]
+        public enum CredentialUiFlags : uint
+        {
+            None = 0,
+            IncorrectPassword = 0x1,
+            DoNoPersist = 0x2,
+            RequestAdministrator = 0x4,
+            ExcludeCertificates = 0x8,
+            RequireCertificates = 0x10,
+            ShowSaveCheckbox = 0x40,
+            AlwaysShowUi = 0x80,
+            RequireSmartCard = 0x100,
+            PasswordOnlyOk = 0x200,
+            ValidateUsername = 0x400,
+            CompleteUsername = 0x800,
+            Persist = 0x1000,
+            ServerCredential = 0x4000,
+            ExpectConfirmation = 0x20000,
+            GenericCredentials = 0x40000,
+            UsernameTargetCredentials = 0x80000,
+            KeepUsername = 0x100000,
+        }
+
+        public enum CredentialUiResult : uint
+        {
+            Success = 0,
+            Cancelled = 1223,
+            NoSuchLogonSession = 1312,
+            NotFound = 1168,
+            InvalidAccountName = 1315,
+            InsufficientBuffer = 122,
+            InvalidParameter = 87,
+            InvalidFlags = 1004,
+        }
+
+        [Flags]
+        public enum CredentialUiWindowsFlags : uint
+        {
+            None = 0,
+
+            /// <summary>
+            /// The caller is requesting that the credential provider return the user name and password in plain text.
+            /// </summary>
+            Generic = 0x0001,
+
+            /// <summary>
+            /// The Save check box is displayed in the dialog box.
+            /// </summary>
+            Checkbox = 0x0002,
+
+            /// <summary>
+            /// Only credential providers that support the authentication package specified by the `authPackage` parameter
+            /// should be enumerated.
+            /// </summary>
+            AuthPackageOnly = 0x0010,
+
+            /// <summary>
+            /// Only the credentials specified by the `inAuthBuffer` parameter for the authentication package specified
+            /// by the `authPackage` parameter should be enumerated.
+            /// <para/>
+            /// If this flag is set, and the `inAuthBuffer` parameter is `null`, the function fails.
+            /// </summary>
+            InCredOnly = 0x0020,
+
+            /// <summary>
+            /// Credential providers should enumerate only administrators.
+            /// <para/>
+            /// This value is intended for User Account Control (UAC) purposes only.
+            /// <para/>
+            /// We recommend that external callers not set this flag.
+            /// </summary>
+            EnumerateAdmins = 0x0100,
+
+            /// <summary>
+            /// Only the incoming credentials for the authentication package specified by the `authPackage` parameter
+            /// should be enumerated.
+            /// </summary>
+            EnumerateCurrentUser = 0x0200,
+
+            /// <summary>
+            /// The credential dialog box should be displayed on the secure desktop.
+            /// <para/>
+            /// This value cannot be combined with <see cref="Generic"/>.
+            /// </summary>
+            SecurePrompt = 0x1000,
+
+            /// <summary>
+            /// The credential dialog box is invoked by the SspiPromptForCredentials function, and the client is prompted
+            /// before a prior handshake.
+            /// <para/>
+            /// If SSPIPFC_NO_CHECKBOX is passed in the `inAuthBuffer` parameter, then the credential provider should
+            /// not display the check box.
+            /// </summary>
+            Preprompting = 0x2000,
+
+            /// <summary>
+            /// The credential provider should align the credential BLOB pointed to by the `outAuthBuffer` parameter to
+            /// a 32-bit boundary, even if the provider is running on a 64-bit system.
+            /// </summary>
+            Pack32Wow = 0x10000000,
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        public struct CredentialUiInfo
+        {
+            [MarshalAs(UnmanagedType.U4)]
+            public int Size;
+
+            [MarshalAs(UnmanagedType.SysInt)]
+            public IntPtr Parent;
+
+            [MarshalAs(UnmanagedType.LPWStr)]
+            public string MessageText;
+
+            [MarshalAs(UnmanagedType.LPWStr)]
+            public string CaptionText;
+
+            [MarshalAs(UnmanagedType.SysInt)]
+            public IntPtr BannerArt;
+        }
+
+        [DllImport(LibraryName, EntryPoint = "CredUIPromptForWindowsCredentialsW", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern int CredUIPromptForWindowsCredentials(
+            ref CredentialUiInfo credInfo,
+            uint authError,
+            ref uint authPackage,
+            IntPtr inAuthBuffer,
+            uint inAuthBufferSize,
+            out IntPtr outAuthBuffer,
+            out uint outAuthBufferSize,
+            ref bool saveCredentials,
+            CredentialUiWindowsFlags flags);
+
+        [DllImport(LibraryName, EntryPoint = "CredPackAuthenticationBufferW", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern bool CredPackAuthenticationBuffer(
+            CredentialPackFlags flags,
+            string username,
+            string password,
+            IntPtr packedCredentials,
+            ref int packedCredentialsSize);
+
+        [DllImport(LibraryName, EntryPoint = "CredUnPackAuthenticationBufferW", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern bool CredUnPackAuthenticationBuffer(
+            CredentialPackFlags flags,
+            IntPtr authBuffer,
+            uint authBufferSize,
+            StringBuilder username,
+            ref int maxUsernameLen,
+            StringBuilder domainName,
+            ref int maxDomainNameLen,
+            StringBuilder password,
+            ref int maxPasswordLen);
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/Native/Kernel32.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/Native/Kernel32.cs
@@ -1,0 +1,652 @@
+
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Win32.SafeHandles;
+
+namespace GitCredentialManager.Interop.Windows.Native
+{
+    public static class Kernel32
+    {
+        private const string LibraryName = "kernel32.dll";
+
+        /// <summary>
+        /// Creates or opens a file or I/O device.
+        /// <para/>
+        /// The most commonly used I/O devices are as follows: file, file stream, directory, physical disk, volume,
+        /// console buffer, tape drive, communications resource, mailslot, and pipe.
+        /// <para/>
+        /// The function returns a handle that can be used to access the file or device for various types of I/O
+        /// depending on the file or device and the flags and attributes specified.
+        /// <para/>
+        /// Return a handle to the file created.
+        /// </summary>
+        /// <param name="fileName">
+        /// The name of the file or device to be created or opened. You may use either forward slashes (/) or
+        /// backslashes (\) in this name.
+        /// <para/>
+        /// In the ANSI version of this function, the name is limited to `MAX_PATH` characters.
+        /// <para/>
+        /// To extend this limit to 32,767 wide characters, call the Unicode version of the function and prepend
+        /// "\\?\" to the path.
+        /// </param>
+        /// <param name="desiredAccess">
+        /// The requested access to the file or device, which can be summarized as read, write, both or neither zero).
+        /// <para/>
+        /// If this parameter is zero, the application can query certain metadata such as file, directory, or device
+        /// attributes without accessing that file or device, even if `<see cref="FileAccess.GenericRead"/>` access
+        /// would have been denied.
+        /// <para/>
+        /// You cannot request an access mode that conflicts with the sharing mode that is specified by the
+        /// `<paramref name="shareMode"/>` parameter in an open request that already has an open handle.
+        /// </param>
+        /// <param name="shareMode">
+        /// The requested sharing mode of the file or device, which can be read, write, both, delete, all of these,
+        /// or none (refer to the following table).
+        /// <para/>
+        /// Access requests to attributes or extended attributes are not affected by this flag.
+        /// <para/>
+        /// If this parameter is zero and CreateFile succeeds, the file or device cannot be shared and cannot be opened
+        /// again until the handle to the file or device is closed.
+        /// <para/>
+        /// You cannot request a sharing mode that conflicts with the access mode that is specified in an existing
+        /// request that has an open handle.
+        /// <para/>
+        /// CreateFile would fail and the `<see cref="Marshal.GetLastWin32Error"/>` function would return
+        /// `<see cref="Win32Error.SharingViloation"/>`.
+        /// <para/>
+        /// To enable a process to share a file or device while another process has the file or device open, use a
+        /// compatible combination of one or more of the following values.
+        /// </param>
+        /// <param name="securityAttributes">
+        /// This parameter should be `<see cref="IntPtr.Zero"/>`.
+        /// </param>
+        /// <param name="creationDisposition">
+        /// An action to take on a file or device that exists or does not exist.
+        /// <para/>
+        /// For devices other than files, this parameter is usually set to
+        /// `<see cref="FileCreationDisposition.OpenExisting"/>`.
+        /// </param>
+        /// <param name="flagsAndAttributes">
+        /// The file or device attributes and flags, `<see cref="FileAttributes.Normal"/>` being the most common
+        /// default value for files.
+        /// <para/>
+        /// This parameter can include any combination of `<see cref="FileAttributes"/>`.
+        /// <para/>
+        /// All other file attributes override `<see cref="FileAttributes.Normal"/>`.
+        /// </param>
+        /// <param name="templateFile">
+        /// This parameter should be `<see cref="IntPtr.Zero"/>`.
+        /// </param>
+        [DllImport(LibraryName, EntryPoint = "CreateFileW", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern SafeFileHandle CreateFile(
+            [In, MarshalAs(UnmanagedType.LPWStr)] string fileName,
+            [In, MarshalAs(UnmanagedType.U4)] FileAccess desiredAccess,
+            [In, MarshalAs(UnmanagedType.U4)] FileShare shareMode,
+            [In, MarshalAs(UnmanagedType.SysInt)] IntPtr securityAttributes,
+            [In, MarshalAs(UnmanagedType.U4)] FileCreationDisposition creationDisposition,
+            [In, MarshalAs(UnmanagedType.U4)] FileAttributes flagsAndAttributes,
+            [In, MarshalAs(UnmanagedType.SysInt)] IntPtr templateFile);
+
+        /// <summary>
+        /// Reads character input from the console input buffer and removes it from the buffer.
+        /// <para/>
+        /// Returns `<see langword="true"/>` if successful; otherwise `<see langword="false"/>`.
+        /// </summary>
+        /// <param name="consoleInputHandle">
+        /// A handle to the console input buffer. The handle must have the `<see cref="FileAccess.GenericRead"/>`
+        /// access right.
+        /// </param>
+        /// <param name="buffer">
+        /// A pointer to a buffer that receives the data read from the console input buffer.
+        /// <para/>
+        /// The storage for this buffer is allocated from a shared heap for the process that is 64 KB in size.
+        /// <para/>
+        /// The maximum size of the buffer will depend on heap usage.
+        /// </param>
+        /// <param name="numberOfCharsToRead">
+        /// The number of characters to be read.
+        /// <para/>
+        /// The size of the buffer pointed to by the `<paramref name="buffer"/>` parameter should be at least `<paramref name="NumberofCharsToRead"/>` * `<see langword="sizeof"/>(<see langword="char"/>)` bytes.
+        /// </param>
+        /// <param name="numberOfCharsRead">
+        /// A pointer to a variable that receives the number of characters actually read.
+        /// </param>
+        /// <param name="reserved">
+        /// Reserved; must be `<see cref="IntPtr.Zero"/>`.
+        /// </param>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2205:UseManagedEquivalentsOfWin32Api")]
+        [DllImport(LibraryName, EntryPoint = "ReadConsoleW", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool ReadConsole(
+            [In] SafeFileHandle consoleInputHandle,
+            [Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder buffer,
+            [In, MarshalAs(UnmanagedType.U4)] uint numberOfCharsToRead,
+            [Out, MarshalAs(UnmanagedType.U4)] out uint numberOfCharsRead,
+            [In, MarshalAs(UnmanagedType.SysInt)] IntPtr reserved);
+
+        /// <summary>
+        /// Writes a character string to a console screen buffer beginning at the current cursor location.
+        /// <para/>
+        /// Returns `<see langword="true"/>` if successful; otherwise `<see langword="false"/>`.
+        /// </summary>
+        /// <param name="consoleOutputHandle">
+        /// A handle to the console screen buffer.
+        /// <para/>
+        /// The handle must have the `<see cref="FileAccess.GenericWrite"/>` access right.
+        /// </param>
+        /// <param name="buffer">
+        /// A pointer to a buffer that contains characters to be written to the console screen buffer.
+        /// <para/>
+        /// The storage for this buffer is allocated from a shared heap for the process that is 64 KB in size.
+        /// <para/>
+        /// The maximum size of the buffer will depend on heap usage.
+        /// </param>
+        /// <param name="numberOfCharsToWrite">
+        /// The number of characters to be written.
+        /// <para/>
+        /// If the total size of the specified number of characters exceeds the available heap, the function fails
+        /// with `<see cref="Win32Error.NotEnoughMemory"/>`.
+        /// </param>
+        /// <param name="numberOfCharsWritten">
+        /// A pointer to a variable that receives the number of characters actually written.
+        /// </param>
+        /// <param name="reserved">
+        /// Reserved; must be `<see cref="IntPtr.Zero"/>`.
+        /// </param>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2205:UseManagedEquivalentsOfWin32Api")]
+        [DllImport(LibraryName, EntryPoint = "WriteConsoleW", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool WriteConsole(
+            [In] SafeHandle consoleOutputHandle,
+            [In, MarshalAs(UnmanagedType.LPWStr)] StringBuilder buffer,
+            [In, MarshalAs(UnmanagedType.U4)] uint numberOfCharsToWrite,
+            [Out, MarshalAs(UnmanagedType.U4)] out uint numberOfCharsWritten,
+            [In, MarshalAs(UnmanagedType.SysInt)] IntPtr reserved);
+
+        /// <summary>
+        /// Retrieves the current input mode of a console's input buffer or the current output mode of a console screen
+        /// buffer.
+        /// <para/>
+        /// Returns `<see langword="true"/>` if successful; otherwise `<see langword="false"/>`.
+        /// </summary>
+        /// <param name="consoleHandle">
+        /// A handle to the console input buffer or the console screen buffer. The handle must have the
+        /// <see cref="FileAccess.GenericRead"/> access right.
+        /// </param>
+        /// <param name="consoleMode">
+        /// A pointer to a variable that receives the current mode of the specified buffer.
+        /// <para/>
+        /// If the `<paramref name="consoleHandle"/>` parameter is an input handle, the mode can be one or more of the
+        /// following values.
+        /// <para/>
+        /// When a console is created, all input modes except `<see cref="ConsoleMode.WindowInput"/>` are enabled by
+        /// default.
+        /// <para/>
+        /// If the `<paramref name="consoleHandle"/>` parameter is a screen buffer handle, the mode can be one or more
+        /// of the following values.
+        /// <para/>
+        /// When a screen buffer is created, both output modes are enabled by default.
+        /// </param>
+        [DllImport(LibraryName, EntryPoint = "GetConsoleMode", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool GetConsoleMode(
+            [In] SafeFileHandle consoleHandle,
+            [Out, MarshalAs(UnmanagedType.U4)] out ConsoleMode consoleMode);
+
+        /// <summary>
+        /// Sets the input mode of a console's input buffer or the output mode of a console screen buffer.
+        /// <para/>
+        /// Returns `<see langword="true"/>` if successful; otherwise `<see langword="false"/>`.
+        /// </summary>
+        /// <param name="consoleHandle">
+        /// A handle to the console input buffer or a console screen buffer.
+        /// <para/>
+        /// The handle must have the `<see cref="FileAccess.GenericRead"/>` access right.
+        /// </param>
+        /// <param name="consoleMode">
+        /// <para>
+        /// The input or output mode to be set.
+        /// <para/>
+        /// If the `<paramref name="consoleHandle"/>` parameter is an input handle, the mode can be one or more of the
+        /// following values.
+        /// <para/>
+        /// When a console is created, all input modes except `<see cref="ConsoleMode.WindowInput"/>` are enabled by
+        /// default.
+        /// </para>
+        /// <para>
+        /// If the `<paramref name="consoleHandle"/>` parameter is a screen buffer handle, the mode can be one or more
+        /// of the following values.
+        /// <para/>
+        /// When a screen buffer is created, both output modes are enabled by default.
+        /// </para>
+        /// </param>
+        [DllImport(LibraryName, EntryPoint = "SetConsoleMode", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool SetConsoleMode(
+            [In] SafeFileHandle consoleHandle,
+            [In, MarshalAs(UnmanagedType.U4)] ConsoleMode consoleMode);
+
+        /// <summary>
+        /// Retrieves the command-line string for the current process.
+        /// </summary>
+        /// <returns>The return value is the command-line string for the current process.</returns>
+        [DllImport(LibraryName, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern IntPtr GetCommandLine();
+
+        /// <summary>
+        /// Frees the specified local memory object and invalidates its handle.
+        /// </summary>
+        /// <param name="ptr">
+        /// A handle to the local memory object.
+        /// This handle is returned by either the LocalAlloc or LocalReAlloc function.
+        /// It is not safe to free memory allocated with GlobalAlloc.
+        /// </param>
+        /// <returns>
+        /// If the function succeeds, the return value is NULL.
+        /// <para/>
+        /// If the function fails, the return value is equal to a handle to the local memory object.
+        /// <para/>
+        /// To get extended error information, call GetLastError.
+        /// </returns>
+        [DllImport(LibraryName, CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern IntPtr LocalFree(IntPtr ptr);
+
+        /// <summary>
+        /// Retrieves the window handle used by the console associated with the calling process.
+        /// </summary>
+        /// <returns>
+        /// The return value is a handle to the window used by the console associated with the calling process or
+        /// NULL if there is no such associated console.
+        /// </returns>
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern IntPtr GetConsoleWindow();
+    }
+
+    [Flags]
+    public enum FileAccess : uint
+    {
+        GenericRead = 0x80000000,
+        GenericWrite = 0x40000000,
+        GenericExecute = 0x20000000,
+        GenericAll = 0x10000000,
+    }
+
+    [Flags]
+    public enum FileAttributes : uint
+    {
+        /// <summary>
+        /// The file is read only.
+        /// <para/>
+        /// Applications can read the file, but cannot write to or delete it.
+        /// </summary>
+        Readonly = 0x00000001,
+
+        /// <summary>
+        /// The file is hidden. Do not include it in an ordinary directory listing.
+        /// </summary>
+        Hidden = 0x00000002,
+
+        /// <summary>
+        /// The file is part of or used exclusively by an operating system.
+        /// </summary>
+        System = 0x00000004,
+
+        Directory = 0x00000010,
+
+        /// <summary>
+        /// The file should be archived.
+        /// <para/>
+        /// Applications use this attribute to mark files for backup
+        /// or removal.
+        /// </summary>
+        Archive = 0x00000020,
+
+        Device = 0x00000040,
+
+        /// <summary>
+        /// The file does not have other attributes set.
+        /// <para/>
+        /// This attribute is valid only if used alone.
+        /// </summary>
+        Normal = 0x00000080,
+
+        /// <summary>
+        /// The file is being used for temporary storage.
+        /// </summary>
+        Temporary = 0x00000100,
+
+        SparseFile = 0x00000200,
+
+        ReparsePoint = 0x00000400,
+
+        Compressed = 0x00000800,
+
+        /// <summary>
+        /// The data of a file is not immediately available. This attribute indicates that file data is physically
+        /// moved to offline storage.
+        /// <para/>
+        /// This attribute is used by Remote Storage, the hierarchical storage management software.
+        /// <para/>
+        /// Applications should not arbitrarily change this attribute.
+        /// </summary>
+        Offline = 0x00001000,
+
+        NotContentIndexed = 0x00002000,
+
+        /// <summary>
+        /// The file or directory is encrypted.
+        /// <para/>For a file, this means that all data in the file is encrypted.
+        /// <para/>
+        /// For a directory, this means that encryption is the default for newly created files and subdirectories.
+        /// <para/>
+        /// This flag has no effect if <see cref="Archive"/> is also specified.
+        /// <para>
+        /// This flag is not supported on Home, Home Premium, Starter, or ARM editions of Windows.
+        /// </summary>
+        Encrypted = 0x00004000,
+
+        FirstPipeInstance = 0x00080000,
+
+        /// <summary>
+        /// The file data is requested, but it should continue to be located in remote storage.
+        /// <para/>
+        /// It should not be transported back to local storage.
+        /// <para/>
+        /// This flag is for use by remote storage systems.
+        /// </summary>
+        OpenNoRecall = 0x00100000,
+
+        /// <summary>
+        /// Normal reparse point processing will not occur;
+        /// `<see cref="CreateFile(string, FileAccess, FileShare, IntPtr, FileCreationDisposition, FileAttributes, IntPtr)"/>`
+        /// will attempt to open the reparse point. When a file is opened, a file handle is returned, whether or not
+        /// the filter that controls the reparse point is operational.
+        /// <para/>
+        /// This flag cannot be used with the `<see cref="FileCreationDisposition.CreateAlways"/>` flag.
+        /// <para/>
+        /// If the file is not a reparse point, then this flag is ignored.
+        /// </summary>
+        OpenReparsePoint = 0x00200000,
+
+        /// <summary>
+        /// The file or device is being opened with session awareness.
+        /// <para/>
+        /// If this flag is not specified, then per-session devices (such as a redirected USB device) cannot be opened
+        /// by processes running in session 0.
+        /// <para/>
+        /// This flag has no effect for callers not in session 0.
+        /// <para/>
+        /// This flag is supported only on server editions of Windows.
+        /// </summary>
+        SessionAware = 0x00800000,
+
+        /// <summary>
+        /// Access will occur according to POSIX rules.
+        /// <para/>
+        /// This includes allowing multiple files with names, differing only in case, for file systems that support
+        /// that naming.
+        /// <para/>
+        /// Use care when using this option, because files created with this flag may not be accessible by applications
+        /// that are written for MS-DOS or 16-bit Windows.
+        /// </summary>
+        PosixSemantics = 0x01000000,
+
+        /// <summary>
+        /// The file is being opened or created for a backup or restore operation.
+        /// <para/>
+        /// The system ensures that the calling process overrides file security checks when the process has
+        /// SE_BACKUP_NAME and SE_RESTORE_NAME privileges.
+        /// <para/>
+        /// You must set this flag to obtain a handle to a directory.
+        /// <para/>
+        /// A directory handle can be passed to some functions instead of a file handle.
+        /// </summary>
+        BackupSemantics = 0x02000000,
+
+        /// <summary>
+        /// The file is to be deleted immediately after all of its handles are closed, which includes the specified
+        /// handle and any other open or duplicated handles.
+        /// <para/>
+        /// If there are existing open handles to a file, the call fails unless they were all opened with the
+        /// `<see cref="FileShare.Delete"/>` share mode.
+        /// <para/>
+        /// Subsequent open requests for the file fail, unless the `<see cref="FileShare.Delete"/>` share mode is
+        /// specified.
+        /// </summary>
+        DeleteOnClose = 0x04000000,
+
+        /// <summary>
+        /// Access is intended to be sequential from beginning to end. The system can use this as a hint to optimize
+        /// file caching.
+        /// <para/>
+        /// This flag should not be used if read-behind (that is, reverse scans) will be used.
+        /// <para/>
+        /// This flag has no effect if the file system does not support cached I/O and `<see cref="NoBuffering"/>`.
+        /// </summary>
+        SequentialScan = 0x08000000,
+
+        /// <summary>
+        /// Access is intended to be random. The system can use this as a hint to optimize file caching.
+        /// <para/>
+        /// This flag has no effect if the file system does not support cached I/O and `<see cref="NoBuffering"/>`.
+        /// </summary>
+        RandomAccess = 0x10000000,
+
+        /// <summary>
+        /// The file or device is being opened with no system caching for data reads and writes.
+        /// <para/>
+        /// This flag does not affect hard disk caching or memory mapped files.
+        /// <para/>
+        /// There are strict requirements for successfully working with files opened with
+        /// `<see cref="CreateFile(string, FileAccess, FileShare, IntPtr, FileCreationDisposition, FileAttributes, IntPtr)"/>`
+        /// using the `<see cref="NoBuffering"/>` flag.
+        /// </summary>
+        NoBuffering = 0x20000000,
+
+        /// <summary>
+        /// The file or device is being opened or created for asynchronous I/O.
+        /// <para/>
+        /// When subsequent I/O operations are completed on this handle, the event specified in the OVERLAPPED
+        /// structure will be set to the signaled state.
+        /// <para/>
+        /// If this flag is specified, the file can be used for simultaneous read and write operations.
+        /// <para/>
+        /// If this flag is not specified, then I/O operations are serialized, even if the calls to the read and write
+        /// functions specify an OVERLAPPED structure.
+        /// </summary>
+        Overlapped = 0x40000000,
+
+        /// <summary>
+        /// Write operations will not go through any intermediate cache, they will go directly to disk.
+        /// </summary>
+        WriteThrough = 0x80000000,
+    }
+
+    public enum FileCreationDisposition : uint
+    {
+        /// <summary>
+        /// Creates a new file, only if it does not already exist.
+        /// <para/>
+        /// If the specified file exists, the function fails and the last-error code is set to <see cref="Win32Error.FileExists"/>.
+        /// <para/>
+        /// If the specified file does not exist and is a valid path to a writable location, a new file is created.
+        /// </summary>
+        New = 1,
+
+        /// <summary>
+        /// Creates a new file, always.
+        /// <para/>
+        /// If the specified file exists and is writable, the function overwrites the file, the function succeeds, and
+        /// last-error code is set to <see cref="Win32Error.AlreadExists"/>.
+        /// <para/>
+        /// If the specified file does not exist and is a valid path, a new file is created, the function succeeds, and
+        /// the last-error code is set to zero.
+        /// </summary>
+        CreateAlways = 2,
+
+        /// <summary>
+        /// Opens a file, always.
+        /// <para/>
+        /// If the specified file exists, the function succeeds and the last-error code is set to
+        /// <see cref="Win32Error.AlreadExists"/>.
+        /// <para/>
+        /// If the specified file does not exist and is a valid path to a writable location, the function creates a
+        /// file and the last-error code is set to zero.
+        /// </summary>
+        OpenExisting = 3,
+
+        /// <summary>
+        /// Opens a file or device, only if it exists.
+        /// <para/>
+        /// If the specified file or device does not exist, the function fails and the last-error code is set to
+        /// <see cref="Win32Error.FileNotFound"/>.
+        /// </summary>
+        OpenAlways = 4,
+
+        /// <summary>
+        /// Opens a file and truncates it so that its size is zero bytes, only if it exists.
+        /// <para/>
+        /// If the specified file does not exist, the function fails and the last-error code is
+        /// set to <see cref="Win32Error.FileNotFound"/>.
+        /// <para/>
+        /// The calling process must open the file with <see cref="FileAccess.GenericWrite"/>.
+        /// </summary>
+        TruncateExisting = 5
+    }
+
+    [Flags]
+    public enum FileShare : uint
+    {
+        /// <summary>
+        /// Prevents other processes from opening a file or device if they request delete, read, or write access.
+        /// </summary>
+        None = 0x00000000,
+
+        /// <summary>
+        /// Enables subsequent open operations on an object to request read access.
+        /// <para/>
+        /// Otherwise, other processes cannot open the object if they request read access.
+        /// <para/>
+        /// If this flag is not specified, but the object has been opened for read access, the function fails.
+        /// </summary>
+        Read = 0x00000001,
+
+        /// <summary>
+        /// Enables subsequent open operations on an object to request write access.
+        /// <para/>
+        /// Otherwise, other processes cannot open the object if they request write access.
+        /// <para/>
+        /// If this flag is not specified, but the object has been opened for write access, the
+        /// function fails.
+        /// </summary>
+        Write = 0x00000002,
+
+        /// <summary>
+        /// Enables subsequent open operations on an object to request delete access.
+        /// <para/>
+        /// Otherwise, other processes cannot open the object if they request delete access.
+        /// <para/>
+        /// If this flag is not specified, but the object has been opened for delete access, the function fails.
+        /// </summary>
+        Delete = 0x00000004
+    }
+
+    [Flags]
+        public enum ConsoleMode : uint
+        {
+            /// <summary>
+            /// CTRL+C is processed by the system and is not placed in the input buffer.
+            /// <para/>
+            /// If the input buffer is being read by
+            /// `<see cref="ReadConsole(SafeFileHandle, StringBuilder, uint, out uint, IntPtr)"/>`, other control
+            /// keys are processed by the system and are not returned in the ReadConsole buffer.
+            /// <para/>
+            /// If the <see cref="LineInput"/> mode is also enabled, backspace, carriage return, and line feed
+            /// characters are handled by the system.
+            /// </summary>
+            ProcessedInput = 0x0001,
+
+            /// <summary>
+            /// The `<see cref="ReadConsole(SafeFileHandle, StringBuilder, uint, out uint, IntPtr)"/>` function
+            /// returns only when a carriage return character is read.
+            /// <para/>
+            /// If this mode is disabled, the functions return when one or more characters are available.
+            /// </summary>
+            LineInput = 0x0002,
+
+            /// <summary>
+            /// Characters read by the `<see cref="ReadConsole(SafeFileHandle, StringBuilder, uint, out uint, IntPtr)"/>`
+            /// function are written to the active screen buffer as they are read.
+            /// <para/>
+            /// This mode can be used only if the <see cref="LineInput"/> mode is also enabled.
+            /// </summary>
+            EchoInput = 0x0004,
+
+            /// <summary>
+            /// User interactions that change the size of the console screen buffer are reported in the
+            /// console's input buffer.
+            /// <para/>
+            /// Information about these events can be read from the input buffer by applications using the
+            /// ReadConsoleInput function, but not by those using `<see cref="ReadConsole(SafeFileHandle, StringBuilder, uint, out uint, IntPtr)"/>`.
+            /// </summary>
+            WindowInput = 0x0008,
+
+            /// <summary>
+            /// If the mouse pointer is within the borders of the console window and the window has the keyboard focus,
+            /// mouse events generated by mouse movement and button presses are placed in the input buffer.
+            /// <para/>
+            /// These events are discarded by
+            /// `<see cref="ReadConsole(SafeFileHandle, StringBuilder, uint, out uint, IntPtr)"/>`, even when this
+            /// mode is enabled.
+            /// </summary>
+            MouseInput = 0x0010,
+
+            /// <summary>
+            /// When enabled, text entered in a console window will be inserted at the current cursor location and all
+            /// text following that location will not be overwritten.
+            /// <para/>
+            /// When disabled, all following text will be overwritten.
+            /// </summary>
+            InsertMode = 0x0020,
+
+            /// <summary>
+            /// This flag enables the user to use the mouse to select and edit text.
+            /// </summary>
+            QuickEdit = 0x0040,
+
+            /// <summary>
+            /// Characters written by the `<see cref="WriteConsole(SafeHandle, StringBuilder, uint, out uint, IntPtr)"/>`
+            /// function or echoed by the ReadFile or ReadConsole function are parsed for ASCII control sequences, and
+            /// the correct action is performed.
+            /// <para/>
+            /// Backspace, tab, bell, carriage return, and line feed characters are processed.
+            /// </summary>
+            ProcessedOuput = 0x0001,
+
+            /// <summary>
+            /// When writing with `<see cref="WriteConsole(SafeHandle, StringBuilder, uint, out uint, IntPtr)"/>` or
+            /// echoing with ReadFile or ReadConsole, the cursor moves to the beginning of the next row when it reaches
+            /// the end of the current row.
+            /// <para/>
+            /// This causes the rows displayed in the console window to scroll up automatically when the cursor advances
+            /// beyond the last row in the window.
+            /// <para/>
+            /// It also causes the contents of the console screen buffer to scroll up (discarding the top row of the
+            /// console screen buffer) when the cursor advances beyond the last row in the console screen buffer.
+            /// <para/>
+            /// If this mode is disabled, the last character in the row is overwritten with any subsequent characters.
+            /// </summary>
+            WrapAtEolOutput = 0x0002,
+
+            AllFlags = ProcessedInput
+                     | LineInput
+                     | EchoInput
+                     | WindowInput
+                     | MouseInput
+                     | InsertMode
+                     | QuickEdit
+                     | ProcessedOuput
+                     | WrapAtEolOutput,
+        }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/Native/Ole32.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/Native/Ole32.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace GitCredentialManager.Interop.Windows.Native
+{
+    public static class Ole32
+    {
+        private const string LibraryName = "ole32.dll";
+
+        public const uint RPC_E_TOO_LATE = 0x80010119;
+
+        [DllImport(LibraryName)]
+        public static extern int CoInitializeSecurity(
+            IntPtr pVoid,
+            int cAuthSvc,
+            IntPtr asAuthSvc,
+            IntPtr pReserved1,
+            RpcAuthnLevel level,
+            RpcImpLevel impers,
+            IntPtr pAuthList,
+            EoAuthnCap dwCapabilities,
+            IntPtr pReserved3);
+
+        public enum RpcAuthnLevel
+        {
+            Default = 0,
+            None = 1,
+            Connect = 2,
+            Call = 3,
+            Pkt = 4,
+            PktIntegrity = 5,
+            PktPrivacy = 6
+        }
+
+        public enum RpcImpLevel
+        {
+            Default = 0,
+            Anonymous = 1,
+            Identify = 2,
+            Impersonate = 3,
+            Delegate = 4
+        }
+
+        public enum EoAuthnCap
+        {
+            None = 0x00,
+            MutualAuth = 0x01,
+            StaticCloaking = 0x20,
+            DynamicCloaking = 0x40,
+            AnyAuthority = 0x80,
+            MakeFullSIC = 0x100,
+            Default = 0x800,
+            SecureRefs = 0x02,
+            AccessControl = 0x04,
+            AppID = 0x08,
+            Dynamic = 0x10,
+            RequireFullSIC = 0x200,
+            AutoImpersonate = 0x400,
+            NoCustomMarshal = 0x2000,
+            DisableAAA = 0x1000
+        }
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/Native/Shell32.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/Native/Shell32.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace GitCredentialManager.Interop.Windows.Native
+{
+    public static class Shell32
+    {
+        private const string LibraryName = "shell32.dll";
+
+        /// <summary>
+        /// Parses a Unicode command line string and returns an array of pointers
+        /// to the command line arguments, along with a count of such arguments,
+        /// in a way that is similar to the standard C run-time argv and argc values.
+        /// </summary>
+        /// <param name="lpCmdLine">
+        /// Pointer to a null-terminated Unicode string that contains the full command line.
+        /// If this parameter is an empty string the function returns the path to the current executable file.
+        /// </param>
+        /// <param name="pNumArgs">
+        /// Pointer to an int that receives the number of array elements returned, similar to argc.
+        /// </param>
+        /// <returns>A pointer to an array of LPWSTR values, similar to argv.</returns>
+        [DllImport("Shell32.dll", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern IntPtr CommandLineToArgvW(IntPtr lpCmdLine, out int pNumArgs);
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/Native/User32.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/Native/User32.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace GitCredentialManager.Interop.Windows.Native
+{
+    public static class User32
+    {
+        private const string LibraryName = "user32.dll";
+
+        public const int UOI_FLAGS = 1;
+        public const int WSF_VISIBLE = 0x0001;
+
+        [DllImport(LibraryName, CallingConvention = CallingConvention.StdCall, SetLastError = true)]
+        public static extern IntPtr GetProcessWindowStation();
+
+        [DllImport(LibraryName, EntryPoint = "GetUserObjectInformation", CallingConvention = CallingConvention.StdCall, SetLastError = true)]
+        public static extern unsafe bool GetUserObjectInformation(IntPtr hObj, int nIndex, void* pvBuffer, uint nLength, ref uint lpnLengthNeeded);
+
+        [DllImport(LibraryName, EntryPoint="SetWindowLong", SetLastError = true)]
+        private static extern IntPtr SetWindowLongPtr32(IntPtr hWnd, int nIndex, IntPtr value);
+
+        [DllImport(LibraryName, EntryPoint="SetWindowLongPtr", SetLastError = true)]
+        private static extern IntPtr SetWindowLongPtr64(IntPtr hWnd, int nIndex, IntPtr value);
+
+        public static IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr value)
+        {
+            if (IntPtr.Size == 8)
+                return SetWindowLongPtr64(hWnd, nIndex, value);
+            else
+                return SetWindowLongPtr32(hWnd, nIndex, value);
+        }
+
+        [DllImport(LibraryName, SetLastError = true)]
+        public static extern bool GetWindowRect(IntPtr hwnd, out RECT lpRect);
+
+        [DllImport(LibraryName, SetLastError = true)]
+        public static extern bool GetClientRect(IntPtr hwnd, out RECT lpRect);
+
+        /// <summary>
+        /// Retrieves the handle to the ancestor of the specified window.
+        /// </summary>
+        /// <param name="hwnd">
+        /// A handle to the window whose ancestor is to be retrieved.
+        /// If this parameter is the desktop window, the function returns NULL.
+        /// </param>
+        /// <param name="flags">The ancestor to be retrieved.</param>
+        /// <returns>The return value is the handle to the ancestor window.</returns>
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern IntPtr GetAncestor(IntPtr hwnd, GetAncestorFlags flags);
+    }
+
+    public enum GetAncestorFlags
+    {
+        /// <summary>
+        /// Retrieves the parent window. This does not include the owner, as it does with the GetParent function.
+        /// </summary>
+        GetParent = 1,
+
+        /// <summary>
+        /// Retrieves the root window by walking the chain of parent windows.
+        /// </summary>
+        GetRoot = 2,
+
+        /// <summary>
+        /// Retrieves the owned root window by walking the chain of parent and owner windows returned by GetParent.
+        /// </summary>
+        GetRootOwner = 3
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct USEROBJECTFLAGS
+    {
+        public int fInherit;
+        public int fReserved;
+        public int dwFlags;
+    }
+
+    public enum WindowLongParam
+    {
+        GWL_WNDPROC = -4,
+        GWL_HINSTANCE = -6,
+        GWL_HWNDPARENT = -8,
+        GWL_ID = -12,
+        GWL_STYLE = -16,
+        GWL_EXSTYLE = -20,
+        GWL_USERDATA = -21
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RECT
+    {
+        public int left;
+        public int top;
+        public int right;
+        public int bottom;
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/Native/Win32Error.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/Native/Win32Error.cs
@@ -1,0 +1,145 @@
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+
+namespace GitCredentialManager.Interop.Windows.Native
+{
+    // https://docs.microsoft.com/en-gb/windows/desktop/Debug/system-error-codes
+
+    /// <summary>
+    /// The System Error Codes are very broad.
+    /// <para/>
+    /// Each one can occur in one of many hundreds of locations in the system.
+    /// <para/>
+    /// Consequently the descriptions of these codes cannot be very specific.
+    /// <para/>
+    /// Use of these codes requires some amount of investigation and analysis.
+    /// <para/>
+    /// You need to note both the programmatic and the run-time context in which these errors occur.
+    /// <para/>
+    /// Because these codes are defined in WinError.h for anyone to use, sometimes the codes are returned by non-system software.
+    /// <para/>
+    /// Sometimes the code is returned by a function deep in the stack and far removed from your code that is handling the error.
+    /// </summary>
+    internal static class Win32Error
+    {
+        /// <summary>
+        /// The operation completed successfully.
+        /// </summary>
+        public const int Success = 0;
+
+        /// <summary>
+        /// The system cannot find the file specified.
+        /// </summary>
+        public const int FileNotFound = 2;
+
+        /// <summary>
+        /// The handle is invalid.
+        /// </summary>
+        public const int InvalidHandle = 6;
+
+        /// <summary>
+        /// Not enough storage is available to process this command.
+        /// </summary>
+        public const int NotEnoughMemory = 8;
+
+        /// <summary>
+        /// A device attached to the system is not functioning.
+        /// </summary>
+        public const int GenericFailure = 31;
+
+        /// <summary>
+        /// The process cannot access the file because it is being used by another process.
+        /// </summary>
+        public const int SharingViolation = 32;
+
+        /// <summary>
+        /// The file exists.
+        /// </summary>
+        public const int FileExists = 80;
+
+        /// <summary>
+        /// The data area passed to a system call is too small.
+        /// </summary>
+        public const int InsufficientBuffer = 122;
+
+        /// <summary>
+        /// Cannot create a file when that file already exists.
+        /// </summary>
+        public const int AlreadyExists = 183;
+
+        /// <summary>
+        /// The implementation is not capable of performing the request.
+        /// </summary>
+        public const int NotCapable = 775;
+
+        /// <summary>
+        /// Element not found.
+        /// </summary>
+        public const int NotFound = 1168;
+
+        /// <summary>
+        /// The operation was canceled by the user.
+        /// </summary>
+        public const int Cancelled = 1223;
+
+        /// <summary>
+        /// A specified logon session does not exist. It may already have been terminated.
+        /// </summary>
+        public const int NoSuchLogonSession = 1312;
+
+        public static int GetLastError(bool success)
+        {
+            if (success)
+            {
+                return Success;
+            }
+
+            return Marshal.GetLastWin32Error();
+        }
+
+        /// <summary>
+        /// Throw an <see cref="InteropException"/> if <paramref name="succeeded"/> is not true.
+        /// </summary>
+        /// <param name="trace2">The application's TRACE2 tracer.</param>
+        /// <param name="succeeded">Windows API return code.</param>
+        /// <param name="defaultErrorMessage">Default error message.</param>
+        /// <exception cref="InteropException">Throw if <paramref name="succeeded"/> is not true.</exception>
+        public static void ThrowIfError(ITrace2 trace2, bool succeeded, string defaultErrorMessage = "Unknown error.")
+        {
+            ThrowIfError(GetLastError(succeeded), defaultErrorMessage, trace2);
+        }
+
+        /// <summary>
+        /// Throw an <see cref="InteropException"/> if <paramref name="succeeded"/> is not true.
+        /// </summary>
+        /// <param name="succeeded">Windows API return code.</param>
+        /// <param name="defaultErrorMessage">Default error message.</param>
+        /// <exception cref="InteropException">Throw if <paramref name="succeeded"/> is not true.</exception>
+        public static void ThrowIfError(bool succeeded, string defaultErrorMessage = "Unknown error.")
+        {
+            ThrowIfError(GetLastError(succeeded), defaultErrorMessage);
+        }
+
+        /// <summary>
+        /// Throw an <see cref="InteropException"/> if <paramref name="error"/> is not <see cref="Success"/>.
+        /// </summary>
+        /// <param name="error">Windows API error code.</param>
+        /// <param name="defaultErrorMessage">Default error message.</param>
+        /// <param name="trace2">The application's TRACE2 tracer.</param>
+        /// <exception cref="InteropException">Throw if <paramref name="error"/> is not <see cref="Success"/>.</exception>
+        public static void ThrowIfError(int error, string defaultErrorMessage = "Unknown error.", ITrace2 trace2 = null)
+        {
+            switch (error)
+            {
+                case Success:
+                    return;
+                default:
+                    // The Win32Exception constructor will automatically get the human-readable
+                    // message for the error code.
+                    if (trace2 != null)
+                        throw new Trace2InteropException(trace2, defaultErrorMessage, new Win32Exception(error));
+                    throw new InteropException(defaultErrorMessage, new Win32Exception(error));
+            }
+        }
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/WindowsCredential.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/WindowsCredential.cs
@@ -1,0 +1,24 @@
+
+namespace GitCredentialManager.Interop.Windows
+{
+    public class WindowsCredential : ICredential
+    {
+        public WindowsCredential(string service, string userName, string password, string targetName)
+        {
+            Service = service;
+            UserName = userName;
+            Password = password;
+            TargetName = targetName;
+        }
+
+        public string Service { get; }
+
+        public string UserName { get; }
+
+        public string Password { get; }
+
+        public string TargetName { get; }
+
+        string ICredential.Account => UserName;
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/WindowsCredentialManager.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/WindowsCredentialManager.cs
@@ -1,0 +1,375 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using GitCredentialManager.Interop.Windows.Native;
+
+namespace GitCredentialManager.Interop.Windows
+{
+    public class WindowsCredentialManager : ICredentialStore
+    {
+        internal const string TargetNameLegacyGenericPrefix = "LegacyGeneric:target=";
+
+        private readonly string _namespace;
+
+        /// <summary>
+        /// Open the Windows Credential Manager vault for the current user.
+        /// </summary>
+        /// <param name="namespace">Optional namespace to scope credential operations.</param>
+        /// <returns>Current user's Credential Manager vault.</returns>
+        public WindowsCredentialManager(string @namespace = null)
+        {
+            PlatformUtils.EnsureWindows();
+            _namespace = @namespace;
+        }
+
+        public IList<string> GetAccounts(string service)
+        {
+            return Enumerate(service, null).Select(x => x.UserName).Distinct().ToList();
+        }
+
+        public ICredential Get(string service, string account)
+        {
+            return Enumerate(service, account).FirstOrDefault();
+        }
+
+        public void AddOrUpdate(string service, string account, string secret)
+        {
+            EnsureArgument.NotNullOrWhiteSpace(service, nameof(service));
+
+            IntPtr existingCredPtr = IntPtr.Zero;
+            IntPtr credBlob = IntPtr.Zero;
+
+            try
+            {
+                // Determine if we need to update an existing credential, which might have
+                // a target name that does not include the account name.
+                //
+                // We first check for the presence of a credential with an account-less
+                // target name.
+                //
+                //  - If such credential exists and *has the same account* then we will
+                //    update that entry.
+                //  - If such credential exists and does *not* have the same account then
+                //    we must create a new entry with the account in the target name.
+                //  - If no such credential exists then we create a new entry with the
+                //    account-less target name.
+                //
+                string targetName = CreateTargetName(service, account: null);
+                if (Advapi32.CredRead(targetName, CredentialType.Generic, 0, out existingCredPtr))
+                {
+                    var existingCred = Marshal.PtrToStructure<Win32Credential>(existingCredPtr);
+                    if (!StringComparer.Ordinal.Equals(existingCred.UserName, account))
+                    {
+                        // Create new entry with the account in the target name
+                        targetName = CreateTargetName(service, account);
+                    }
+                    else
+                    {
+                        // No need to write out credential if the account and secret/password are the same
+                        string existingSecret = existingCred.GetCredentialBlobAsString();
+                        if (StringComparer.Ordinal.Equals(existingSecret, secret))
+                        {
+                            return;
+                        }
+                    }
+                }
+
+                byte[] secretBytes = Encoding.Unicode.GetBytes(secret);
+                credBlob = Marshal.AllocHGlobal(secretBytes.Length);
+                Marshal.Copy(secretBytes, 0, credBlob, secretBytes.Length);
+
+                var newCred = new Win32Credential
+                {
+                    Type = CredentialType.Generic,
+                    TargetName = targetName,
+                    CredentialBlobSize = secretBytes.Length,
+                    CredentialBlob = credBlob,
+                    Persist = CredentialPersist.LocalMachine,
+                    UserName = account,
+                };
+
+                int result = Win32Error.GetLastError(
+                    Advapi32.CredWrite(ref newCred, 0)
+                );
+
+                Win32Error.ThrowIfError(result, "Failed to write item to store.");
+            }
+            finally
+            {
+                if (credBlob != IntPtr.Zero)
+                {
+                    Marshal.FreeHGlobal(credBlob);
+                }
+
+                if (existingCredPtr != IntPtr.Zero)
+                {
+                    Advapi32.CredFree(existingCredPtr);
+                }
+            }
+        }
+
+        public bool Remove(string service, string account)
+        {
+            WindowsCredential credential = Enumerate(service, account).FirstOrDefault();
+
+            if (credential != null)
+            {
+                int result = Win32Error.GetLastError(
+                    Advapi32.CredDelete(credential.TargetName, CredentialType.Generic, 0)
+                );
+
+                switch (result)
+                {
+                    case Win32Error.Success:
+                        return true;
+
+                    case Win32Error.NotFound:
+                        return false;
+
+                    default:
+                        Win32Error.ThrowIfError(result);
+                        return false;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Check if we can persist credentials to for the current process and logon session.
+        /// </summary>
+        /// <returns>True if persistence is possible, false otherwise.</returns>
+        public static bool CanPersist()
+        {
+            uint count = Advapi32.CRED_TYPE_MAXIMUM;
+            var arr = new CredentialPersist[count];
+
+            int result = Win32Error.GetLastError(
+                Advapi32.CredGetSessionTypes(count, arr)
+            );
+
+            CredentialPersist persist = CredentialPersist.None;
+            if (result == Win32Error.Success)
+            {
+                persist = arr[(int)CredentialType.Generic];
+            }
+
+            // If the maximum allowed is anything less than "local machine" then cannot persist credentials.
+            return persist >= CredentialPersist.LocalMachine;
+        }
+
+        private IEnumerable<WindowsCredential> Enumerate(string service, string account)
+        {
+            IntPtr credList = IntPtr.Zero;
+
+            try
+            {
+                int result = Win32Error.GetLastError(
+                    Advapi32.CredEnumerate(
+                        null,
+                        CredentialEnumerateFlags.AllCredentials,
+                        out int count,
+                        out credList)
+                );
+
+                switch (result)
+                {
+                    case Win32Error.Success:
+                        int ptrSize = Marshal.SizeOf<IntPtr>();
+                        for (int i = 0; i < count; i++)
+                        {
+                            IntPtr credPtr = Marshal.ReadIntPtr(credList, i * ptrSize);
+                            Win32Credential credential = Marshal.PtrToStructure<Win32Credential>(credPtr);
+
+                            if (!IsMatch(service, account, credential))
+                            {
+                                continue;
+                            }
+
+                            yield return CreateCredentialFromStructure(credential);
+                        }
+                        break;
+
+                    case Win32Error.NotFound:
+                        yield break;
+
+                    default:
+                        Win32Error.ThrowIfError(result, "Failed to enumerate credentials.");
+                        yield break;
+                }
+            }
+            finally
+            {
+                if (credList != IntPtr.Zero)
+                {
+                    Advapi32.CredFree(credList);
+                }
+            }
+        }
+
+        private WindowsCredential CreateCredentialFromStructure(Win32Credential credential)
+        {
+            string password = credential.GetCredentialBlobAsString();
+
+            // Recover the target name we gave from the internal (raw) target name
+            string targetName = credential.TargetName.TrimUntilIndexOf(TargetNameLegacyGenericPrefix);
+
+            // Recover the service name from the target name
+            string serviceName = targetName;
+            if (!string.IsNullOrWhiteSpace(_namespace))
+            {
+                serviceName = serviceName.TrimUntilIndexOf($"{_namespace}:");
+            }
+
+            // Strip any userinfo component from the service name
+            serviceName = RemoveUriUserInfo(serviceName);
+
+            return new WindowsCredential(serviceName, credential.UserName, password, targetName);
+        }
+
+        public /* for testing */ static string RemoveUriUserInfo(string url)
+        {
+            // To remove the userinfo component we must search for the end of the :// scheme
+            // delimiter, and the start of the @ userinfo delimiter. We don't want to match
+            // any other '@' character however (such as one in the URI path).
+            // To ensure this we only consider an '@' character that exists before the first
+            // '/' character after the scheme delimiter - that is to say the authority-path
+            // separator.
+            //
+            //                authority
+            //              |-----------|
+            //     scheme://userinfo@host/path
+            //
+            int schemeDelimIdx = url.IndexOf(Uri.SchemeDelimiter, StringComparison.Ordinal);
+            if (schemeDelimIdx > 0)
+            {
+                int authorityIdx = schemeDelimIdx + Uri.SchemeDelimiter.Length;
+                int slashIdx = url.IndexOf("/", authorityIdx, StringComparison.Ordinal);
+                int atIdx = url.IndexOf("@", StringComparison.Ordinal);
+
+                // No path component or trailing slash; use end of string
+                if (slashIdx < 0)
+                {
+                    slashIdx = url.Length - 1;
+                }
+
+                // Only if the '@' is before the first slash is this the userinfo delimiter
+                if (0 < atIdx && atIdx < slashIdx)
+                {
+                    return url.Substring(0, authorityIdx) + url.Substring(atIdx + 1);
+                }
+            }
+
+            return url;
+        }
+
+        internal /* for testing */ bool IsMatch(string service, string account, Win32Credential credential)
+        {
+            // Match against the username first
+            if (!string.IsNullOrWhiteSpace(account) &&
+                !StringComparer.Ordinal.Equals(account, credential.UserName))
+            {
+                return false;
+            }
+
+            // Trim the "LegacyGeneric" prefix Windows adds
+            string targetName = credential.TargetName.TrimUntilIndexOf(TargetNameLegacyGenericPrefix);
+            
+            // Only match credentials with the namespace we have been configured with (if any)
+            if (!string.IsNullOrWhiteSpace(_namespace))
+            {
+                string nsPrefix = $"{_namespace}:";
+                if (!targetName.StartsWith(nsPrefix, StringComparison.Ordinal))
+                {
+                    return false;
+                }
+
+                targetName = targetName.Substring(nsPrefix.Length);
+            }
+
+            // If the target name matches the service name exactly then return 'match'
+            if (StringComparer.Ordinal.Equals(service, targetName))
+            {
+                return true;
+            }
+
+            // Try matching the target and service as URIs
+            if (Uri.TryCreate(service, UriKind.Absolute, out Uri serviceUri) &&
+                Uri.TryCreate(targetName, UriKind.Absolute, out Uri targetUri))
+            {
+                // Match scheme/protocol
+                if (!StringComparer.OrdinalIgnoreCase.Equals(serviceUri.Scheme, targetUri.Scheme))
+                {
+                    return false;
+                }
+
+                // Match host name
+                if (!StringComparer.OrdinalIgnoreCase.Equals(serviceUri.Host, targetUri.Host))
+                {
+                    return false;
+                }
+
+                // Match port number
+                if (serviceUri.Port != targetUri.Port)
+                {
+                    return false;
+                }
+
+                // Match path
+                if (!string.IsNullOrWhiteSpace(serviceUri.AbsolutePath) &&
+                    !StringComparer.OrdinalIgnoreCase.Equals(serviceUri.AbsolutePath, targetUri.AbsolutePath))
+                {
+                    return false;
+                }
+
+                // URLs match
+                return true;
+            }
+
+            // Unable to match
+            return false;
+        }
+
+        internal /* for testing */ string CreateTargetName(string service, string account)
+        {
+            var serviceUri = new Uri(service, UriKind.Absolute);
+            var sb = new StringBuilder();
+
+            if (!string.IsNullOrWhiteSpace(_namespace))
+            {
+                sb.AppendFormat("{0}:", _namespace);
+            }
+
+            if (!string.IsNullOrWhiteSpace(serviceUri.Scheme))
+            {
+                sb.AppendFormat("{0}://", serviceUri.Scheme);
+            }
+
+            if (!string.IsNullOrWhiteSpace(account))
+            {
+                string escapedAccount = account.Replace('@', '_');
+                sb.AppendFormat("{0}@", escapedAccount);
+            }
+
+            if (!string.IsNullOrWhiteSpace(serviceUri.Host))
+            {
+                sb.Append(serviceUri.Host);
+            }
+
+            if (!serviceUri.IsDefaultPort)
+            {
+                sb.AppendFormat(":{0}", serviceUri.Port);
+            }
+
+            string trimmedPath = serviceUri.AbsolutePath.TrimEnd('/');
+            if (!string.IsNullOrWhiteSpace(trimmedPath))
+            {
+                sb.Append(trimmedPath);
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/WindowsEnvironment.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/WindowsEnvironment.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace GitCredentialManager.Interop.Windows
+{
+    public class WindowsEnvironment : EnvironmentBase
+    {
+        public WindowsEnvironment(IFileSystem fileSystem)
+            : base(fileSystem) { }
+
+        internal WindowsEnvironment(IFileSystem fileSystem, IReadOnlyDictionary<string, string> variables)
+            : base(fileSystem, variables) { }
+
+        #region EnvironmentBase
+
+        protected override string[] SplitPathVariable(string value)
+        {
+            // Ensure we don't return empty values here - callers may use this as the base
+            // path for `Path.Combine(..)`, for which an empty value means 'current directory'.
+            // We only ever want to use the current directory for path resolution explicitly.
+            return value.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+        }
+
+        public override void AddDirectoryToPath(string directoryPath, EnvironmentVariableTarget target)
+        {
+            // Read the current PATH variable, not the cached one
+            string currentValue = Environment.GetEnvironmentVariable("PATH", target) ?? string.Empty;
+
+            // Append directory to the end
+            var sb = new StringBuilder();
+            sb.Append(currentValue);
+            if (!currentValue.EndsWith(";"))
+            {
+                sb.Append(';');
+            }
+            sb.Append(directoryPath);
+
+            string newValue = sb.ToString();
+
+            // Update the real system immediately
+            Environment.SetEnvironmentVariable("PATH", newValue, target);
+
+            // Update the cached PATH variable to the latest value (as well as all other variables)
+            Refresh();
+        }
+
+        public override void RemoveDirectoryFromPath(string directoryPath, EnvironmentVariableTarget target)
+        {
+            // Read the current PATH variable, not the cached one
+            string currentValue = Environment.GetEnvironmentVariable("PATH", target) ?? string.Empty;
+
+            // Only need to update PATH if it does indeed contain the parent directory
+            if (directoryPath != null && currentValue.IndexOf(directoryPath, StringComparison.OrdinalIgnoreCase) > -1)
+            {
+                // Cut out the directory path
+                string newValue = currentValue.TrimMiddle(directoryPath, StringComparison.OrdinalIgnoreCase);
+
+                // Update the real system immediately
+                Environment.SetEnvironmentVariable("PATH", newValue, target);
+
+                // Update the cached PATH variable to the latest value (as well as all other variables)
+                Refresh();
+            }
+        }
+
+        #endregion
+
+        protected override IReadOnlyDictionary<string, string> GetCurrentVariables()
+        {
+            // On Windows it is technically possible to get env vars which differ only by case
+            // even though the general assumption is that they are case insensitive on Windows.
+            // For example, some of the standard .NET types like System.Diagnostics.Process
+            // will fail to start a process on Windows if given duplicate environment variables.
+            // See this issue for more information: https://github.com/dotnet/corefx/issues/13146
+
+            // We should de-duplicate by setting the string comparer to OrdinalIgnoreCase.
+            var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            var variables = Environment.GetEnvironmentVariables();
+
+            foreach (var key in variables.Keys)
+            {
+                if (key is string name && variables[key] is string value)
+                {
+                    dict[name] = value;
+                }
+            }
+
+            return dict;
+        }
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/WindowsFileSystem.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/WindowsFileSystem.cs
@@ -1,0 +1,24 @@
+using System;
+using System.IO;
+
+namespace GitCredentialManager.Interop.Windows
+{
+    public class WindowsFileSystem : FileSystem
+    {
+        public override bool IsSamePath(string a, string b)
+        {
+            if (string.IsNullOrWhiteSpace(a) || string.IsNullOrWhiteSpace(b))
+            {
+                return false;
+            }
+
+            a = Path.GetFullPath(a);
+            b = Path.GetFullPath(b);
+
+            // Note: we do not resolve or handle symlinks on Windows
+            // because they require administrator permissions to even create!
+
+            return StringComparer.OrdinalIgnoreCase.Equals(a, b);
+        }
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/WindowsProcessManager.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/WindowsProcessManager.cs
@@ -1,0 +1,21 @@
+namespace GitCredentialManager.Interop.Windows;
+
+public class WindowsProcessManager : ProcessManager
+{
+    public WindowsProcessManager(ITrace2 trace2) : base(trace2)
+    {
+        PlatformUtils.EnsureWindows();
+    }
+
+    public override ChildProcess CreateProcess(string path, string args, bool useShellExecute, string workingDirectory)
+    {
+        // If we're asked to start a WSL executable we must launch via the wsl.exe command tool
+        if (!useShellExecute && WslUtils.IsWslPath(path))
+        {
+            string wslPath = WslUtils.ConvertToDistroPath(path, out string distro);
+            return WslUtils.CreateWslProcess(distro, $"{wslPath} {args}", Trace2, workingDirectory);
+        }
+
+        return base.CreateProcess(path, args, useShellExecute, workingDirectory);
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/WindowsSessionManager.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/WindowsSessionManager.cs
@@ -1,0 +1,42 @@
+using System;
+using GitCredentialManager.Interop.Windows.Native;
+
+namespace GitCredentialManager.Interop.Windows
+{
+    public class WindowsSessionManager : SessionManager
+    {
+        public WindowsSessionManager(IEnvironment env, IFileSystem fs) : base(env, fs)
+        {
+            PlatformUtils.EnsureWindows();
+        }
+
+        public override unsafe bool IsDesktopSession
+        {
+            get
+            {
+                // Environment.UserInteractive is hard-coded to return true for POSIX and Windows platforms on .NET Core 2.x and 3.x.
+                // In .NET 5 the implementation on Windows has been 'fixed', but still POSIX versions always return true.
+                //
+                // This code is lifted from the .NET 5 targeting dotnet/runtime implementation for Windows:
+                // https://github.com/dotnet/runtime/blob/cf654f08fb0078a96a4e414a0d2eab5e6c069387/src/libraries/System.Private.CoreLib/src/System/Environment.Windows.cs#L125-L145
+
+                // Per documentation of GetProcessWindowStation, this handle should not be closed
+                IntPtr handle = User32.GetProcessWindowStation();
+                if (handle != IntPtr.Zero)
+                {
+                    USEROBJECTFLAGS flags = default;
+                    uint dummy = 0;
+                    if (User32.GetUserObjectInformation(handle, User32.UOI_FLAGS, &flags,
+                        (uint) sizeof(USEROBJECTFLAGS), ref dummy))
+                    {
+                        return (flags.dwFlags & User32.WSF_VISIBLE) != 0;
+                    }
+                }
+
+                // If we can't determine, return true optimistically
+                // This will include cases like Windows Nano which do not expose WindowStations
+                return true;
+            }
+        }
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/WindowsSettings.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/WindowsSettings.cs
@@ -1,0 +1,56 @@
+
+namespace GitCredentialManager.Interop.Windows
+{
+    /// <summary>
+    /// Reads settings from Git configuration, environment variables, and defaults from the Windows Registry.
+    /// </summary>
+    public class WindowsSettings : Settings
+    {
+        private readonly ITrace _trace;
+
+        public WindowsSettings(IEnvironment environment, IGit git, ITrace trace)
+            : base(environment, git)
+        {
+            EnsureArgument.NotNull(trace, nameof(trace));
+            _trace = trace;
+
+            PlatformUtils.EnsureWindows();
+        }
+
+        protected override bool TryGetExternalDefault(string section, string scope, string property, out string value)
+        {
+            value = null;
+
+#if NETFRAMEWORK
+            // Check for machine (HKLM) registry keys that match the Git configuration name.
+            // These can be set by system administrators via Group Policy, so make useful defaults.
+            using (Microsoft.Win32.RegistryKey configKey = Microsoft.Win32.Registry.LocalMachine.OpenSubKey(Constants.WindowsRegistry.HKConfigurationPath))
+            {
+                if (configKey is null)
+                {
+                    // No configuration key exists
+                    return false;
+                }
+
+                string name = string.IsNullOrWhiteSpace(scope)
+                    ? $"{section}.{property}"
+                    : $"{section}.{scope}.{property}";
+
+                object registryValue = configKey.GetValue(name);
+                if (registryValue is null)
+                {
+                    // No property exists
+                    return false;
+                }
+
+                value = registryValue.ToString();
+                _trace.WriteLine($"Default setting found in registry: {name}={value}");
+
+                return true;
+            }
+#else
+            return base.TryGetExternalDefault(section, scope, property, out value);
+#endif
+        }
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/WindowsSystemPrompts.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/WindowsSystemPrompts.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+using GitCredentialManager.Interop.Windows.Native;
+
+namespace GitCredentialManager.Interop.Windows
+{
+    public class WindowsSystemPrompts : ISystemPrompts
+    {
+        private IntPtr _parentHwd = IntPtr.Zero;
+
+        public object ParentWindowId
+        {
+            get => _parentHwd.ToString();
+            set => _parentHwd = ConvertUtils.TryToInt32(value, out int ptr) ? new IntPtr(ptr) : IntPtr.Zero;
+        }
+
+        public bool ShowCredentialPrompt(string resource, string userName, out ICredential credential)
+        {
+            EnsureArgument.NotNullOrWhiteSpace(resource, nameof(resource));
+
+            string message = $"Enter credentials for '{resource}'";
+
+            var credUiInfo = new CredUi.CredentialUiInfo
+            {
+                BannerArt = IntPtr.Zero,
+                CaptionText = "Git Credential Manager", // TODO: make this a parameter?
+                Parent = _parentHwd,
+                MessageText = message,
+                Size = Marshal.SizeOf(typeof(CredUi.CredentialUiInfo))
+            };
+
+            var packFlags = CredUi.CredentialPackFlags.None;
+            var uiFlags = CredUi.CredentialUiWindowsFlags.Generic;
+            if (!string.IsNullOrEmpty(userName))
+            {
+                // If we are given a username, pre-populate the dialog with the given value
+                uiFlags |= CredUi.CredentialUiWindowsFlags.InCredOnly;
+            }
+
+            IntPtr inBufferPtr = IntPtr.Zero;
+            uint inBufferSize;
+
+            try
+            {
+                CreateCredentialInfoBuffer(userName, packFlags, out inBufferSize, out inBufferPtr);
+
+                return DisplayCredentialPrompt(ref credUiInfo, ref packFlags, inBufferPtr, inBufferSize, false, uiFlags, out credential);
+            }
+            finally
+            {
+                if (inBufferPtr != IntPtr.Zero)
+                {
+                    Marshal.FreeHGlobal(inBufferPtr);
+                }
+            }
+        }
+
+        private static void CreateCredentialInfoBuffer(string userName, CredUi.CredentialPackFlags flags, out uint inBufferSize, out IntPtr inBufferPtr)
+        {
+            // Windows Credential API calls require at least an empty string; not null
+            userName = userName ?? string.Empty;
+
+            int desiredBufSize = 0;
+
+            // Execute with a null packed credentials pointer to determine the required buffer size.
+            // This method always returns false when determining the buffer size so we only fail if the size is not strictly positive.
+            CredUi.CredPackAuthenticationBuffer(flags, userName, string.Empty, IntPtr.Zero, ref desiredBufSize);
+            Win32Error.ThrowIfError(desiredBufSize > 0, "Unable to determine credential buffer size.");
+
+            // Create a buffer of the desired size and pass the pointer and size back to the caller
+            inBufferSize = (uint) desiredBufSize;
+            inBufferPtr = Marshal.AllocHGlobal(desiredBufSize);
+
+            Win32Error.ThrowIfError(
+                CredUi.CredPackAuthenticationBuffer(flags, userName, string.Empty, inBufferPtr, ref desiredBufSize),
+                "Unable to write to credential buffer."
+            );
+        }
+
+        private static bool DisplayCredentialPrompt(
+            ref CredUi.CredentialUiInfo credUiInfo,
+            ref CredUi.CredentialPackFlags packFlags,
+            IntPtr inBufferPtr,
+            uint inBufferSize,
+            bool saveCredentials,
+            CredUi.CredentialUiWindowsFlags uiFlags,
+            out ICredential credential)
+        {
+            uint authPackage = 0;
+            IntPtr outBufferPtr = IntPtr.Zero;
+            uint outBufferSize;
+
+            try
+            {
+                // Open a standard Windows authentication dialog to acquire username and password credentials
+                int error = CredUi.CredUIPromptForWindowsCredentials(
+                    ref credUiInfo,
+                    0,
+                    ref authPackage,
+                    inBufferPtr,
+                    inBufferSize,
+                    out outBufferPtr,
+                    out outBufferSize,
+                    ref saveCredentials,
+                    uiFlags);
+
+                switch (error)
+                {
+                    case Win32Error.Cancelled:
+                        credential = null;
+                        return false;
+                    default:
+                        Win32Error.ThrowIfError(error, "Failed to show credential prompt.");
+                        break;
+                }
+
+                int maxUserLength = 512;
+                int maxPassLength = 512;
+                int maxDomainLength = 256;
+                var usernameBuffer = new StringBuilder(maxUserLength);
+                var domainBuffer = new StringBuilder(maxDomainLength);
+                var passwordBuffer = new StringBuilder(maxPassLength);
+
+                // Unpack the result
+                Win32Error.ThrowIfError(
+                    CredUi.CredUnPackAuthenticationBuffer(
+                        packFlags,
+                        outBufferPtr,
+                        outBufferSize,
+                        usernameBuffer,
+                        ref maxUserLength,
+                        domainBuffer,
+                        ref maxDomainLength,
+                        passwordBuffer,
+                        ref maxPassLength),
+                    "Failed to unpack credential buffer."
+                );
+
+                // Return the plaintext credential strings to the caller
+                string userName = usernameBuffer.ToString();
+                string password = passwordBuffer.ToString();
+
+                credential = new GitCredential(userName, password);
+                return true;
+            }
+            finally
+            {
+                if (outBufferPtr != IntPtr.Zero)
+                {
+                    Marshal.FreeHGlobal(outBufferPtr);
+                }
+            }
+        }
+    }
+}

--- a/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/WindowsTerminal.cs
+++ b/src/Core/Interop/src/shared/Core/Interop/src/shared/Core/Interop/Windows/WindowsTerminal.cs
@@ -1,0 +1,221 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+using GitCredentialManager.Interop.Windows.Native;
+using Microsoft.Win32.SafeHandles;
+
+namespace GitCredentialManager.Interop.Windows
+{
+    /// <summary>
+    /// Represents a thin wrapper around the Windows console device.
+    /// </summary>
+    public class WindowsTerminal : ITerminal
+    {
+        // ReadConsole 32768 fail, 32767 OK @linquize [https://github.com/Microsoft/Git-Credential-Manager-for-Windows/commit/a62b9a19f430d038dcd85a610d97e5f763980f85]
+        private const int BufferReadSize = 16 * 1024;
+        private const string ConsoleInName = "CONIN$";
+        private const string ConsoleOutName = "CONOUT$";
+
+        private readonly ITrace _trace;
+        private readonly ITrace2 _trace2;
+
+        public WindowsTerminal(ITrace trace, ITrace2 trace2)
+        {
+            PlatformUtils.EnsureWindows();
+
+            _trace = trace;
+            _trace2 = trace2;
+        }
+
+        public void WriteLine(string format, params object[] args)
+        {
+            var fileAccessFlags = FileAccess.GenericRead
+                                | FileAccess.GenericWrite;
+            var fileAttributes = FileAttributes.Normal;
+            var fileCreationDisposition = FileCreationDisposition.OpenExisting;
+            var fileShareFlags = FileShare.Read
+                               | FileShare.Write;
+
+            using (SafeFileHandle stdout = Kernel32.CreateFile(fileName: ConsoleOutName,
+                                                          desiredAccess: fileAccessFlags,
+                                                              shareMode: fileShareFlags,
+                                                     securityAttributes: IntPtr.Zero,
+                                                    creationDisposition: fileCreationDisposition,
+                                                     flagsAndAttributes: fileAttributes,
+                                                           templateFile: IntPtr.Zero))
+            {
+                if (stdout.IsInvalid)
+                {
+                    _trace.WriteLine("Not a TTY, abandoning write line.");
+                    return;
+                }
+
+                var sb = new StringBuilder();
+                sb.AppendFormat(format, args);
+                sb.AppendLine();
+
+                if (!Kernel32.WriteConsole(buffer: sb,
+                              consoleOutputHandle: stdout,
+                             numberOfCharsToWrite: (uint) sb.Length,
+                             numberOfCharsWritten: out uint written,
+                                         reserved: IntPtr.Zero))
+                {
+                    Win32Error.ThrowIfError(Marshal.GetLastWin32Error(), trace2: _trace2);
+                }
+            }
+        }
+
+        public string Prompt(string prompt)
+        {
+            return Prompt(prompt, echo: true);
+        }
+
+        public string PromptSecret(string prompt)
+        {
+            return Prompt(prompt, echo: false);
+        }
+
+        private string Prompt(string prompt, bool echo)
+        {
+            var fileAccessFlags = FileAccess.GenericRead
+                                | FileAccess.GenericWrite;
+            var fileAttributes = FileAttributes.Normal;
+            var fileCreationDisposition = FileCreationDisposition.OpenExisting;
+            var fileShareFlags = FileShare.Read
+                               | FileShare.Write;
+
+            using (SafeFileHandle stdout = Kernel32.CreateFile(fileName: ConsoleOutName,
+                                                          desiredAccess: fileAccessFlags,
+                                                              shareMode: fileShareFlags,
+                                                     securityAttributes: IntPtr.Zero,
+                                                    creationDisposition: fileCreationDisposition,
+                                                     flagsAndAttributes: fileAttributes,
+                                                           templateFile: IntPtr.Zero))
+            using (SafeFileHandle stdin  = Kernel32.CreateFile(fileName: ConsoleInName,
+                                                          desiredAccess: fileAccessFlags,
+                                                              shareMode: fileShareFlags,
+                                                     securityAttributes: IntPtr.Zero,
+                                                    creationDisposition: fileCreationDisposition,
+                                                     flagsAndAttributes: fileAttributes,
+                                                           templateFile: IntPtr.Zero))
+            {
+                string input;
+                var sb = new StringBuilder(BufferReadSize);
+                uint read = 0;
+                uint written = 0;
+
+                if (stdin.IsInvalid || stdout.IsInvalid)
+                {
+                    _trace.WriteLine("Not a TTY, abandoning prompt.");
+                    return null;
+                }
+
+                // Prompt the user
+                sb.Append($"{prompt}: ");
+                if (!Kernel32.WriteConsole(buffer: sb,
+                              consoleOutputHandle: stdout,
+                             numberOfCharsToWrite: (uint) sb.Length,
+                             numberOfCharsWritten: out written,
+                                         reserved: IntPtr.Zero))
+                {
+                    Win32Error.ThrowIfError(Marshal.GetLastWin32Error(), "Failed to write prompt text", _trace2);
+                }
+
+                sb.Clear();
+
+                // Read input from the user
+                using (new TtyContext(_trace, _trace2, stdin, echo))
+                {
+                    if (!Kernel32.ReadConsole(buffer: sb,
+                                  consoleInputHandle: stdin,
+                                 numberOfCharsToRead: BufferReadSize,
+                                   numberOfCharsRead: out read,
+                                            reserved: IntPtr.Zero))
+                    {
+                        Win32Error.ThrowIfError(Marshal.GetLastWin32Error(),
+                            "Unable to read prompt input from standard input", _trace2);
+                    }
+
+                    // Record input from the user into local storage, stripping any EOL chars
+                    input = sb.ToString(0, (int) read);
+                    input = input.Trim('\n', '\r').Trim('\n');
+
+                    sb.Clear();
+                }
+
+                // Write the final newline to stdout manually if we had disabled echo
+                if (!echo)
+                {
+                    sb.Append(Environment.NewLine);
+                    if (!Kernel32.WriteConsole(buffer: sb,
+                                  consoleOutputHandle: stdout,
+                                 numberOfCharsToWrite: (uint) sb.Length,
+                                 numberOfCharsWritten: out written,
+                                             reserved: IntPtr.Zero))
+                    {
+                        Win32Error.ThrowIfError(Marshal.GetLastWin32Error(),
+                            "Failed to write final newline in secret prompting", _trace2);
+                    }
+                }
+
+                return input;
+            }
+        }
+
+        private class TtyContext : IDisposable
+        {
+            private readonly ITrace _trace;
+            private readonly ITrace2 _trace2;
+            private readonly SafeFileHandle _stream;
+
+            private ConsoleMode _originalMode;
+            private bool _isDisposed;
+
+            public TtyContext(ITrace trace, ITrace2 trace2, SafeFileHandle stream, bool echo)
+            {
+                EnsureArgument.NotNull(stream, nameof(stream));
+
+                _trace = trace;
+                _trace2 = trace2;
+                _stream = stream;
+
+                // Capture current console mode so we can restore it later
+                ConsoleMode consoleMode;
+                if (!Kernel32.GetConsoleMode(consoleMode: out consoleMode, consoleHandle: stream))
+                {
+                    Win32Error.ThrowIfError(Marshal.GetLastWin32Error(), "Failed to get initial console mode", trace2);
+                }
+
+                _originalMode = consoleMode;
+
+                // Set desired echo state
+                _trace.WriteLine($"Setting console echo state to '{echo}'");
+                if (!echo)
+                {
+                    ConsoleMode newConsoleMode = consoleMode ^ ConsoleMode.EchoInput;
+                    if (!Kernel32.SetConsoleMode(consoleMode: newConsoleMode, consoleHandle: _stream))
+                    {
+                        Win32Error.ThrowIfError(
+                            Marshal.GetLastWin32Error(), "Failed to set console mode", trace2);
+                    }
+                }
+            }
+
+            public void Dispose()
+            {
+                if (_isDisposed)
+                {
+                    return;
+                }
+
+                // Restore original console mode
+                if (!Kernel32.SetConsoleMode(consoleMode: _originalMode, consoleHandle: _stream))
+                {
+                    _trace.WriteLine("Failed to restore console mode");
+                }
+
+                _isDisposed = true;
+            }
+        }
+    }
+}

--- a/src/Core/NameValueCollectionExtensions.cs
+++ b/src/Core/NameValueCollectionExtensions.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+
+namespace GitCredentialManager
+{
+    public static class NameValueCollectionExtensions
+    {
+        public static IDictionary<string, string> ToDictionary(this NameValueCollection collection, IEqualityComparer<string> comparer = null)
+        {
+            var dict = new Dictionary<string, string>(comparer ?? StringComparer.Ordinal);
+
+            foreach (string key in collection.AllKeys)
+            {
+                dict[key] = collection[key];
+            }
+
+            return dict;
+        }
+    }
+}

--- a/src/Core/PlaintextCredentialStore.cs
+++ b/src/Core/PlaintextCredentialStore.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace GitCredentialManager
+{
+    public class PlaintextCredentialStore : ICredentialStore
+    {
+        public PlaintextCredentialStore(IFileSystem fileSystem, string storeRoot, string @namespace = null)
+        {
+            EnsureArgument.NotNull(fileSystem, nameof(fileSystem));
+            EnsureArgument.NotNullOrWhiteSpace(storeRoot, nameof(storeRoot));
+
+            FileSystem = fileSystem;
+            StoreRoot = storeRoot;
+            Namespace = @namespace;
+        }
+
+        protected IFileSystem FileSystem { get; }
+        protected string StoreRoot { get; }
+        protected string Namespace { get; }
+        protected virtual string CredentialFileExtension => ".credential";
+
+        public IList<string> GetAccounts(string service)
+        {
+            return Enumerate(service, null).Select(x => x.Account).Distinct().ToList();
+        }
+
+        public ICredential Get(string service, string account)
+        {
+            return Enumerate(service, account).FirstOrDefault();
+        }
+
+        public void AddOrUpdate(string service, string account, string secret)
+        {
+            // Ensure the store root exists and permissions are set
+            EnsureStoreRoot();
+
+            FileCredential existingCredential = Enumerate(service, account).FirstOrDefault();
+
+            // No need to update existing credential if nothing has changed
+            if (existingCredential != null &&
+                StringComparer.Ordinal.Equals(account, existingCredential.Account) &&
+                StringComparer.Ordinal.Equals(secret, existingCredential.Password))
+            {
+                return;
+            }
+
+            string serviceSlug = CreateServiceSlug(service);
+            string servicePath = Path.Combine(StoreRoot, serviceSlug);
+
+            if (!FileSystem.DirectoryExists(servicePath))
+            {
+                FileSystem.CreateDirectory(servicePath);
+            }
+
+            string fullPath = Path.Combine(servicePath, $"{account}{CredentialFileExtension}");
+            var credential = new FileCredential(fullPath, service, account, secret);
+            SerializeCredential(credential);
+        }
+
+        public bool Remove(string service, string account)
+        {
+            foreach (FileCredential credential in Enumerate(service, account))
+            {
+                // Only delete the first match
+                FileSystem.DeleteFile(credential.FullPath);
+                return true;
+            }
+
+            return false;
+        }
+
+        protected virtual bool TryDeserializeCredential(string path, out FileCredential credential)
+        {
+            string text;
+            using (var stream = FileSystem.OpenFileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var reader = new StreamReader(stream))
+            {
+                text = reader.ReadToEnd();
+            }
+
+            int line1Idx = text.IndexOf(Environment.NewLine, StringComparison.OrdinalIgnoreCase);
+            if (line1Idx > 0)
+            {
+                // Password is the first line
+                string password = text.Substring(0, line1Idx);
+
+                // All subsequent lines are metadata/attributes
+                string attrText = text.Substring(line1Idx + Environment.NewLine.Length);
+                using var attrReader = new StringReader(attrText);
+                IDictionary<string, string> attrs = attrReader.ReadDictionary(StringComparer.OrdinalIgnoreCase);
+
+                // Account is optional
+                attrs.TryGetValue("account", out string account);
+
+                // Service is required
+                if (attrs.TryGetValue("service", out string service))
+                {
+                    credential = new FileCredential(path, service, account, password);
+                    return true;
+                }
+            }
+
+            credential = null;
+            return false;
+        }
+
+        protected virtual void SerializeCredential(FileCredential credential)
+        {
+            // Ensure the parent directory exists
+            string parentDir = Path.GetDirectoryName(credential.FullPath);
+            if (!FileSystem.DirectoryExists(parentDir))
+            {
+                FileSystem.CreateDirectory(parentDir);
+            }
+
+            using (var stream = FileSystem.OpenFileStream(credential.FullPath, FileMode.Create, FileAccess.Write, FileShare.None))
+            using (var writer = new StreamWriter(stream))
+            {
+                writer.WriteLine(credential.Password);
+                writer.WriteLine("service={0}", credential.Service);
+                writer.WriteLine("account={0}", credential.Account);
+                writer.Flush();
+            }
+        }
+
+        private IEnumerable<FileCredential> Enumerate(string service, string account)
+        {
+            string serviceSlug = CreateServiceSlug(service);
+            string searchPath = Path.Combine(StoreRoot, serviceSlug);
+            bool anyAccount = string.IsNullOrWhiteSpace(account);
+
+            if (!FileSystem.DirectoryExists(searchPath))
+            {
+                yield break;
+            }
+
+            IEnumerable<string> allFiles = FileSystem.EnumerateFiles(searchPath, $"*{CredentialFileExtension}");
+
+            foreach (string fullPath in allFiles)
+            {
+                string accountFile = Path.GetFileNameWithoutExtension(fullPath);
+                if (anyAccount || StringComparer.OrdinalIgnoreCase.Equals(account, accountFile))
+                {
+                    // Validate the credential metadata also matches our search
+                    if (TryDeserializeCredential(fullPath, out FileCredential credential) &&
+                        StringComparer.OrdinalIgnoreCase.Equals(service, credential.Service) &&
+                        (anyAccount || StringComparer.OrdinalIgnoreCase.Equals(account, credential.Account)))
+                    {
+                        yield return credential;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Ensure the store root directory exists. If it does not, create a new directory with
+        /// permissions that only permit the owner to read/write/execute. Permissions on an existing
+        /// directory are not modified.
+        /// </summary>
+        private void EnsureStoreRoot()
+        {
+            if (FileSystem.DirectoryExists(StoreRoot))
+            {
+                // Don't touch the permissions on the existing directory
+                return;
+            }
+
+            FileSystem.CreateDirectory(StoreRoot);
+
+            // We only set file system permissions on POSIX platforms
+            if (!PlatformUtils.IsPosix())
+            {
+                return;
+            }
+
+            // Set store root permissions such that only the owner can read/write/execute
+            var mode = Interop.Posix.Native.NativeFileMode.S_IRUSR |
+                       Interop.Posix.Native.NativeFileMode.S_IWUSR |
+                       Interop.Posix.Native.NativeFileMode.S_IXUSR;
+
+            // Ignore the return code.. this is a best effort only
+            Interop.Posix.Native.Stat.chmod(StoreRoot, mode);
+        }
+
+        private string CreateServiceSlug(string service)
+        {
+            var sb = new StringBuilder();
+            char sep = Path.DirectorySeparatorChar;
+
+            if (!string.IsNullOrWhiteSpace(Namespace))
+            {
+                sb.AppendFormat("{0}{1}", Namespace, sep);
+            }
+
+            if (Uri.TryCreate(service, UriKind.Absolute, out Uri serviceUri))
+            {
+                sb.AppendFormat("{0}{1}", serviceUri.Scheme, sep);
+                sb.AppendFormat("{0}", serviceUri.Host);
+
+                if (!serviceUri.IsDefaultPort)
+                {
+                    sb.Append(PlatformUtils.IsWindows() ? '-' : ':');
+                    sb.Append(serviceUri.Port);
+                }
+
+                sb.Append(serviceUri.AbsolutePath.Replace('/', sep));
+            }
+            else
+            {
+                sb.Append(service);
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/src/Core/PlatformUtils.cs
+++ b/src/Core/PlatformUtils.cs
@@ -1,0 +1,550 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using GitCredentialManager.Interop.Posix.Native;
+
+namespace GitCredentialManager
+{
+    public static class PlatformUtils
+    {
+        /// <summary>
+        /// Get information about the current platform (OS and CLR details).
+        /// </summary>
+        /// <returns>Platform information.</returns>
+        public static PlatformInformation GetPlatformInformation(ITrace2 trace2)
+        {
+            string osType = GetOSType();
+            string osVersion = GetOSVersion(trace2);
+            string cpuArch = GetCpuArchitecture();
+            string clrVersion = RuntimeInformation.FrameworkDescription;
+
+            return new PlatformInformation(osType, osVersion, cpuArch, clrVersion);
+        }
+
+        public static bool IsDevBox()
+        {
+            if (!IsWindows())
+            {
+                return false;
+            }
+
+#if NETFRAMEWORK
+            // Check for machine (HKLM) registry keys for Cloud PC indicators
+            // Note that the keys are only found in the 64-bit registry view
+            using (Microsoft.Win32.RegistryKey hklm64 = Microsoft.Win32.RegistryKey.OpenBaseKey(Microsoft.Win32.RegistryHive.LocalMachine, Microsoft.Win32.RegistryView.Registry64))
+            using (Microsoft.Win32.RegistryKey w365Key = hklm64.OpenSubKey(Constants.WindowsRegistry.HKWindows365Path))
+            {
+                if (w365Key is null)
+                {
+                    // No Windows365 key exists
+                    return false;
+                }
+
+                object w365Value = w365Key.GetValue(Constants.WindowsRegistry.IsW365EnvironmentKeyName);
+                string partnerValue = w365Key.GetValue(Constants.WindowsRegistry.W365PartnerIdKeyName)?.ToString();
+
+                return w365Value is not null && Guid.TryParse(partnerValue, out Guid partnerId) && partnerId == Constants.DevBoxPartnerId;
+            }
+#else
+            return false;
+#endif
+        }
+
+        /// <summary>
+        /// Returns true if the current process is running on an ARM processor.
+        /// </summary>
+        /// <returns>True if ARM(v6,hf) or ARM64, false otherwise</returns>
+        public static bool IsArm()
+        {
+            switch (RuntimeInformation.OSArchitecture)
+            {
+                case Architecture.Arm:
+                case Architecture.Arm64:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        public static bool IsWindowsBrokerSupported()
+        {
+            if (!IsWindows())
+            {
+                return false;
+            }
+
+            // Implementation of version checking was taken from:
+            // https://github.com/dotnet/runtime/blob/6578f257e3be2e2144a65769706e981961f0130c/src/libraries/System.Private.CoreLib/src/System/Environment.Windows.cs#L110-L122
+            //
+            // Note that we cannot use Environment.OSVersion in .NET Framework (or Core versions less than 5.0) as
+            // the implementation in those versions "lies" about Windows versions > 8.1 if there is no application manifest.
+            if (RtlGetVersionEx(out RTL_OSVERSIONINFOEX osvi) != 0)
+            {
+                return false;
+            }
+
+            // Windows major version 10 is required for WAM
+            if (osvi.dwMajorVersion < 10)
+            {
+                return false;
+            }
+
+            // Specific minimum build number is different between Windows Server and Client SKUs
+            const int minClientBuildNumber = 15063;
+            const int minServerBuildNumber = 17763; // Server 2019
+
+            switch (osvi.wProductType)
+            {
+                case VER_NT_WORKSTATION:
+                    return osvi.dwBuildNumber >= minClientBuildNumber;
+
+                case VER_NT_SERVER:
+                case VER_NT_DOMAIN_CONTROLLER:
+                    return osvi.dwBuildNumber >= minServerBuildNumber;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Check if the current Operating System is macOS.
+        /// </summary>
+        /// <returns>True if running on macOS, false otherwise.</returns>
+        public static bool IsMacOS()
+        {
+            return RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+        }
+
+        /// <summary>
+        /// Check if the current Operating System is Windows.
+        /// </summary>
+        /// <returns>True if running on Windows, false otherwise.</returns>
+        public static bool IsWindows()
+        {
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        }
+
+        /// <summary>
+        /// Check if the current Operating System is Linux-based.
+        /// </summary>
+        /// <returns>True if running on a Linux distribution, false otherwise.</returns>
+        public static bool IsLinux()
+        {
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+        }
+
+        /// <summary>
+        /// Check if the current Operating System is POSIX-compliant.
+        /// </summary>
+        /// <returns>True if running on a POSIX-compliant Operating System, false otherwise.</returns>
+        public static bool IsPosix()
+        {
+            return IsMacOS() || IsLinux();
+        }
+
+        /// <summary>
+        /// Ensure the current Operating System is macOS, fail otherwise.
+        /// </summary>
+        /// <exception cref="PlatformNotSupportedException">Thrown if the current OS is not macOS.</exception>
+        public static void EnsureMacOS()
+        {
+            if (!IsMacOS())
+            {
+                throw new PlatformNotSupportedException();
+            }
+        }
+
+        /// <summary>
+        /// Ensure the current Operating System is Windows, fail otherwise.
+        /// </summary>
+        /// <exception cref="PlatformNotSupportedException">Thrown if the current OS is not Windows.</exception>
+        public static void EnsureWindows()
+        {
+            if (!IsWindows())
+            {
+                throw new PlatformNotSupportedException();
+            }
+        }
+
+        /// <summary>
+        /// Ensure the current Operating System is Linux-based, fail otherwise.
+        /// </summary>
+        /// <exception cref="PlatformNotSupportedException">Thrown if the current OS is not Linux-based.</exception>
+        public static void EnsureLinux()
+        {
+            if (!IsLinux())
+            {
+                throw new PlatformNotSupportedException();
+            }
+        }
+
+        /// <summary>
+        /// Ensure the current Operating System is POSIX-compliant, fail otherwise.
+        /// </summary>
+        /// <exception cref="PlatformNotSupportedException">Thrown if the current OS is not POSIX-compliant.</exception>
+        public static void EnsurePosix()
+        {
+            if (!IsPosix())
+            {
+                throw new PlatformNotSupportedException();
+            }
+        }
+
+        public static bool IsElevatedUser()
+        {
+            if (IsWindows())
+            {
+#if NETFRAMEWORK
+                var identity = System.Security.Principal.WindowsIdentity.GetCurrent();
+                var principal = new System.Security.Principal.WindowsPrincipal(identity);
+                return principal.IsInRole(System.Security.Principal.WindowsBuiltInRole.Administrator);
+#endif
+            }
+            else if (IsPosix())
+            {
+                return Unistd.geteuid() == 0;
+            }
+
+            return false;
+        }
+
+        #region Platform Entry Path Utils
+
+        /// <summary>
+        /// Get the native entry executable absolute path.
+        /// </summary>
+        /// <returns>Entry absolute path or null if there was an error.</returns>
+        public static string GetNativeEntryPath()
+        {
+            try
+            {
+                if (IsWindows())
+                {
+                    return GetWindowsEntryPath();
+                }
+
+                if (IsMacOS())
+                {
+                    return GetMacOSEntryPath();
+                }
+
+                if (IsLinux())
+                {
+                    return GetLinuxEntryPath();
+                }
+            }
+            catch
+            {
+                // If there are any issues getting the native entry path
+                // we should not throw, and certainly not crash!
+                // Just return null instead.
+            }
+
+            return null;
+        }
+
+        private static string GetLinuxEntryPath()
+        {
+            // Try to extract our native argv[0] from the original cmdline
+            string cmdline = File.ReadAllText("/proc/self/cmdline");
+            string argv0 = cmdline.Split('\0')[0];
+
+            // argv[0] is an absolute file path
+            if (Path.IsPathRooted(argv0))
+            {
+                return argv0;
+            }
+
+            string path = Path.GetFullPath(
+                Path.Combine(Environment.CurrentDirectory, argv0)
+            );
+
+            // argv[0] is relative to current directory (./app) or a relative
+            // name resolved from the current directory (subdir/app).
+            // Note that we do NOT want to consider the case when it is just
+            // a simple filename (argv[0] == "app") because that would actually
+            // have been resolved from the $PATH instead (handled below)!
+            if ((argv0.StartsWith("./") || argv0.IndexOf('/') > 0) && File.Exists(path))
+            {
+                return path;
+            }
+
+            // argv[0] is a name that was resolved from the $PATH
+            string pathVar = Environment.GetEnvironmentVariable("PATH");
+            if (pathVar != null)
+            {
+                string[] paths = pathVar.Split(':');
+                foreach (string pathBase in paths)
+                {
+                    path = Path.Combine(pathBase, argv0);
+                    if (File.Exists(path))
+                    {
+                        return path;
+                    }
+                }
+            }
+
+#if NETFRAMEWORK || NETSTANDARD2_0
+            return null;
+#else
+            //
+            // We cannot determine the absolute file path from argv[0]
+            // (how we were launched), so let's now try to extract the
+            // fully resolved executable path from /proc/self/exe.
+            // Note that this means we may miss if we've been invoked
+            // via a symlink, but it's better than nothing at this point!
+            //
+            FileSystemInfo fsi = File.ResolveLinkTarget("/proc/self/exe", returnFinalTarget: false);
+            return fsi?.FullName;
+#endif
+        }
+
+        private static string GetMacOSEntryPath()
+        {
+            // Determine buffer size by passing NULL initially
+            Interop.MacOS.Native.LibC._NSGetExecutablePath(IntPtr.Zero, out int size);
+
+            IntPtr bufPtr = Marshal.AllocHGlobal(size);
+            int result = Interop.MacOS.Native.LibC._NSGetExecutablePath(bufPtr, out size);
+
+            // buf is null-byte terminated
+            string name = result == 0 ? Marshal.PtrToStringAuto(bufPtr) : null;
+            Marshal.FreeHGlobal(bufPtr);
+
+            return name;
+        }
+
+        private static string GetWindowsEntryPath()
+        {
+            IntPtr argvPtr = Interop.Windows.Native.Shell32.CommandLineToArgvW(
+                Interop.Windows.Native.Kernel32.GetCommandLine(), out _);
+            IntPtr argv0Ptr = Marshal.ReadIntPtr(argvPtr);
+            string argv0 = Marshal.PtrToStringAuto(argv0Ptr);
+            Interop.Windows.Native.Kernel32.LocalFree(argvPtr);
+
+            // If this isn't absolute then we should return null to prevent any
+            // caller that expect only an absolute path from mis-using this result.
+            // They will have to fall-back to other mechanisms for getting the entry path.
+            return Path.IsPathRooted(argv0) ? argv0 : null;
+        }
+
+        #endregion
+
+        #region Platform information helper methods
+
+        private static string GetOSType()
+        {
+            if (IsWindows())
+            {
+                return "Windows";
+            }
+
+            if (IsMacOS())
+            {
+                return "macOS";
+            }
+
+            if (IsLinux())
+            {
+                return "Linux";
+            }
+
+            return "Unknown";
+        }
+
+        private static string _linuxDistroVersion;
+
+        private static string GetOSVersion(ITrace2 trace2)
+        {
+            //
+            // Since .NET 5 we can use Environment.OSVersion because it was updated to
+            // return the correct version on Windows & macOS, rather than the manifested
+            // version for Windows or the kernel version for macOS.
+            // https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/5.0/environment-osversion-returns-correct-version
+            //
+            // However, we still need to use the old method for Windows on .NET Framework
+            // and call into the Win32 API to get the correct version (regardless of app
+            // compatibility settings).
+#if NETFRAMEWORK
+            if (IsWindows() && RtlGetVersionEx(out RTL_OSVERSIONINFOEX osvi) == 0)
+            {
+                return $"{osvi.dwMajorVersion}.{osvi.dwMinorVersion} (build {osvi.dwBuildNumber})";
+            }
+#endif
+            if (IsWindows() || IsMacOS())
+            {
+                return Environment.OSVersion.Version.ToString();
+            }
+
+            if (IsLinux())
+            {
+                return _linuxDistroVersion ??= GetLinuxDistroVersion();
+
+                string GetLinuxDistroVersion()
+                {
+                    // Let's first try to get the distribution information from /etc/os-release
+                    // (or /usr/lib/os-release) which is required in systemd distributions.
+                    // https://www.freedesktop.org/software/systemd/man/os-release.html
+                    foreach (string osReleasePath in new[] { "/etc/os-release", "/usr/lib/os-release" })
+                    {
+                        if (!File.Exists(osReleasePath))
+                        {
+                            continue;
+                        }
+
+                        var props = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                        char[] split = { '=' };
+                        string[] lines = File.ReadAllLines(osReleasePath);
+                        foreach (string line in lines)
+                        {
+                            // Each line is a key="value" pair
+                            string[] kvp = line.Split(split, count: 2);
+                            if (kvp.Length != 2)
+                            {
+                                continue;
+                            }
+
+                            props[kvp[0]] = kvp[1].Trim('"');
+                        }
+
+                        // Try to get the PRETTY_NAME first which is a user-friendly description
+                        // including the distro name and version.
+                        if (props.TryGetValue("PRETTY_NAME", out string prettyName))
+                        {
+                            return prettyName;
+                        }
+
+                        // Fall-back to (NAME || ID) + (VERSION || VERSION_ID || VERSION_CODENAME)?
+                        if (props.TryGetValue("NAME", out string distro) ||
+                            props.TryGetValue("ID", out distro))
+                        {
+                            if (props.TryGetValue("VERSION", out string version) ||
+                                props.TryGetValue("VERSION_ID", out version) ||
+                                props.TryGetValue("VERSION_CODENAME", out version))
+                            {
+                                return $"{distro} {version}";
+                            }
+
+                            // Return just the distro name if we don't have a version
+                            return distro;
+                        }
+                    }
+
+                    // If we couldn't get the distribution information from /etc/os-release
+                    // (for example if we're running on a non-systemd distribution), then let's
+                    // use `uname -a` to get at least some information.
+                    var psi = new ProcessStartInfo
+                    {
+                        FileName = "uname",
+                        Arguments = "-a",
+                        RedirectStandardOutput = true
+                    };
+
+                    using (var uname = new ChildProcess(trace2, psi))
+                    {
+                        uname.Start(Trace2ProcessClass.Other);
+                        uname.Process.WaitForExit();
+
+                        if (uname.ExitCode == 0)
+                        {
+                            return uname.StandardOutput.ReadToEnd().Trim();
+                        }
+                    }
+
+                    return "Unknown-Linux";
+                }
+            }
+
+            return "Unknown";
+        }
+
+        private static string GetCpuArchitecture()
+        {
+            switch (RuntimeInformation.OSArchitecture)
+            {
+                case Architecture.Arm:
+                    return "ARM32";
+                case Architecture.Arm64:
+                    return "ARM64";
+                case Architecture.X64:
+                    return "x86-64";
+                case Architecture.X86:
+                    return "x86";
+                default:
+                    return RuntimeInformation.OSArchitecture.ToString();
+            }
+        }
+
+        #endregion
+
+        #region Windows Native Version APIs
+
+        // Interop code sourced from the .NET Runtime as of version 5.0:
+        // https://github.com/dotnet/runtime/blob/6578f257e3be2e2144a65769706e981961f0130c/src/libraries/Common/src/Interop/Windows/NtDll/Interop.RtlGetVersion.cs
+
+        [DllImport("ntdll.dll", ExactSpelling = true)]
+        private static extern int RtlGetVersion(ref RTL_OSVERSIONINFOEX lpVersionInformation);
+
+        private static unsafe int RtlGetVersionEx(out RTL_OSVERSIONINFOEX osvi)
+        {
+            osvi = default;
+            osvi.dwOSVersionInfoSize = (uint)sizeof(RTL_OSVERSIONINFOEX);
+            return RtlGetVersion(ref osvi);
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        private unsafe struct RTL_OSVERSIONINFOEX
+        {
+            internal uint dwOSVersionInfoSize;
+            internal uint dwMajorVersion;
+            internal uint dwMinorVersion;
+            internal uint dwBuildNumber;
+            internal uint dwPlatformId;
+            internal fixed char szCSDVersion[128];
+            internal ushort wServicePackMajor;
+            internal ushort wServicePackMinor;
+            internal short wSuiteMask;
+            internal byte wProductType;
+            internal byte wReserved;
+        }
+
+        /// <summary>
+        /// The operating system is Windows client.
+        /// </summary>
+        private const byte VER_NT_WORKSTATION = 0x0000001;
+
+        /// <summary>
+        /// The system is a domain controller and the operating system is Windows Server.
+        /// </summary>
+        private const byte VER_NT_DOMAIN_CONTROLLER = 0x0000002;
+
+        /// <summary>
+        /// The operating system is Windows Server.
+        /// </summary>
+        /// <remarks>
+        /// A server that is also a domain controller is reported as VER_NT_DOMAIN_CONTROLLER, not VER_NT_SERVER.
+        /// </remarks>
+        private const byte VER_NT_SERVER = 0x0000003;
+
+        #endregion
+    }
+
+    public struct PlatformInformation
+    {
+        public PlatformInformation(string osType, string osVersion, string cpuArch, string clrVersion)
+        {
+            OperatingSystemType = osType;
+            OperatingSystemVersion = osVersion;
+            CpuArchitecture = cpuArch;
+            ClrVersion = clrVersion;
+        }
+
+        public readonly string OperatingSystemType;
+        public readonly string OperatingSystemVersion;
+        public readonly string CpuArchitecture;
+        public readonly string ClrVersion;
+    }
+}

--- a/src/Core/ProcessManager.cs
+++ b/src/Core/ProcessManager.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Diagnostics;
+
+namespace GitCredentialManager;
+
+public interface IProcessManager
+{
+    /// <summary>
+    /// Create a process ready to start.
+    /// </summary>
+    /// <param name="path">Absolute file path of executable or command to start.</param>
+    /// <param name="args">Command line arguments to pass to executable.</param>
+    /// <param name="useShellExecute">
+    ///     True to resolve <paramref name="path"/> using the OS shell, false to use as an absolute file path.
+    /// </param>
+    /// <param name="workingDirectory">Working directory for the new process.</param>
+    /// <returns><see cref="Process"/> object ready to start.</returns>
+    ChildProcess CreateProcess(string path, string args, bool useShellExecute, string workingDirectory);
+
+    /// <summary>
+    /// Create a process ready to start.
+    /// </summary>
+    /// <param name="psi">Process start info.</param>
+    /// <returns><see cref="Process"/> object ready to start.</returns>
+    ChildProcess CreateProcess(ProcessStartInfo psi);
+}
+
+public class ProcessManager : IProcessManager
+{
+    private const string SidEnvar = "GIT_TRACE2_PARENT_SID";
+
+    protected readonly ITrace2 Trace2;
+
+    public static string Sid { get; internal set; }
+
+    public static int Depth { get; internal set; }
+
+    public ProcessManager(ITrace2 trace2)
+    {
+        EnsureArgument.NotNull(trace2, nameof(trace2));
+
+        Trace2 = trace2;
+    }
+
+    public virtual ChildProcess CreateProcess(string path, string args, bool useShellExecute, string workingDirectory)
+    {
+        var psi = new ProcessStartInfo(path, args)
+        {
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = false, // Do not redirect stderr as tracing might be enabled
+            UseShellExecute = useShellExecute,
+            WorkingDirectory = workingDirectory ?? string.Empty
+        };
+
+        return CreateProcess(psi);
+    }
+
+    public virtual ChildProcess CreateProcess(ProcessStartInfo psi)
+    {
+        return new ChildProcess(Trace2, psi);
+    }
+
+    /// <summary>
+    /// Create a TRACE2 "session id" (sid) for this process.
+    /// </summary>
+    public static void CreateSid()
+    {
+        Sid = Environment.GetEnvironmentVariable(SidEnvar);
+
+        if (!string.IsNullOrEmpty(Sid))
+        {
+            // Use trim to ensure no accidental leading or trailing slashes
+            Sid = $"{Sid.Trim('/')}/{Guid.NewGuid():D}";
+            // Only check for process depth if there is a parent.
+            // If there is not a parent, depth defaults to 0.
+            Depth = GetProcessDepth();
+        }
+        else
+        {
+            // We are the root process; create our own 'root' SID
+            Sid = Guid.NewGuid().ToString("D");
+        }
+
+        Environment.SetEnvironmentVariable(SidEnvar, Sid);
+    }
+
+    /// <summary>
+    /// Get "depth" of current process relative to top-level GCM process.
+    /// </summary>
+    /// <returns>Depth of current process.</returns>
+    internal static int GetProcessDepth()
+    {
+        char processSeparator = '/';
+
+        int count = 0;
+        // Use AsSpan() for slight performance bump over traditional foreach loop.
+        foreach (var c in Sid.AsSpan())
+        {
+            if (c == processSeparator)
+                count++;
+        }
+
+        return count;
+    }
+}

--- a/src/Core/Settings.cs
+++ b/src/Core/Settings.cs
@@ -1,0 +1,842 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using KnownEnvars = GitCredentialManager.Constants.EnvironmentVariables;
+using KnownGitCfg = GitCredentialManager.Constants.GitConfiguration;
+using GitCredCfg  = GitCredentialManager.Constants.GitConfiguration.Credential;
+using GitHttpCfg  = GitCredentialManager.Constants.GitConfiguration.Http;
+
+namespace GitCredentialManager
+{
+    /// <summary>
+    /// Component that represents settings for Git Credential Manager as found from the environment and Git configuration.
+    /// Setting values from Git configuration may be cached for performance reasons.
+    /// </summary>
+    public interface ISettings : IDisposable
+    {
+        /// <summary>
+        /// Try and get the value of a specified setting as specified in the environment and Git configuration,
+        /// with the environment taking precedence over Git.
+        /// </summary>
+        /// <param name="envarName">Optional environment variable name.</param>
+        /// <param name="section">Optional Git configuration section name.</param>
+        /// <param name="property">Git configuration property name. Required if <paramref name="section"/> is set, optional otherwise.</param>
+        /// <param name="value">Value of the requested setting.</param>
+        /// <returns>True if a setting value was found, false otherwise.</returns>
+        bool TryGetSetting(string envarName, string section, string property, out string value);
+
+        /// <summary>
+        /// Try and get the value of a specified setting as specified in the environment and Git configuration,
+        /// with the environment taking precedence over Git. If the value is pulled from the Git configuration,
+        /// it is returned as a canonical path.
+        /// </summary>
+        /// <param name="envarName">Optional environment variable name.</param>
+        /// <param name="section">Optional Git configuration section name.</param>
+        /// <param name="property">Git configuration property name. Required if <paramref name="section"/> is set, optional otherwise.</param>
+        /// <param name="value">Value of the requested setting as a canonical path.</param>
+        /// <returns>True if a setting value was found, false otherwise.</returns>
+        bool TryGetPathSetting(string envarName, string section, string property, out string value);
+
+        /// <summary>
+        /// Try and get the all values of a specified setting as specified in the environment and Git configuration,
+        /// in the correct order or precedence.
+        /// </summary>
+        /// <param name="envarName">Optional environment variable name.</param>
+        /// <param name="section">Optional Git configuration section name.</param>
+        /// <param name="property">Git configuration property name. Required if <paramref name="section"/> is set, optional otherwise.</param>
+        /// <param name="isPath">Whether the returned values should be transformed into canonical paths.</param>
+        /// <returns>All values for the specified setting, in order of precedence, or an empty collection if no such values are set.</returns>
+        IEnumerable<string> GetSettingValues(string envarName, string section, string property, bool isPath);
+
+        /// <summary>
+        /// Git remote address that setting lookup is scoped to, or null if no remote URL has been discovered.
+        /// </summary>
+        Uri RemoteUri { get; set; }
+
+        /// <summary>
+        /// True if debugging is enabled, false otherwise.
+        /// </summary>
+        bool IsDebuggingEnabled { get; }
+
+        /// <summary>
+        /// True if terminal prompting is enabled, false otherwise.
+        /// </summary>
+        bool IsTerminalPromptsEnabled { get; }
+
+        /// <summary>
+        /// True if GUI prompts are enabled, false otherwise.
+        /// </summary>
+        /// <remarks>
+        /// If GUI prompts are disabled but an equivalent terminal prompt is available, the latter will be used instead.
+        /// </remarks>
+        bool IsGuiPromptsEnabled { get; set; }
+
+        /// <summary>
+        /// True if it is permitted to interact with the user, false otherwise.
+        /// </summary>
+        /// <remarks>
+        /// If this value is false but interactivity is required to continue execution, the caller should
+        /// abort the operation and report failure.
+        /// </remarks>
+        bool IsInteractionAllowed { get; }
+
+        /// <summary>
+        /// Get if tracing has been enabled, returning trace setting value in the out parameter.
+        /// </summary>
+        /// <param name="value">Trace setting value.</param>
+        /// <returns>True if tracing is enabled, false otherwise.</returns>
+        bool GetTracingEnabled(out string value);
+
+        /// <summary>
+        /// True if tracing of secrets and sensitive information is enabled, false otherwise.
+        /// </summary>
+        bool IsSecretTracingEnabled { get; }
+
+        /// <summary>
+        /// True if MSAL tracing is enabled, false otherwise.
+        /// </summary>
+        bool IsMsalTracingEnabled { get; }
+
+        /// <summary>
+        /// Get the host provider configured to override auto-detection if set, null otherwise.
+        /// </summary>
+        string ProviderOverride { get; }
+
+        /// <summary>
+        /// Get the authority name configured to override host provider auto-detection if set, null otherwise.
+        /// </summary>
+        string LegacyAuthorityOverride { get; }
+
+        /// <summary>
+        /// True if Windows Integrated Authentication (NTLM, Kerberos) should be detected and used if available, false otherwise.
+        /// </summary>
+        bool IsWindowsIntegratedAuthenticationEnabled { get; }
+
+        /// <summary>
+        /// True if certificate verification should occur, false otherwise.
+        /// </summary>
+        bool IsCertificateVerificationEnabled { get; }
+
+        /// <summary>
+        /// Automatically send client TLS certificates.
+        /// </summary>
+        bool AutomaticallyUseClientCertificates { get; }
+
+        /// <summary>
+        /// Get the proxy setting if configured, or null otherwise.
+        /// </summary>
+        /// <returns>Proxy setting, or null if not configured.</returns>
+        ProxyConfiguration GetProxyConfiguration();
+
+        /// <summary>
+        /// The parent window handle/ID. Used to correctly position and parent dialogs generated by GCM.
+        /// </summary>
+        /// <remarks>This value is platform specific.</remarks>
+        string ParentWindowId { get; }
+
+        /// <summary>
+        /// Credential storage namespace prefix.
+        /// </summary>
+        /// <remarks>The default value is "git" if unset.</remarks>
+        string CredentialNamespace { get; }
+
+        /// <summary>
+        /// Credential backing store override.
+        /// </summary>
+        string CredentialBackingStore { get; }
+
+        /// <summary>
+        /// Optional path to a file containing one or more certificates that should
+        /// be used *exclusively* when verifying server certificate chains.
+        /// </summary>
+        /// <remarks>The default value is null if unset.</remarks>
+        string CustomCertificateBundlePath { get; }
+
+        /// <summary>
+        // Optional path to a file containing one or more cookies.
+        /// </summary>
+        /// <remarks>The default value is null if unset.</remarks>
+        string CustomCookieFilePath { get; }
+
+        /// <summary>
+        /// The SSL/TLS backend.
+        /// </summary>
+        TlsBackend TlsBackend { get; }
+
+        /// <summary>
+        /// True if, when using an schannel backend, using certificates from the
+        /// CustomCertificateBundlePath is allowed.
+        /// </summary>
+        /// <remarks>The default value is false if unset.</remarks>
+        bool UseCustomCertificateBundleWithSchannel { get; }
+
+        /// <summary>
+        /// Maximum number of milliseconds to wait for a network response when probing a remote URL for the purpose
+        /// of host provider auto-detection. Use a zero or negative value to disable probing.
+        /// </summary>
+        int AutoDetectProviderTimeout { get; }
+
+        /// <summary>
+        /// Automatically use the default/current operating system account if no other account information is given
+        /// for Microsoft Authentication.
+        /// </summary>
+        bool UseMsAuthDefaultAccount { get; }
+
+        /// <summary>
+        /// True if software rendering should be used for graphical user interfaces, false otherwise.
+        /// </summary>
+        bool UseSoftwareRendering { get; }
+
+        /// <summary>
+        /// Get TRACE2 settings.
+        /// </summary>
+        /// <returns>TRACE2 settings object.</returns>
+        Trace2Settings GetTrace2Settings();
+    }
+
+    public class ProxyConfiguration
+    {
+        public ProxyConfiguration(
+            Uri proxyAddress,
+            string userName = null,
+            string password = null,
+            string noProxyRaw = null,
+            bool isDeprecatedSource = false)
+        {
+            Address = proxyAddress;
+            UserName = userName;
+            Password = password;
+            NoProxyRaw = noProxyRaw;
+            IsDeprecatedSource = isDeprecatedSource;
+        }
+
+        /// <summary>
+        /// True if the proxy configuration method is deprecated, false otherwise.
+        /// </summary>
+        public bool IsDeprecatedSource { get; }
+
+        /// <summary>
+        /// Configured proxy URI (proxy server address and optional user authentication information).
+        /// </summary>
+        public Uri Address { get; }
+
+        /// <summary>
+        /// User name to use to authenticate to the proxy address.
+        /// </summary>
+        public string UserName { get; }
+
+        /// <summary>
+        /// Password to use to authenticate to the proxy address.
+        /// </summary>
+        public string Password { get; }
+
+        /// <summary>
+        /// List of host names that should not be proxied.
+        /// </summary>
+        /// <remarks>
+        /// This is the raw value from the NO_PROXY setting. Values are expected to be in a libcurl compatible format.
+        /// <para/>
+        /// To convert the string in to a set of .NET regular expressions for use with proxy settings,
+        /// use the <see cref="ConvertToBypassRegexArray"/> method.
+        /// </remarks>
+        public string NoProxyRaw { get; }
+
+        /// <summary>
+        /// Convert a libcurl-format NO_PROXY string in to a set of equivalent .NET regular expressions.
+        /// </summary>
+        /// <param name="noProxy">NO_PROXY value in a libcurl-compatible format.</param>
+        /// <returns>Array of regular expressions.</returns>
+        public static IEnumerable<string> ConvertToBypassRegexArray(string noProxy)
+        {
+            if (string.IsNullOrWhiteSpace(noProxy))
+            {
+                yield break;
+            }
+
+            string[] split = noProxy.Split(new[] { ",", " " }, StringSplitOptions.RemoveEmptyEntries);
+
+            var normalized = new StringBuilder();
+            var regex = new StringBuilder();
+            foreach (string str in split)
+            {
+                // Normalize the domain search value
+                normalized.Clear();
+                normalized.Append(str);
+
+                // Strip leading subdomain wildcards: *.example.com => example.com
+                if (normalized.Length > 1 && normalized[0] == '*' && normalized[1] == '.')
+                {
+                    normalized.Remove(0, 2);
+                }
+
+                // Strip all leading dots: .example.com => example.com
+                while (normalized.Length > 0 && normalized[0] == '.')
+                {
+                    normalized.Remove(0, 1);
+                }
+
+                // Build the regular expression
+                regex.Clear();
+
+                // Only match (sub-)domains, not partial domain names.
+                // For example: "example.com" should match "http://example.com" and
+                // "http://www.example.com" but not "http://notanexample.com".
+                regex.Append(@"(\.|\:\/\/)");
+
+                // Add the escaped domain search value
+                regex.Append(Regex.Escape(normalized.ToString()));
+
+                // Ensure we only match the specified port and TLD
+                regex.Append('$');
+
+                yield return regex.ToString();
+            }
+        }
+    }
+
+    public enum TlsBackend
+    {
+        OpenSsl,
+        Schannel,
+        Other,
+    }
+
+    public class Settings : ISettings
+    {
+        private readonly IEnvironment _environment;
+        private readonly IGit _git;
+
+        private Dictionary<string,string> _configEntries;
+
+        public Settings(IEnvironment environment, IGit git)
+        {
+            EnsureArgument.NotNull(environment, nameof(environment));
+            EnsureArgument.NotNull(git, nameof(git));
+
+            _environment = environment;
+            _git = git;
+        }
+
+        public bool TryGetSetting(string envarName, string section, string property, out string value)
+        {
+            IEnumerable<string> allValues = GetSettingValues(envarName, section, property, false);
+
+            value = allValues.FirstOrDefault();
+
+            return value != null;
+        }
+
+        public bool TryGetPathSetting(string envarName, string section, string property, out string value)
+        {
+            IEnumerable<string> allValues = GetSettingValues(envarName, section, property, true);
+
+            value = allValues.FirstOrDefault();
+
+            return value != null;
+        }
+
+        public IEnumerable<string> GetSettingValues(string envarName, string section, string property, bool isPath)
+        {
+            string value;
+
+            if (envarName != null)
+            {
+                if (_environment.Variables.TryGetValue(envarName, out value))
+                {
+                    yield return value;
+                }
+            }
+
+            if (section != null && property != null)
+            {
+                IGitConfiguration config = _git.GetConfiguration();
+
+                //
+                // Enumerate all configuration entries for all sections and property names and make a
+                // local copy of them here to avoid needing to call `TryGetValue` on the IGitConfiguration
+                // object multiple times in a loop below.
+                //
+                // This is a performance optimisation to avoid calling `TryGet` on the IGitConfiguration
+                // object multiple times in a loop below, or each time this entire method is called.
+                // The assumption is that the configuration entries will not change during a single invocation
+                // of Git Credential Manager, which is reasonable given process lifetime is typically less
+                // than a few seconds. For some entries (type=path), we still need to ask Git in order to
+                // expand the path correctly.
+                //
+                if (_configEntries is null)
+                {
+                    _configEntries = new Dictionary<string, string>(GitConfigurationKeyComparer.Instance);
+                    config.Enumerate(entry =>
+                    {
+                        _configEntries[entry.Key] = entry.Value;
+
+                        // Continue the enumeration
+                        return true;
+                    });
+                }
+
+                if (RemoteUri != null)
+                {
+                    /*
+                     * Look for URL scoped "section" configuration entries, starting from the most specific
+                     * down to the least specific (stopping before the TLD).
+                     *
+                     * In a divergence from standard Git configuration rules, we also consider matching URL scopes
+                     * without a scheme ("protocol://").
+                     *
+                     * For each level of scope, we look for an entry with the scheme included (the default), and then
+                     * also one without it specified. This allows you to have one configuration scope for both "http" and
+                     * "https" without needing to repeat yourself, for example.
+                     *
+                     * For example, starting with "https://foo.example.com/bar/buzz" we have:
+                     *
+                     *   1a. [section "https://foo.example.com/bar/buzz"]
+                     *          property = value
+                     *
+                     *   1b. [section "foo.example.com/bar/buzz"]
+                     *          property = value
+                     *
+                     *   2a. [section "https://foo.example.com/bar"]
+                     *          property = value
+                     *
+                     *   2b. [section "foo.example.com/bar"]
+                     *          property = value
+                     *
+                     *   3a. [section "https://foo.example.com"]
+                     *          property = value
+                     *
+                     *   3b. [section "foo.example.com"]
+                     *          property = value
+                     *
+                     *   4a. [section "https://example.com"]
+                     *          property = value
+                     *
+                     *   4b. [section "example.com"]
+                     *          property = value
+                     *
+                     * It is also important to note that although the section and property names are NOT case
+                     * sensitive, the "scope" part IS case sensitive! We must be careful when searching to ensure
+                     * we follow Git's rules.
+                     *
+                     */
+
+                    foreach (string scope in RemoteUri.GetGitConfigurationScopes())
+                    {
+                        string queryName = $"{section}.{scope}.{property}";
+                        // Look for a scoped entry that includes the scheme "protocol://example.com" first as
+                        // this is more specific. If `isPath` is true, then re-get the value from the
+                        // `GitConfiguration` with `isPath` specified.
+                        if ((isPath && config.TryGet(queryName, true, out value)) ||
+                            _configEntries.TryGetValue(queryName, out value))
+                        {
+                            yield return value;
+                        }
+
+                        // Now look for a scoped entry that omits the scheme "example.com" second as this is less
+                        // specific. As above, if `isPath` is true, get the configuration setting again with
+                        // `isPath` specified.
+                        string scopeWithoutScheme = scope.TrimUntilIndexOf(Uri.SchemeDelimiter);
+                        string queryWithSchemeName = $"{section}.{scopeWithoutScheme}.{property}";
+                        if ((isPath && config.TryGet(queryWithSchemeName, true, out value)) ||
+                            _configEntries.TryGetValue(queryWithSchemeName, out value))
+                        {
+                            yield return value;
+                        }
+
+                        // Check for an externally specified default value
+                        if (TryGetExternalDefault(section, scope, property, out value))
+                        {
+                            yield return value;
+                        }
+                    }
+                }
+
+                /*
+                 * Try to look for an un-scoped "section" property setting:
+                 *
+                 *    [section]
+                 *        property = value
+                 *
+                 */
+                string name = $"{section}.{property}";
+                if ((isPath && config.TryGet(name, true, out value)) ||
+                    _configEntries.TryGetValue(name, out value))
+                {
+                    yield return value;
+                }
+
+                // Check for an externally specified default value without a scope
+                if (TryGetExternalDefault(section, null, property, out value))
+                {
+                    yield return value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Try to get the default value for a configuration setting.
+        /// This may come from external policies or the Operating System.
+        /// </summary>
+        /// <param name="section">Configuration section name.</param>
+        /// <param name="scope">Optional configuration scope.</param>
+        /// <param name="property">Configuration property name.</param>
+        /// <param name="value">Value of the configuration setting, or null.</param>
+        /// <returns>True if a default setting has been set, false otherwise.</returns>
+        protected virtual bool TryGetExternalDefault(string section, string scope, string property, out string value)
+        {
+            value = null;
+            return false;
+        }
+
+        public Uri RemoteUri { get; set; }
+
+        public bool IsDebuggingEnabled =>
+            TryGetSetting(KnownEnvars.GcmDebug,
+                KnownGitCfg.Credential.SectionName,
+                KnownGitCfg.Credential.Debug,
+                out string str) && str.IsTruthy();
+
+        public bool IsTerminalPromptsEnabled => _environment.Variables.GetBooleanyOrDefault(KnownEnvars.GitTerminalPrompts, true);
+
+        public bool IsGuiPromptsEnabled
+        {
+            get
+            {
+                const bool defaultValue = true;
+
+                if (TryGetSetting(
+                        KnownEnvars.GcmGuiPromptsEnabled,
+                        KnownGitCfg.Credential.SectionName,
+                        KnownGitCfg.Credential.GuiPromptsEnabled,
+                        out string str))
+                {
+                    return str.ToBooleanyOrDefault(defaultValue);
+                }
+
+                return defaultValue;
+            }
+            set => _environment.SetEnvironmentVariable(KnownEnvars.GcmGuiPromptsEnabled, value ? bool.TrueString : bool.FalseString);
+        }
+
+        public bool IsInteractionAllowed
+        {
+            get
+            {
+                const bool defaultValue = true;
+                if (TryGetSetting(KnownEnvars.GcmInteractive, GitCredCfg.SectionName, GitCredCfg.Interactive, out string value))
+                {
+                    /*
+                     * COMPAT: In the previous GCM we accepted the values 'auto', 'never', and 'always'.
+                     *
+                     * We've slightly changed the behaviour of this setting in GCM to essentially
+                     * remove the 'always' option. The table below outlines the changes:
+                     *
+                     * -------------------------------------------------------------
+                     * | Value(s) | Old meaning               | New meaning        |
+                     * |-----------------------------------------------------------|
+                     * | auto     | Prompt if required        | [unchanged]        |
+                     * |-----------------------------------------------------------|
+                     * | never    | Never prompt ─ fail if    | [unchanged]        |
+                     * | false    | interaction is required   |                    |
+                     * |-----------------------------------------------------------|
+                     * | always   | Always prompt ─ don't use | Prompt if required |
+                     * | force    | cached credentials        |                    |
+                     * | true     |                           |                    |
+                     * -------------------------------------------------------------
+                     */
+                    if (StringComparer.OrdinalIgnoreCase.Equals("never", value))
+                    {
+                        return false;
+                    }
+
+                    return value.ToBooleanyOrDefault(defaultValue);
+                }
+
+                return defaultValue;
+            }
+        }
+
+        public bool GetTracingEnabled(out string value) =>
+            TryGetSetting(KnownEnvars.GcmTrace,
+                KnownGitCfg.Credential.SectionName,
+                KnownGitCfg.Credential.Trace,
+                out value) && !value.IsFalsey();
+
+        public bool UseSoftwareRendering
+        {
+            get
+            {
+                // WORKAROUND: Some Windows ARM devices have a graphics driver issue that causes transparent windows
+                // when using hardware rendering. Until this is fixed, we will default to software rendering on these
+                // devices. Users can always override this setting back to HW-accelerated rendering if they wish.
+                bool defaultValue = PlatformUtils.IsWindows() && PlatformUtils.IsArm();
+
+                return TryGetSetting(KnownEnvars.GcmGuiSoftwareRendering,
+                    KnownGitCfg.Credential.SectionName,
+                    KnownGitCfg.Credential.GuiSoftwareRendering,
+                    out string str) ? str.ToBooleanyOrDefault(defaultValue) : defaultValue;
+            }
+        }
+
+        public Trace2Settings GetTrace2Settings()
+        {
+            var settings = new Trace2Settings();
+
+            if (TryGetSetting(Constants.EnvironmentVariables.GitTrace2Event, KnownGitCfg.Trace2.SectionName,
+                    Constants.GitConfiguration.Trace2.EventTarget, out string value))
+            {
+                settings.FormatTargetsAndValues.Add(Trace2FormatTarget.Event, value);
+            }
+
+            if (TryGetSetting(Constants.EnvironmentVariables.GitTrace2Normal, KnownGitCfg.Trace2.SectionName,
+                    Constants.GitConfiguration.Trace2.NormalTarget, out value))
+            {
+                settings.FormatTargetsAndValues.Add(Trace2FormatTarget.Normal, value);
+            }
+
+            if (TryGetSetting(Constants.EnvironmentVariables.GitTrace2Performance, KnownGitCfg.Trace2.SectionName,
+                    Constants.GitConfiguration.Trace2.PerformanceTarget, out value))
+            {
+                settings.FormatTargetsAndValues.Add(Trace2FormatTarget.Performance, value);
+            }
+
+            return settings;
+        }
+
+        public bool IsSecretTracingEnabled =>
+            TryGetSetting(KnownEnvars.GcmTraceSecrets,
+                KnownGitCfg.Credential.SectionName,
+                KnownGitCfg.Credential.TraceSecrets,
+                out string str) && str.IsTruthy();
+
+        public bool IsMsalTracingEnabled =>
+            TryGetSetting(KnownEnvars.GcmTraceMsAuth,
+                KnownGitCfg.Credential.SectionName,
+                KnownGitCfg.Credential.TraceMsAuth,
+                out string str) && str.IsTruthy();
+
+        public string ProviderOverride =>
+            TryGetSetting(KnownEnvars.GcmProvider, GitCredCfg.SectionName, GitCredCfg.Provider, out string providerId) ? providerId : null;
+
+        public string LegacyAuthorityOverride =>
+            TryGetSetting(KnownEnvars.GcmAuthority, GitCredCfg.SectionName, GitCredCfg.Authority, out string authority) ? authority : null;
+
+        public bool IsWindowsIntegratedAuthenticationEnabled =>
+            !TryGetSetting(KnownEnvars.GcmAllowWia, GitCredCfg.SectionName, GitCredCfg.AllowWia, out string value) || value.ToBooleanyOrDefault(true);
+
+        public bool IsCertificateVerificationEnabled
+        {
+            get
+            {
+                // Prefer environment variable
+                if (_environment.Variables.TryGetValue(KnownEnvars.GitSslNoVerify, out string envarValue))
+                {
+                    return !envarValue.ToBooleanyOrDefault(false);
+                }
+
+                // Next try the equivalent Git configuration option
+                if (TryGetSetting(null, KnownGitCfg.Http.SectionName, KnownGitCfg.Http.SslVerify, out string cfgValue))
+                {
+                    return cfgValue.ToBooleanyOrDefault(true);
+                }
+
+                // Safe default
+                return true;
+            }
+        }
+
+        public bool AutomaticallyUseClientCertificates =>
+            TryGetSetting(null, KnownGitCfg.Credential.SectionName, KnownGitCfg.Http.SslAutoClientCert, out string value) && value.ToBooleanyOrDefault(false);
+
+        public string CustomCertificateBundlePath =>
+            TryGetPathSetting(KnownEnvars.GitSslCaInfo, KnownGitCfg.Http.SectionName, KnownGitCfg.Http.SslCaInfo, out string value) ? value : null;
+
+        public string CustomCookieFilePath =>
+            TryGetPathSetting(null, KnownGitCfg.Http.SectionName, KnownGitCfg.Http.CookieFile, out string value) ? value : null;
+
+        public TlsBackend TlsBackend =>
+            TryGetSetting(null, KnownGitCfg.Http.SectionName, KnownGitCfg.Http.SslBackend, out string config)
+                ? (Enum.TryParse(config, true, out TlsBackend backend) ? backend : GitCredentialManager.TlsBackend.Other)
+                : default(TlsBackend);
+
+        public bool UseCustomCertificateBundleWithSchannel =>
+            TryGetSetting(null, KnownGitCfg.Http.SectionName, KnownGitCfg.Http.SchannelUseSslCaInfo, out string schannelUseSslCaInfo) &&
+                schannelUseSslCaInfo.ToBooleanyOrDefault(false);
+
+        public int AutoDetectProviderTimeout
+        {
+            get
+            {
+                if (TryGetSetting(KnownEnvars.GcmAutoDetectTimeout,
+                        KnownGitCfg.Credential.SectionName,
+                        KnownGitCfg.Credential.AutoDetectTimeout,
+                        out string valueStr) &&
+                    ConvertUtils.TryToInt32(valueStr, out int value))
+                {
+                    return value;
+                }
+
+                return Constants.DefaultAutoDetectProviderTimeoutMs;
+            }
+        }
+
+        public ProxyConfiguration GetProxyConfiguration()
+        {
+            bool TryGetUriSetting(string envarName, string section, string property, out Uri uri)
+            {
+                IEnumerable<string> allValues = GetSettingValues(envarName, section, property, false);
+
+                foreach (var value in allValues)
+                {
+                    if (Uri.TryCreate(value, UriKind.Absolute, out uri))
+                    {
+                        return true;
+                    }
+                    else if (string.IsNullOrWhiteSpace(value))
+                    {
+                        // An empty string value means "no proxy"
+                        return false;
+                    }
+                }
+
+                uri = null;
+                return false;
+            }
+
+            char[] bypassListSeparators = {',', ' '};
+
+            ProxyConfiguration CreateConfiguration(Uri uri, bool isLegacy = false)
+            {
+                // Strip the userinfo, query, and fragment parts of the Uri retaining only the scheme, host, port, and path
+                Uri address = new UriBuilder(uri)
+                {
+                    UserName = string.Empty,
+                    Password = string.Empty,
+                    Query    = string.Empty,
+                    Fragment = string.Empty,
+                }.Uri;
+
+                // Extract the username and password from the URI if present
+                uri.TryGetUserInfo(out string userName, out string password);
+
+                // Get the proxy bypass host names
+                // Check both lowercase "no_proxy" and uppercase "NO_PROXY" variants (preferring the former)
+                if (!_environment.Variables.TryGetValue(KnownEnvars.CurlNoProxy, out string noProxyStr))
+                {
+                    _environment.Variables.TryGetValue(KnownEnvars.CurlNoProxyUpper, out noProxyStr);
+                }
+
+                return new ProxyConfiguration(address, userName, password, noProxyStr, isLegacy);
+            }
+
+            /*
+             * There are several different ways we support the configuration of a proxy.
+             *
+             * In order of preference:
+             *
+             *   1. GCM proxy Git configuration (deprecated)
+             *        credential.httpsProxy
+             *        credential.httpProxy
+             *
+             *   2. Standard Git configuration
+             *        http.proxy
+             *
+             *   3. cURL environment variables
+             *        https_proxy
+             *        HTTPS_PROXY
+             *        http_proxy (note that uppercase HTTP_PROXY is not supported by libcurl)
+             *        all_proxy
+             *        ALL_PROXY
+             *
+             *   4. GCM proxy environment variable (deprecated)
+             *        GCM_HTTP_PROXY
+             *
+             * If the remote URI is HTTPS we check the HTTPS variants first, and fallback to the
+             * non-secure HTTP options if not found.
+             *
+             * For HTTP URIs we only check the HTTP variants.
+             *
+             * We also support the cURL "no_proxy" / "NO_PROXY" environment variables in conjunction with any
+             * of the above supported proxy address configurations. This comma separated list of
+             * host names (or host name wildcards) should be respected and the proxy should NOT
+             * be used for these addresses.
+             *
+             */
+
+            bool isHttps = StringComparer.OrdinalIgnoreCase.Equals(Uri.UriSchemeHttps, RemoteUri?.Scheme);
+
+            Uri proxyUri;
+
+            // 1. GCM proxy Git configuration (deprecated)
+            if (isHttps && TryGetUriSetting(null, GitCredCfg.SectionName, GitCredCfg.HttpsProxy, out proxyUri) ||
+                TryGetUriSetting(null, GitCredCfg.SectionName, GitCredCfg.HttpProxy, out proxyUri))
+            {
+                return CreateConfiguration(proxyUri, isLegacy: true);
+            }
+
+            // 2. Standard Git configuration
+            if (TryGetUriSetting(null, GitHttpCfg.SectionName, GitHttpCfg.Proxy, out proxyUri))
+            {
+                return CreateConfiguration(proxyUri);
+            }
+
+            // 3. cURL environment variables (both lower- and uppercase variants)
+            // Prefer the lowercase variants as these are quasi-standard.
+            if (isHttps && TryGetUriSetting(KnownEnvars.CurlHttpsProxy, null, null, out proxyUri) ||
+                isHttps && TryGetUriSetting(KnownEnvars.CurlHttpsProxyUpper, null, null, out proxyUri) ||
+                TryGetUriSetting(KnownEnvars.CurlHttpProxy, null, null, out proxyUri) ||
+                // Note that the uppercase HTTP_PROXY is not recognized by libcurl
+                TryGetUriSetting(KnownEnvars.CurlAllProxy, null, null, out proxyUri) ||
+                TryGetUriSetting(KnownEnvars.CurlAllProxyUpper, null, null, out proxyUri))
+            {
+                return CreateConfiguration(proxyUri);
+            }
+
+            // 4. GCM proxy environment variable (deprecated)
+            if (TryGetUriSetting(KnownEnvars.GcmHttpProxy, null, null, out proxyUri))
+            {
+                return CreateConfiguration(proxyUri, isLegacy: true);
+            }
+
+            return null;
+        }
+
+        public string ParentWindowId => _environment.Variables.TryGetValue(KnownEnvars.GcmParentWindow, out string parentWindowId) ? parentWindowId : null;
+
+        public string CredentialNamespace =>
+            TryGetSetting(KnownEnvars.GcmCredNamespace,
+                KnownGitCfg.Credential.SectionName, KnownGitCfg.Credential.CredNamespace,
+                out string @namespace)
+                ? @namespace
+                : Constants.DefaultCredentialNamespace;
+
+        public string CredentialBackingStore =>
+            TryGetSetting(
+                KnownEnvars.GcmCredentialStore,
+                KnownGitCfg.Credential.SectionName,
+                KnownGitCfg.Credential.CredentialStore,
+                out string credStore)
+                ? credStore
+                : null;
+
+        public bool UseMsAuthDefaultAccount =>
+            TryGetSetting(
+                KnownEnvars.MsAuthUseDefaultAccount,
+                KnownGitCfg.Credential.SectionName,
+                KnownGitCfg.Credential.MsAuthUseDefaultAccount,
+                out string str)
+            ? str.IsTruthy()
+            : PlatformUtils.IsDevBox(); // default to true in DevBox environment
+
+        #region IDisposable
+
+        public void Dispose()
+        {
+            // Do nothing
+        }
+
+        #endregion
+    }
+}

--- a/src/Core/StandardStreams.cs
+++ b/src/Core/StandardStreams.cs
@@ -1,0 +1,83 @@
+using System;
+using System.IO;
+using System.Text;
+
+namespace GitCredentialManager
+{
+    /// <summary>
+    /// Represents the standard I/O streams (input, output, error) of a process.
+    /// </summary>
+    public interface IStandardStreams
+    {
+        /// <summary>
+        /// The standard input text stream from the calling process, typically Git.
+        /// </summary>
+        TextReader In { get; }
+
+        /// <summary>
+        /// The standard output text stream connected back to the calling process, typically Git.
+        /// </summary>
+        TextWriter Out { get; }
+
+        /// <summary>
+        /// The standard error text stream connected back to the calling process, typically Git.
+        /// </summary>
+        TextWriter Error { get; }
+    }
+
+    public class StandardStreams : IStandardStreams
+    {
+        private const string LineFeed  = "\n";
+
+        private TextReader _stdIn;
+        private TextWriter _stdOut;
+        private TextWriter _stdErr;
+
+        public TextReader In
+        {
+            get
+            {
+                if (_stdIn == null)
+                {
+                    _stdIn = new StreamReader(Console.OpenStandardInput(), EncodingEx.UTF8NoBom);
+                }
+
+                return _stdIn;
+            }
+        }
+
+        public TextWriter Out
+        {
+            get
+            {
+                if (_stdOut == null)
+                {
+                    _stdOut = new StreamWriter(Console.OpenStandardOutput(), EncodingEx.UTF8NoBom)
+                    {
+                        AutoFlush = true,
+                        NewLine = LineFeed,
+                    };
+                }
+
+                return _stdOut;
+            }
+        }
+
+        public TextWriter Error
+        {
+            get
+            {
+                if (_stdErr == null)
+                {
+                    _stdErr = new StreamWriter(Console.OpenStandardError(), EncodingEx.UTF8NoBom)
+                    {
+                        AutoFlush = true,
+                        NewLine = LineFeed,
+                    };
+                }
+
+                return _stdErr;
+            }
+        }
+    }
+}

--- a/src/Core/StreamExtensions.cs
+++ b/src/Core/StreamExtensions.cs
@@ -1,0 +1,285 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace GitCredentialManager
+{
+    public static class StreamExtensions
+    {
+        /// <summary>
+        /// Read a dictionary in the form `key1=value\nkey2=value\n\n` from the specified <see cref="TextReader"/>.
+        /// </summary>
+        /// <remarks>
+        /// Uses the <see cref="StringComparer.Ordinal"/> comparer for dictionary keys.
+        /// <para/>
+        /// Also accepts dictionary lines terminated using \r\n (CR LF) as well as \n (LF).
+        /// </remarks>
+        /// <param name="reader">Text reader to read a dictionary from.</param>
+        /// <returns>Dictionary read from the text reader.</returns>
+        public static IDictionary<string, string> ReadDictionary(this TextReader reader) =>
+            ReadDictionary(reader, StringComparer.Ordinal);
+
+        /// <summary>
+        /// Read a dictionary in the form `key1=value\nkey2=value\n\n` from the specified <see cref="TextReader"/>,
+        /// with the specified <see cref="StringComparer"/> used to compare dictionary keys.
+        /// </summary>
+        /// <remarks>Also accepts dictionary lines terminated using \r\n (CR LF) as well as \n (LF).</remarks>
+        /// <param name="reader">Text reader to read a dictionary from.</param>
+        /// <param name="comparer">Comparer to use when comparing dictionary keys.</param>
+        /// <returns>Dictionary read from the text reader.</returns>
+        public static IDictionary<string, string> ReadDictionary(this TextReader reader, StringComparer comparer)
+        {
+            var dict = new Dictionary<string, string>(comparer);
+
+            string line;
+            while ((line = reader.ReadLine()) != null && !string.IsNullOrWhiteSpace(line))
+            {
+                ParseLine(dict, line);
+            }
+
+            return dict;
+        }
+
+        /// <summary>
+        /// Read a multi-dictionary in the form `key1=value\nkey2=value\n\n` from the specified <see cref="TextReader"/>.
+        /// </summary>
+        /// <remarks>
+        /// Uses the <see cref="StringComparer.Ordinal"/> comparer for dictionary keys.
+        /// <para/>
+        /// Also accepts dictionary lines terminated using \r\n (CR LF) as well as \n (LF).
+        /// </remarks>
+        /// <param name="reader">Text reader to read a dictionary from.</param>
+        /// <returns>Dictionary read from the text reader.</returns>
+        public static IDictionary<string, IList<string>> ReadMultiDictionary(this TextReader reader) =>
+            ReadMultiDictionary(reader, StringComparer.Ordinal);
+
+        /// <summary>
+        /// Read a multi-dictionary in the form `key1=value\nkey2=value\n\n` from the specified <see cref="TextReader"/>,
+        /// with the specified <see cref="StringComparer"/> used to compare dictionary keys.
+        /// </summary>
+        /// <remarks>Also accepts dictionary lines terminated using \r\n (CR LF) as well as \n (LF).</remarks>
+        /// <param name="reader">Text reader to read a dictionary from.</param>
+        /// <param name="comparer">Comparer to use when comparing dictionary keys.</param>
+        /// <returns>Dictionary read from the text reader.</returns>
+        public static IDictionary<string, IList<string>> ReadMultiDictionary(this TextReader reader, StringComparer comparer)
+        {
+            var dict = new Dictionary<string, IList<string>>(comparer);
+
+            string line;
+            while ((line = reader.ReadLine()) != null && !string.IsNullOrWhiteSpace(line))
+            {
+                ParseMultiLine(dict, line);
+            }
+
+            return dict;
+        }
+
+        /// <summary>
+        /// Asynchronously read a dictionary in the form `key1=value\nkey2=value\n\n` from the specified <see cref="TextReader"/>.
+        /// </summary>
+        /// <remarks>
+        /// Uses the <see cref="StringComparer.Ordinal"/> comparer for dictionary keys.
+        /// <para/>
+        /// Also accepts dictionary lines terminated using \r\n (CR LF) as well as \n (LF).
+        /// </remarks>
+        /// <param name="reader">Text reader to read a dictionary from.</param>
+        /// <returns>Dictionary read from the text reader.</returns>
+        public static Task<IDictionary<string, string>> ReadDictionaryAsync(this TextReader reader) =>
+            ReadDictionaryAsync(reader, StringComparer.Ordinal);
+
+        /// <summary>
+        /// Asynchronously read a multi-dictionary in the form `key1=value\nkey2=value\n\n` from the specified <see cref="TextReader"/>.
+        /// </summary>
+        /// <remarks>
+        /// Uses the <see cref="StringComparer.Ordinal"/> comparer for dictionary keys.
+        /// <para/>
+        /// Also accepts dictionary lines terminated using \r\n (CR LF) as well as \n (LF).
+        /// </remarks>
+        /// <param name="reader">Text reader to read a dictionary from.</param>
+        /// <returns>Dictionary read from the text reader.</returns>
+        public static Task<IDictionary<string, IList<string>>> ReadMultiDictionaryAsync(this TextReader reader) =>
+            ReadMultiDictionaryAsync(reader, StringComparer.Ordinal);
+
+        /// <summary>
+        /// Asynchronously read a dictionary in the form `key1=value\nkey2=value\n\n` from the specified <see cref="TextReader"/>,
+        /// with the specified <see cref="StringComparer"/> used to compare dictionary keys.
+        /// </summary>
+        /// <remarks>Also accepts dictionary lines terminated using \r\n (CR LF) as well as \n (LF).</remarks>
+        /// <param name="reader">Text reader to read a dictionary from.</param>
+        /// <param name="comparer">Comparer to use when comparing dictionary keys.</param>
+        /// <returns>Dictionary read from the text reader.</returns>
+        public static async Task<IDictionary<string, string>> ReadDictionaryAsync(this TextReader reader, StringComparer comparer)
+        {
+            var dict = new Dictionary<string, string>(comparer);
+
+            string line;
+            while ((line = await reader.ReadLineAsync()) != null && !string.IsNullOrWhiteSpace(line))
+            {
+                ParseLine(dict, line);
+            }
+
+            return dict;
+        }
+
+        /// <summary>
+        /// Asynchronously read a multi-dictionary in the form `key1=value\nkey2=value\n\n` from the specified <see cref="TextReader"/>,
+        /// with the specified <see cref="StringComparer"/> used to compare dictionary keys.
+        /// </summary>
+        /// <remarks>Also accepts dictionary lines terminated using \r\n (CR LF) as well as \n (LF).</remarks>
+        /// <param name="reader">Text reader to read a dictionary from.</param>
+        /// <param name="comparer">Comparer to use when comparing dictionary keys.</param>
+        /// <returns>Dictionary read from the text reader.</returns>
+        public static async Task<IDictionary<string, IList<string>>> ReadMultiDictionaryAsync(this TextReader reader, StringComparer comparer)
+        {
+            var dict = new Dictionary<string, IList<string>>(comparer);
+
+            string line;
+            while ((line = await reader.ReadLineAsync()) != null && !string.IsNullOrWhiteSpace(line))
+            {
+                ParseMultiLine(dict, line);
+            }
+
+            return dict;
+        }
+
+        /// <summary>
+        /// Write a dictionary in the form `key1=value\nkey2=value\n\n` to the specified <see cref="TextWriter"/>,
+        /// where \n is the configured new-line (see <see cref="TextWriter.NewLine"/>).
+        /// </summary>
+        /// <remarks>The output dictionary new-lines are determined by the <see cref="TextWriter.NewLine"/> property.</remarks>
+        /// <param name="writer">Text writer to write a dictionary to.</param>
+        /// <param name="dict">Dictionary to write to the text writer.</param>
+        public static void WriteDictionary(this TextWriter writer, IDictionary<string, string> dict)
+        {
+            foreach (var kvp in dict)
+            {
+                writer.WriteLine($"{kvp.Key}={kvp.Value}");
+            }
+
+            // Write terminating line
+            writer.WriteLine();
+        }
+
+        /// <summary>
+        /// Write a dictionary in the form `key1=value\nkey2=value\n\n` to the specified <see cref="TextWriter"/>,
+        /// where \n is the configured new-line (see <see cref="TextWriter.NewLine"/>).
+        /// </summary>
+        /// <remarks>The output dictionary new-lines are determined by the <see cref="TextWriter.NewLine"/> property.</remarks>
+        /// <param name="writer">Text writer to write a dictionary to.</param>
+        /// <param name="dict">Dictionary to write to the text writer.</param>
+        public static void WriteDictionary(this TextWriter writer, IDictionary<string, IList<string>> dict)
+        {
+            foreach (var kvp in dict)
+            {
+                IList<string> values = GetNormalizedValueList(kvp.Value);
+                switch (values.Count)
+                {
+                    case 0:
+                        break;
+
+                    case 1:
+                        writer.WriteLine($"{kvp.Key}={kvp.Value[0]}");
+                        break;
+
+                    default:
+                        foreach (string value in values)
+                        {
+                            writer.WriteLine($"{kvp.Key}[]={value}");
+                        }
+                        break;
+                }
+            }
+
+            // Write terminating line
+            writer.WriteLine();
+        }
+
+        /// <summary>
+        /// Asynchronously write a dictionary in the form `key1=value\nkey2=value\n\n` to the specified <see cref="TextWriter"/>,
+        /// where \n is the configured new-line (see <see cref="TextWriter.NewLine"/>).
+        /// </summary>
+        /// <remarks>The output dictionary new-lines are determined by the <see cref="TextWriter.NewLine"/> property.</remarks>
+        /// <param name="writer">Text writer to write a dictionary to.</param>
+        /// <param name="dict">Dictionary to write to the text writer.</param>
+        public static async Task WriteDictionaryAsync(this TextWriter writer, IDictionary<string, string> dict)
+        {
+            foreach (var kvp in dict)
+            {
+                await writer.WriteLineAsync($"{kvp.Key}={kvp.Value}");
+            }
+
+            // Write terminating line
+            await writer.WriteLineAsync();
+        }
+
+        private static void ParseLine(IDictionary<string, string> dict, string line)
+        {
+            int splitIndex = line.IndexOf('=');
+            if (splitIndex > 0)
+            {
+                string key = line.Substring(0, splitIndex);
+                string value = line.Substring(splitIndex + 1);
+
+                dict[key] = value;
+            }
+        }
+
+        private static void ParseMultiLine(IDictionary<string, IList<string>> dict, string line)
+        {
+            int splitIndex = line.IndexOf('=');
+            if (splitIndex > 0)
+            {
+                string key = line.Substring(0, splitIndex);
+                string value = line.Substring(splitIndex + 1);
+
+                bool multi = key.EndsWith("[]");
+                if (multi)
+                {
+                    key = key.Substring(0, key.Length - 2);
+                }
+
+                if (!dict.TryGetValue(key, out IList<string> list))
+                {
+                    list = new List<string>();
+                    dict[key] = list;
+                }
+
+                // Only allow one value for non-multi/array entries ("key=value")
+                // and reset the array of a multi-entry if the value is empty ("key[]=<empty>")
+                bool emptyValue = string.IsNullOrEmpty(value);
+
+                if (!multi || emptyValue)
+                {
+                    list.Clear();
+                }
+
+                if (multi && emptyValue)
+                {
+                    return;
+                }
+
+                list.Add(value);
+            }
+        }
+
+        private static IList<string> GetNormalizedValueList(IEnumerable<string> values)
+        {
+            var result = new List<string>();
+
+            foreach (string value in values)
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    result.Clear();
+                }
+                else
+                {
+                    result.Add(value);
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/Core/StringExtensions.cs
+++ b/src/Core/StringExtensions.cs
@@ -1,0 +1,268 @@
+using System;
+using System.Text;
+
+namespace GitCredentialManager
+{
+    public static class StringExtensions
+    {
+        /// <summary>
+        /// Check if the string is considered to be 'truthy' (a value considered equivalent to 'true').
+        /// </summary>
+        /// <remarks>
+        /// Git considers several different values to be equivalent to 'true'; we try to be consistent with this
+        /// behavior.
+        /// <para/>
+        /// See the following Git documentation for a list of values considered to be equivalent to 'true':
+        /// https://git-scm.com/docs/git-config#git-config-boolean
+        /// </remarks>
+        /// <param name="str">String value to check.</param>
+        /// <returns>True if the value is 'truthy', false otherwise.</returns>
+        public static bool IsTruthy(this string str)
+        {
+            return StringComparer.OrdinalIgnoreCase.Equals(str, bool.TrueString) ||
+                   StringComparer.OrdinalIgnoreCase.Equals(str, "1") ||
+                   StringComparer.OrdinalIgnoreCase.Equals(str, "on") ||
+                   StringComparer.OrdinalIgnoreCase.Equals(str, "yes");
+        }
+
+        /// <summary>
+        /// Check if the string is considered to be 'falsey' (a value considered equivalent to 'false').
+        /// </summary>
+        /// <remarks>
+        /// Git considers several different values to be equivalent to 'false'; we try to be consistent with this
+        /// behavior.
+        /// <para/>
+        /// See the following Git documentation for a list of values considered to be equivalent to 'false':
+        /// https://git-scm.com/docs/git-config#git-config-boolean
+        /// </remarks>
+        /// <param name="str">String value to check.</param>
+        /// <returns>True if the value is 'falsey', false otherwise.</returns>
+        public static bool IsFalsey(this string str)
+        {
+            return StringComparer.OrdinalIgnoreCase.Equals(str, bool.FalseString) ||
+                   StringComparer.OrdinalIgnoreCase.Equals(str, "0") ||
+                   StringComparer.OrdinalIgnoreCase.Equals(str, "off") ||
+                   StringComparer.OrdinalIgnoreCase.Equals(str, "no");
+        }
+
+        /// <summary>
+        /// Check if the string is considered to be either 'truthy' or 'falsey' (values considered equivalent to 'true' and 'false').
+        /// </summary>
+        /// <remarks>
+        /// Git considers several different values to be equivalent to 'true' and 'false'; we try to be consistent with this
+        /// behavior.
+        /// <para/>
+        /// See the following Git documentation for a list of values considered to be equivalent to 'true' and 'false':
+        /// https://git-scm.com/docs/git-config#git-config-boolean
+        /// </remarks>
+        /// <param name="str">String value to check.</param>
+        /// <returns>True if the value is 'truthy', 'false' if the value is 'falsey', null otherwise.</returns>
+        public static bool? ToBooleany(this string str)
+        {
+            if (IsTruthy(str))
+            {
+                return true;
+            }
+
+            if (IsFalsey(str))
+            {
+                return false;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Check if the string is considered to be either 'truthy' or 'falsey' (values considered equivalent to 'true' and 'false').
+        /// </summary>
+        /// <remarks>
+        /// Git considers several different values to be equivalent to 'true' and 'false'; we try to be consistent with this
+        /// behavior.
+        /// <para/>
+        /// See the following Git documentation for a list of values considered to be equivalent to 'true' and 'false':
+        /// https://git-scm.com/docs/git-config#git-config-boolean
+        /// </remarks>
+        /// <param name="str">String value to check.</param>
+        /// <param name="defaultValue">Default value to return if the string is neither 'truthy', 'falsey', or has not been set.</param>
+        /// <returns>True if the value is 'truthy', 'false' if the value is 'falsey', <paramref name="defaultValue"/> otherwise.</returns>
+        public static bool ToBooleanyOrDefault(this string str, bool defaultValue)
+        {
+            return ToBooleany(str) ?? defaultValue;
+        }
+
+        /// <summary>
+        /// Truncate the string from the first index of the given character, also removing the indexed character.
+        /// </summary>
+        /// <param name="str">String to truncate.</param>
+        /// <param name="c">Character to locate the index of.</param>
+        /// <returns>Truncated string.</returns>
+        public static string TruncateFromIndexOf(this string str, char c)
+        {
+            EnsureArgument.NotNull(str, nameof(str));
+
+            int last = str.IndexOf(c);
+            if (last > -1)
+            {
+                return str.Substring(0, last);
+            }
+
+            return str;
+        }
+
+        /// <summary>
+        /// Truncate the string from the last index of the given character, also removing the indexed character.
+        /// </summary>
+        /// <param name="str">String to truncate.</param>
+        /// <param name="c">Character to locate the index of.</param>
+        /// <returns>Truncated string.</returns>
+        public static string TruncateFromLastIndexOf(this string str, char c)
+        {
+            EnsureArgument.NotNull(str, nameof(str));
+
+            int last = str.LastIndexOf(c);
+            if (last > -1)
+            {
+                return str.Substring(0, last);
+            }
+
+            return str;
+        }
+
+        /// <summary>
+        /// Trim all characters at the start of the string until the first index of the given character,
+        /// also removing the indexed character.
+        /// </summary>
+        /// <param name="str">String to trim.</param>
+        /// <param name="c">Character to locate the index of.</param>
+        /// <returns>Trimmed string.</returns>
+        public static string TrimUntilIndexOf(this string str, char c)
+        {
+            EnsureArgument.NotNull(str, nameof(str));
+
+            int first = str.IndexOf(c);
+            if (first > -1)
+            {
+                return str.Substring(first + 1, str.Length - first - 1);
+            }
+
+            return str;
+        }
+
+        /// <summary>
+        /// Trim all characters at the start of the string until the first index of the given string,
+        /// also removing the indexed character.
+        /// </summary>
+        /// <param name="str">String to trim.</param>
+        /// <param name="value">String to locate the index of.</param>
+        /// <param name="comparisonType">Comparison rule for locating the string.</param>
+        /// <returns>Trimmed string.</returns>
+        public static string TrimUntilIndexOf(this string str, string value, StringComparison comparisonType = StringComparison.Ordinal)
+        {
+            EnsureArgument.NotNull(str, nameof(str));
+
+            int first = str.IndexOf(value, comparisonType);
+            if (first > -1)
+            {
+                return str.Substring(first + value.Length, str.Length - first - value.Length);
+            }
+
+            return str;
+        }
+
+        /// <summary>
+        /// Trim all characters at the start of the string until the last index of the given character,
+        /// also removing the indexed character.
+        /// </summary>
+        /// <param name="str">String to trim.</param>
+        /// <param name="c">Character to locate the index of.</param>
+        /// <returns>Trimmed string.</returns>
+        public static string TrimUntilLastIndexOf(this string str, char c)
+        {
+            EnsureArgument.NotNull(str, nameof(str));
+
+            int first = str.LastIndexOf(c);
+            if (first > -1)
+            {
+                return str.Substring(first + 1, str.Length - first - 1);
+            }
+
+            return str;
+        }
+
+        /// <summary>
+        /// Trim all characters at the start of the string until the last index of the given string,
+        /// also removing the indexed character.
+        /// </summary>
+        /// <param name="str">String to trim.</param>
+        /// <param name="value">String to locate the index of.</param>
+        /// <param name="comparisonType">Comparison rule for locating the string.</param>
+        /// <returns>Trimmed string.</returns>
+        public static string TrimUntilLastIndexOf(this string str, string value, StringComparison comparisonType = StringComparison.Ordinal)
+        {
+            EnsureArgument.NotNull(str, nameof(str));
+
+            int first = str.LastIndexOf(value, comparisonType);
+            if (first > -1)
+            {
+                return str.Substring(first + value.Length, str.Length - first - value.Length);
+            }
+
+            return str;
+        }
+
+        /// <summary>
+        /// Trim the matching value from the middle of the string.
+        /// </summary>
+        /// <param name="str">String to trim.</param>
+        /// <param name="value">String to locate and remove.</param>
+        /// <param name="comparisonType">Comparison rule for locating the string.</param>
+        /// <returns>Trimmed string.</returns>
+        public static string TrimMiddle(this string str, string value, StringComparison comparisonType = StringComparison.Ordinal)
+        {
+            int index = str.IndexOf(value, comparisonType);
+
+            if (index > -1)
+            {
+                return str.Substring(0, index) +
+                       str.Substring(index + value.Length);
+            }
+
+            return str;
+        }
+
+        /// <summary>
+        /// Check whether string contains a specified substring.
+        /// </summary>
+        /// <param name="str">String to check.</param>
+        /// <param name="value">String to locate.</param>
+        /// <param name="comparisonType">Comparison rule for comparing the strings.</param>
+        /// <returns>True if the string contains the substring, false if not.</returns>
+        public static bool Contains(this string str, string value, StringComparison comparisonType)
+        {
+            return str?.IndexOf(value, comparisonType) >= 0;
+        }
+
+        /// <summary>
+        /// Convert string to snake case.
+        /// </summary>
+        /// <param name="str">String to convert.</param>
+        /// <returns>Input string converted to snake case.</returns>
+        public static string ToSnakeCase(this string str)
+        {
+            int len = str.Length;
+            var sb = new StringBuilder(2*len);
+            for (int i = 0; i < len; i++)
+            {
+                if (i > 0 && char.IsUpper(str[i]) &&
+                    (char.IsLower(str[i - 1]) || i < len - 1 && char.IsLower(str[i + 1])))
+                {
+                    sb.Append('_');
+
+                }
+                sb.Append(char.ToLower(str[i]));
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/src/Core/Trace.cs
+++ b/src/Core/Trace.cs
@@ -1,0 +1,344 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace GitCredentialManager
+{
+    /// <summary>
+    /// Represents the application's tracing system.
+    /// </summary>
+    public interface ITrace : IDisposable
+    {
+        /// <summary>
+        /// True if any listeners have been added to the tracing system.
+        /// </summary>
+        bool HasListeners { get; }
+
+        /// <summary>
+        /// Get or set whether or not sensitive information such as secrets and credentials should be
+        /// output to attached trace listeners.
+        /// </summary>
+        bool IsSecretTracingEnabled { get; set; }
+
+        /// <summary>
+        /// Add a listener to the trace writer.
+        /// </summary>
+        /// <param name="listener">The listener to add.</param>
+        void AddListener(TextWriter listener);
+
+        /// <summary>
+        /// Forces any pending trace messages to be written to any listeners.
+        /// </summary>
+        void Flush();
+
+        /// <summary>
+        /// Writes an exception as a message to the trace writer.
+        /// <para/>
+        /// Expands exceptions' inner exceptions into additional trace lines.
+        /// </summary>
+        /// <param name="exception">The exception to write.</param>
+        /// <param name="filePath">Path of the file this method is called from.</param>
+        /// <param name="lineNumber">Line number of file this method is called from.</param>
+        /// <param name="memberName">Name of the member in which this method is called.</param>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
+        void WriteException(
+            Exception exception,
+            [System.Runtime.CompilerServices.CallerFilePath] string filePath = "",
+            [System.Runtime.CompilerServices.CallerLineNumber] int lineNumber = 0,
+            [System.Runtime.CompilerServices.CallerMemberName] string memberName = "");
+
+        /// <summary>
+        /// Write the contents of a dictionary to the trace writer.
+        /// <para/>
+        /// Calls <see cref="object.ToString"/> on all keys and values.
+        /// </summary>
+        /// <param name="dictionary">The dictionary to write.</param>
+        /// <param name="filePath">Path of the file this method is called from.</param>
+        /// <param name="lineNumber">Line number of file this method is called from.</param>
+        /// <param name="memberName">Name of the member in which this method is called.</param>
+        void WriteDictionary<TKey, TValue>(
+            IDictionary<TKey, TValue> dictionary,
+            [System.Runtime.CompilerServices.CallerFilePath] string filePath = "",
+            [System.Runtime.CompilerServices.CallerLineNumber] int lineNumber = 0,
+            [System.Runtime.CompilerServices.CallerMemberName] string memberName = "");
+
+        /// <summary>
+        /// Write the contents of a dictionary that contains sensitive information to the trace writer.
+        /// <para/>
+        /// Calls <see cref="object.ToString"/> on all keys and values, except keys specified as secret.
+        /// </summary>
+        /// <param name="dictionary">The dictionary to write.</param>
+        /// <param name="secretKeys">Dictionary keys that contain secrets/sensitive information.</param>
+        /// <param name="keyComparer">Comparer to use for <paramref name="secretKeys"/>.</param>
+        /// <param name="filePath">Path of the file this method is called from.</param>
+        /// <param name="lineNumber">Line number of file this method is called from.</param>
+        /// <param name="memberName">Name of the member in which this method is called.</param>
+        void WriteDictionarySecrets<TKey, TValue>(
+            IDictionary<TKey, TValue> dictionary,
+            TKey[] secretKeys,
+            IEqualityComparer<TKey> keyComparer = null,
+            [System.Runtime.CompilerServices.CallerFilePath] string filePath = "",
+            [System.Runtime.CompilerServices.CallerLineNumber] int lineNumber = 0,
+            [System.Runtime.CompilerServices.CallerMemberName] string memberName = "");
+
+        /// <summary>
+        /// Writes a message to the trace writer followed by a line terminator.
+        /// </summary>
+        /// <param name="message">The message to write.</param>
+        /// <param name="filePath">Path of the file this method is called from.</param>
+        /// <param name="lineNumber">Line number of file this method is called from.</param>
+        /// <param name="memberName">Name of the member in which this method is called.</param>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
+        void WriteLine(
+            string message,
+            [System.Runtime.CompilerServices.CallerFilePath] string filePath = "",
+            [System.Runtime.CompilerServices.CallerLineNumber] int lineNumber = 0,
+            [System.Runtime.CompilerServices.CallerMemberName] string memberName = "");
+
+        /// <summary>
+        /// Writes a message containing sensitive information to the trace writer followed by a line terminator.
+        /// <para/>
+        /// Attached listeners will only receive the fully formatted message if <see cref="IsSecretTracingEnabled"/> is set
+        /// to true, otherwise the secret arguments will be masked.
+        /// </summary>
+        /// <param name="format">The format string to write.</param>
+        /// <param name="secrets">Sensitive/secret arguments for the format string.</param>
+        /// <param name="filePath">Path of the file this method is called from.</param>
+        /// <param name="lineNumber">Line number of file this method is called from.</param>
+        /// <param name="memberName">Name of the member in which this method is called.</param>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
+        void WriteLineSecrets(
+            string format,
+            object[] secrets,
+            [System.Runtime.CompilerServices.CallerFilePath] string filePath = "",
+            [System.Runtime.CompilerServices.CallerLineNumber] int lineNumber = 0,
+            [System.Runtime.CompilerServices.CallerMemberName] string memberName = "");
+    }
+
+    public class Trace : DisposableObject, ITrace
+    {
+        private const string SecretMask = "********";
+
+        private readonly object _writersLock = new object();
+        private readonly List<TextWriter> _writers = new List<TextWriter>();
+
+        public bool HasListeners
+        {
+            get
+            {
+                lock (_writersLock)
+                {
+                    return _writers.Any();
+                }
+            }
+        }
+
+        public bool IsSecretTracingEnabled { get; set; }
+
+        public void AddListener(TextWriter listener)
+        {
+            ThrowIfDisposed();
+
+            lock (_writersLock)
+            {
+                // Try not to add the same listener more than once
+                if (_writers.Contains(listener))
+                    return;
+
+                _writers.Add(listener);
+            }
+        }
+
+        public void Flush()
+        {
+            ThrowIfDisposed();
+
+            lock (_writersLock)
+            {
+                foreach (var writer in _writers)
+                {
+                    try
+                    {
+                        writer?.Flush();
+                    }
+                    catch
+                    { /* squelch */ }
+                }
+            }
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
+        public void WriteException(
+            Exception exception,
+            [System.Runtime.CompilerServices.CallerFilePath] string filePath = "",
+            [System.Runtime.CompilerServices.CallerLineNumber] int lineNumber = 0,
+            [System.Runtime.CompilerServices.CallerMemberName] string memberName = "")
+        {
+            // Exception being null probably won't happen, but we shouldn't die because we failed to trace it.
+            if (exception is null)
+                return;
+
+            WriteLine($"! error: '{exception.Message}'.", filePath, lineNumber, memberName);
+
+            while ((exception = exception.InnerException) != null)
+            {
+                WriteLine($"       > '{exception.Message}'.", filePath, lineNumber, memberName);
+            }
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
+        public void WriteDictionary<TKey, TValue>(
+            IDictionary<TKey, TValue> dictionary,
+            [System.Runtime.CompilerServices.CallerFilePath] string filePath = "",
+            [System.Runtime.CompilerServices.CallerLineNumber] int lineNumber = 0,
+            [System.Runtime.CompilerServices.CallerMemberName] string memberName = "")
+        {
+            foreach (KeyValuePair<TKey, TValue> entry in dictionary)
+            {
+                WriteLine($"\t{entry.Key}={entry.Value}", filePath, lineNumber, memberName);
+            }
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
+        public void WriteDictionarySecrets<TKey, TValue>(
+            IDictionary<TKey, TValue> dictionary,
+            TKey[] secretKeys,
+            IEqualityComparer<TKey> keyComparer = null,
+            [System.Runtime.CompilerServices.CallerFilePath] string filePath = "",
+            [System.Runtime.CompilerServices.CallerLineNumber] int lineNumber = 0,
+            [System.Runtime.CompilerServices.CallerMemberName] string memberName = "")
+        {
+            foreach (KeyValuePair<TKey, TValue> entry in dictionary)
+            {
+                bool isSecretEntry = !(secretKeys is null) &&
+                                     secretKeys.Contains(entry.Key, keyComparer ?? EqualityComparer<TKey>.Default);
+
+                void WriteSecretLine(string keySuffix, object value)
+                {
+                    var message = isSecretEntry && !IsSecretTracingEnabled
+                        ? $"\t{entry.Key}{keySuffix}={SecretMask}"
+                        : $"\t{entry.Key}{keySuffix}={value}";
+                    WriteLine(message, filePath, lineNumber, memberName);
+                }
+
+                if (entry.Value is IEnumerable<string> values)
+                {
+                    List<string> valueList = values.ToList();
+                    foreach (string value in valueList)
+                    {
+                        WriteSecretLine(valueList.Count > 1 ? "[]" : string.Empty, value);
+                    }
+                }
+                else
+                {
+                    WriteSecretLine(string.Empty, entry.Value);
+                }
+            }
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
+        public void WriteLine(
+            string message,
+            [System.Runtime.CompilerServices.CallerFilePath] string filePath = "",
+            [System.Runtime.CompilerServices.CallerLineNumber] int lineNumber = 0,
+            [System.Runtime.CompilerServices.CallerMemberName] string memberName = "")
+        {
+            ThrowIfDisposed();
+
+            lock (_writersLock)
+            {
+                if (_writers.Count == 0)
+                {
+                    return;
+                }
+
+                string text = FormatText(message, filePath, lineNumber, memberName);
+
+                foreach (var writer in _writers)
+                {
+                    try
+                    {
+                        writer?.Write(text);
+                        writer?.Write('\n');
+                        writer?.Flush();
+                    }
+                    catch { /* squelch */ }
+                }
+            }
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
+        public void WriteLineSecrets(
+            string format,
+            object[] secrets,
+            [System.Runtime.CompilerServices.CallerFilePath] string filePath = "",
+            [System.Runtime.CompilerServices.CallerLineNumber] int lineNumber = 0,
+            [System.Runtime.CompilerServices.CallerMemberName] string memberName = "")
+        {
+            string message = this.IsSecretTracingEnabled
+                           ? string.Format(format, secrets)
+                           : string.Format(format, secrets.Select(_ => (object)SecretMask).ToArray());
+
+            WriteLine(message, filePath, lineNumber, memberName);
+        }
+
+        protected override void ReleaseManagedResources()
+        {
+            lock (_writersLock)
+            {
+                try
+                {
+                    for (int i = 0; i < _writers.Count; i += 1)
+                    {
+                        using (var writer = _writers[i])
+                        {
+                            _writers.Remove(writer);
+                        }
+                    }
+                }
+                catch
+                { /* squelch */ }
+            }
+
+            base.ReleaseManagedResources();
+        }
+
+        private static string FormatText(string message, string filePath, int lineNumber, string memberName)
+        {
+            const int sourceColumnMaxWidth = 23;
+
+            EnsureArgument.NotNull(message, nameof(message));
+            EnsureArgument.NotNull(filePath, nameof(filePath));
+            EnsureArgument.PositiveOrZero(lineNumber, nameof(lineNumber));
+            EnsureArgument.NotNull(memberName, nameof(memberName));
+
+            // Source column format is file:line
+            string source = $"{filePath}:{lineNumber}";
+
+            if (source.Length > sourceColumnMaxWidth)
+            {
+                source = TraceUtils.FormatSource(source, sourceColumnMaxWidth);
+            }
+
+            // Git's trace format is "{timestamp,-15} {source,-23} trace: {details}"
+            string text = $"{DateTime.Now:HH:mm:ss.ffffff} {source,-23} trace: [{memberName}] {message}";
+
+            return text;
+        }
+    }
+
+    public class DebugTraceWriter : TextWriter
+    {
+        public override Encoding Encoding => Encoding.UTF8;
+
+        public override void Write(char value) => Debug.Write(value);
+
+        public override void Write(string value) => Debug.Write(value);
+
+        public override void WriteLine(string value) => Debug.WriteLine(value);
+    }
+}

--- a/src/Core/Trace2.cs
+++ b/src/Core/Trace2.cs
@@ -1,0 +1,660 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Pipes;
+using System.Text;
+using System.Threading;
+
+namespace GitCredentialManager;
+
+/// <summary>
+/// The different event types tracked in the TRACE2 tracing
+/// system.
+/// </summary>
+public enum Trace2Event
+{
+    Version = 0,
+    Start = 1,
+    Exit = 2,
+    ChildStart = 3,
+    ChildExit = 4,
+    Error = 5,
+    RegionEnter = 6,
+    RegionLeave = 7,
+}
+
+/// <summary>
+/// Classifications of processes invoked by GCM.
+/// </summary>
+public enum Trace2ProcessClass
+{
+    None = 0,
+    UIHelper = 1,
+    Git = 2,
+    Other = 3
+}
+
+/// <summary>
+/// Stores various TRACE2 format targets user has enabled.
+/// Check <see cref="Trace2FormatTarget"/> for supported formats.
+/// </summary>
+public class Trace2Settings
+{
+    public IDictionary<Trace2FormatTarget, string> FormatTargetsAndValues { get; set; } =
+        new Dictionary<Trace2FormatTarget, string>();
+}
+
+/// <summary>
+/// Specifies a "text span" (i.e. space between two pipes) for the performance format target.
+/// </summary>
+public class PerformanceFormatSpan
+{
+    public int Size { get; set; }
+
+    public int BeginPadding { get; set; }
+
+    public int EndPadding { get; set; }
+}
+
+/// <summary>
+/// Class that manages regions.
+/// </summary>
+public class Region : DisposableObject
+{
+    private readonly ITrace2 _trace2;
+    private readonly string _category;
+    private readonly string _label;
+    private readonly string _filePath;
+    private readonly int _lineNumber;
+    private readonly string _message;
+    private readonly DateTimeOffset _startTime;
+
+    public Region(ITrace2 trace2, string category, string label, string filePath, int lineNumber, string message = "")
+    {
+        _trace2 = trace2;
+        _category = category;
+        _label = label;
+        _filePath = filePath;
+        _lineNumber = lineNumber;
+        _message = message;
+
+        _startTime = DateTimeOffset.UtcNow;
+
+        _trace2.WriteRegionEnter(_category, _label, _message, _filePath, _lineNumber);
+    }
+
+    protected override void ReleaseManagedResources()
+    {
+        double relativeTime = (DateTimeOffset.UtcNow - _startTime).TotalSeconds;
+        _trace2.WriteRegionLeave(relativeTime, _category, _label, _message, _filePath, _lineNumber);
+    }
+}
+
+/// <summary>
+/// Represents the application's TRACE2 tracing system.
+/// </summary>
+public interface ITrace2 : IDisposable
+{
+    /// <summary>
+    /// Initialize TRACE2 tracing by initializing multi-use fields and setting up any configured target formats.
+    /// </summary>
+    /// <param name="startTime">Approximate time calling application began executing.</param>
+    void Initialize(DateTimeOffset startTime);
+
+    /// <summary>
+    /// Write Version and Start events.
+    /// </summary>
+    /// <param name="appPath">The path to the application.</param>
+    /// <param name="args">Args passed to the application (if applicable).</param>
+    /// <param name="filePath">Path of the file this method is called from.</param>
+    /// <param name="lineNumber">Line number of file this method is called from.</param>
+    void Start(string appPath,
+        string[] args,
+        [System.Runtime.CompilerServices.CallerFilePath] string filePath = "",
+        [System.Runtime.CompilerServices.CallerLineNumber] int lineNumber = 0);
+
+    /// <summary>
+    /// Write Exit event and dispose of writers.
+    /// </summary>
+    /// <param name="exitCode">The exit code of the GCM application.</param>
+    /// <param name="filePath">Path of the file this method is called from.</param>
+    /// <param name="lineNumber">Line number of file this method is called from.</param>
+    void Stop(int exitCode,
+        [System.Runtime.CompilerServices.CallerFilePath] string filePath = "",
+        [System.Runtime.CompilerServices.CallerLineNumber] int lineNumber = 0);
+
+    /// <summary>
+    /// Writes information related to startup of child process to trace writer.
+    /// </summary>
+    /// <param name="startTime">Time at which child process began executing.</param>
+    /// <param name="processClass">Process classification.</param>
+    /// <param name="useShell">Specifies whether or not OS shell was used to start the process.</param>
+    /// <param name="appName">Name of application running in child process.</param>
+    /// <param name="argv">Arguments specific to the child process.</param>
+    /// <param name="sid">The child process's session id.</param>
+    /// <param name="filePath">Path of the file this method is called from.</param>
+    /// <param name="lineNumber">Line number of file this method is called from.</param>
+    void WriteChildStart(DateTimeOffset startTime,
+        Trace2ProcessClass processClass,
+        bool useShell,
+        string appName,
+        string argv,
+        [System.Runtime.CompilerServices.CallerFilePath]
+        string filePath = "",
+        [System.Runtime.CompilerServices.CallerLineNumber]
+        int lineNumber = 0);
+
+    /// <summary>
+    /// Writes information related to exit of child process to trace writer.
+    /// </summary>
+    /// <param name="relativeTime">Runtime of child process.</param>
+    /// <param name="pid">Id of exiting process.</param>
+    /// <param name="code">Process exit code.</param>
+    /// <param name="filePath">Path of the file this method is called from.</param>
+    /// <param name="lineNumber">Line number of file this method is called from.</param>
+    void WriteChildExit(
+        double relativeTime,
+        int pid,
+        int code,
+        [System.Runtime.CompilerServices.CallerFilePath]
+        string filePath = "",
+        [System.Runtime.CompilerServices.CallerLineNumber]
+        int lineNumber = 0);
+
+    /// <summary>
+    /// Writes an error as a message to the trace writer.
+    /// </summary>
+    /// <param name="errorMessage">The error message to write.</param>
+    /// <param name="parameterizedMessage">The error format string.</param>
+    /// <param name="filePath">Path of the file this method is called from.</param>
+    /// <param name="lineNumber">Line number of file this method is called from.</param>
+    void WriteError(
+        string errorMessage,
+        string parameterizedMessage = null,
+        [System.Runtime.CompilerServices.CallerFilePath]
+        string filePath = "",
+        [System.Runtime.CompilerServices.CallerLineNumber]
+        int lineNumber = 0);
+
+    /// <summary>
+    /// Creates a region and manages entry/leaving.
+    /// </summary>
+    /// <param name="category">Category of region.</param>
+    /// <param name="label">Description of region.</param>
+    /// <param name="message">Message associated with entering region.</param>
+    /// <param name="filePath">Path of the file this method is called from.</param>
+    /// <param name="lineNumber">Line number of file this method is called from.</param>
+    Region CreateRegion(
+        string category,
+        string label,
+        string message = "",
+        [System.Runtime.CompilerServices.CallerFilePath]
+        string filePath = "",
+        [System.Runtime.CompilerServices.CallerLineNumber]
+        int lineNumber = 0);
+
+    /// <summary>
+    /// Writes a region enter message to the trace writer.
+    /// </summary>
+    /// <param name="category">Category of region.</param>
+    /// <param name="label">Description of region.</param>
+    /// <param name="message">Message associated with entering region.</param>
+    /// <param name="filePath">Path of the file this method is called from.</param>
+    /// <param name="lineNumber">Line number of file this method is called from.</param>
+    void WriteRegionEnter(
+        string category,
+        string label,
+        string message = "",
+        [System.Runtime.CompilerServices.CallerFilePath]
+        string filePath = "",
+        [System.Runtime.CompilerServices.CallerLineNumber]
+        int lineNumber = 0);
+
+    /// <summary>
+    /// Writes a region leave message to the trace writer.
+    /// </summary>
+    /// <param name="relativeTime">Time of region execution.</param>
+    /// <param name="category">Category of region.</param>
+    /// <param name="label">Description of region.</param>
+    /// <param name="message">Message associated with entering region.</param>
+    /// <param name="filePath">Path of the file this method is called from.</param>
+    /// <param name="lineNumber">Line number of file this method is called from.</param>
+    void WriteRegionLeave(
+        double relativeTime,
+        string category,
+        string label,
+        string message = "",
+        [System.Runtime.CompilerServices.CallerFilePath]
+        string filePath = "",
+        [System.Runtime.CompilerServices.CallerLineNumber]
+        int lineNumber = 0);
+}
+
+public class Trace2 : DisposableObject, ITrace2
+{
+    private readonly ICommandContext _commandContext;
+    private readonly object _writersLock = new object();
+    private readonly Encoding _utf8NoBomEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+    private readonly List<ITrace2Writer> _writers = new List<ITrace2Writer>();
+
+    private const string GitSidVariable = "GIT_TRACE2_PARENT_SID";
+
+    private DateTimeOffset _applicationStartTime;
+    private Trace2Settings _settings;
+    private string _sid;
+
+    private bool _initialized;
+    // Increment with each new child process that is tracked
+    private int _childProcCounter = 0;
+
+    public Trace2(ICommandContext commandContext)
+    {
+        _commandContext = commandContext;
+    }
+
+    public void Initialize(DateTimeOffset startTime)
+    {
+        if (_initialized)
+        {
+            return;
+        }
+
+        _applicationStartTime = startTime;
+        _settings = _commandContext.Settings.GetTrace2Settings();
+        _sid = ProcessManager.Sid;
+
+        InitializeWriters();
+
+        _initialized = true;
+    }
+
+    public void Start(string appPath,
+        string[] args,
+        string filePath,
+        int lineNumber)
+    {
+        if (!AssemblyUtils.TryGetAssemblyVersion(out string version))
+        {
+            // A version is required for TRACE2, so if this call fails
+            // manually set the version.
+            version = "0.0.0";
+        }
+        WriteVersion(version, filePath, lineNumber);
+        WriteStart(appPath, args, filePath, lineNumber);
+    }
+
+    public void Stop(int exitCode, string filePath, int lineNumber)
+    {
+        WriteExit(exitCode, filePath, lineNumber);
+    }
+
+    public void WriteChildStart(DateTimeOffset startTime,
+        Trace2ProcessClass processClass,
+        bool useShell,
+        string appName,
+        string argv,
+        string filePath = "",
+        int lineNumber = 0)
+    {
+        // Some child processes are started before TRACE2 can be initialized.
+        // Since certain dependencies are not available until initialization,
+        // we must immediately return if this method is invoked prior to
+        // initialization.
+        if (!_initialized)
+        {
+            return;
+        }
+
+        // Always add name of the application the process is executing
+        var procArgs = new List<string>()
+        {
+            Path.GetFileName(appName)
+        };
+
+        // If the process has arguments, append them.
+        if (!string.IsNullOrEmpty(argv))
+        {
+            procArgs.AddRange(argv.Split(' '));
+        }
+
+        WriteMessage(new ChildStartMessage()
+        {
+            Event = Trace2Event.ChildStart,
+            Sid = _sid,
+            Time = startTime,
+            Thread = BuildThreadName(),
+            File = Path.GetFileName(filePath),
+            Line = lineNumber,
+            Id = ++_childProcCounter,
+            Classification = processClass,
+            UseShell = useShell,
+            Argv = procArgs,
+            ElapsedTime = (DateTimeOffset.UtcNow - _applicationStartTime).TotalSeconds,
+            Depth = ProcessManager.Depth,
+        });
+    }
+
+    public void WriteChildExit(
+        double relativeTime,
+        int pid,
+        int code,
+        string filePath = "",
+        int lineNumber = 0)
+    {
+        // Some child processes are started before TRACE2 can be initialized.
+        // Since certain dependencies are not available until initialization,
+        // we must immediately return if this method is invoked prior to
+        // initialization.
+        if (!_initialized)
+        {
+            return;
+        }
+
+        WriteMessage(new ChildExitMessage()
+        {
+            Event = Trace2Event.ChildExit,
+            Sid = _sid,
+            Time = DateTimeOffset.UtcNow,
+            Thread = BuildThreadName(),
+            File = Path.GetFileName(filePath),
+            Line = lineNumber,
+            Id = _childProcCounter,
+            Pid = pid,
+            Code = code,
+            ElapsedTime = (DateTimeOffset.UtcNow - _applicationStartTime).TotalSeconds,
+            RelativeTime = relativeTime,
+            Depth = ProcessManager.Depth
+        });
+    }
+
+    public void WriteError(
+        string errorMessage,
+        string parameterizedMessage = null,
+        [System.Runtime.CompilerServices.CallerFilePath] string filePath = "",
+        [System.Runtime.CompilerServices.CallerLineNumber] int lineNumber = 0)
+    {
+        // It is possible for an error to be thrown before TRACE2 can be initialized.
+        // Since certain dependencies are not available until initialization,
+        // we must immediately return if this method is invoked prior to
+        // initialization.
+        if (!_initialized)
+        {
+            return;
+        }
+
+        WriteMessage(new ErrorMessage()
+        {
+            Event = Trace2Event.Error,
+            Sid = _sid,
+            Time = DateTimeOffset.UtcNow,
+            Thread = BuildThreadName(),
+            File = Path.GetFileName(filePath),
+            Line = lineNumber,
+            Message = errorMessage,
+            ParameterizedMessage = parameterizedMessage ?? errorMessage,
+            Depth = ProcessManager.Depth
+        });
+    }
+
+    public Region CreateRegion(
+        string category,
+        string label,
+        string message,
+        string filePath,
+        int lineNumber)
+    {
+        return new Region(this, category, label, filePath, lineNumber, message);
+    }
+
+    public void WriteRegionEnter(
+        string category,
+        string label,
+        string message = "",
+        string filePath = "",
+        int lineNumber = 0)
+    {
+        WriteMessage(new RegionEnterMessage()
+        {
+            Event = Trace2Event.RegionEnter,
+            Sid = _sid,
+            Time = DateTimeOffset.UtcNow,
+            Category = category,
+            Label = label,
+            Message = message == "" ? label : message,
+            Thread = BuildThreadName(),
+            File = Path.GetFileName(filePath),
+            Line = lineNumber,
+            ElapsedTime = (DateTimeOffset.UtcNow - _applicationStartTime).TotalSeconds,
+            Depth = ProcessManager.Depth
+        });
+    }
+
+    public void WriteRegionLeave(
+        double relativeTime,
+        string category,
+        string label,
+        string message = "",
+        string filePath = "",
+        int lineNumber = 0)
+    {
+        WriteMessage(new RegionLeaveMessage()
+        {
+            Event = Trace2Event.RegionLeave,
+            Sid = _sid,
+            Time = DateTimeOffset.UtcNow,
+            Category = category,
+            Label = label,
+            Message = message == "" ? label : message,
+            Thread = BuildThreadName(),
+            File = Path.GetFileName(filePath),
+            Line = lineNumber,
+            ElapsedTime = (DateTimeOffset.UtcNow - _applicationStartTime).TotalSeconds,
+            RelativeTime = relativeTime,
+            Depth = ProcessManager.Depth
+        });
+    }
+
+    protected override void ReleaseManagedResources()
+    {
+        lock (_writersLock)
+        {
+            try
+            {
+                for (int i = 0; i < _writers.Count; i += 1)
+                {
+                    using (var writer = _writers[i])
+                    {
+                        _writers.Remove(writer);
+                    }
+                }
+            }
+            catch
+            {
+                /* squelch */
+            }
+        }
+
+        base.ReleaseManagedResources();
+    }
+
+    internal static bool TryGetPipeName(string eventTarget, out string name)
+    {
+        // Use prefixes to determine whether target is a named pipe/socket
+        if (eventTarget.Contains("af_unix:", StringComparison.OrdinalIgnoreCase) ||
+            eventTarget.Contains("\\\\.\\pipe\\", StringComparison.OrdinalIgnoreCase) ||
+            eventTarget.Contains("/./pipe/", StringComparison.OrdinalIgnoreCase))
+        {
+            name = PlatformUtils.IsWindows()
+                ? eventTarget.TrimUntilLastIndexOf("\\")
+                : eventTarget.TrimUntilLastIndexOf(":");
+            return true;
+        }
+
+        name = "";
+        return false;
+    }
+
+    private void InitializeWriters()
+    {
+        // Set up the correct writer for every enabled format target.
+        foreach (var formatTarget in _settings.FormatTargetsAndValues)
+        {
+            if (TryGetPipeName(formatTarget.Value, out string name)) // Write to named pipe/socket
+            {
+                AddWriter(new Trace2CollectorWriter(formatTarget.Key, (
+                        () => new NamedPipeClientStream(".", name,
+                            PipeDirection.Out,
+                            PipeOptions.Asynchronous)
+                    )
+                ));
+            }
+            else if (formatTarget.Value.IsTruthy()) // Write to stderr
+            {
+                AddWriter(new Trace2StreamWriter(formatTarget.Key, _commandContext.Streams.Error));
+            }
+            else if (Path.IsPathRooted(formatTarget.Value)) // Write to file
+            {
+                try
+                {
+                    AddWriter(new Trace2FileWriter(formatTarget.Key, formatTarget.Value));
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"warning: unable to trace to file '{formatTarget.Value}': {ex.Message}");
+                }
+            }
+        }
+    }
+
+    private void WriteVersion(
+        string gcmVersion,
+        string filePath,
+        int lineNumber,
+        string eventFormatVersion = "3")
+    {
+        EnsureArgument.NotNull(gcmVersion, nameof(gcmVersion));
+
+        WriteMessage(new VersionMessage()
+        {
+            Event = Trace2Event.Version,
+            Sid = _sid,
+            Time = DateTimeOffset.UtcNow,
+            Thread = BuildThreadName(),
+            File = Path.GetFileName(filePath),
+            Line = lineNumber,
+            Evt = eventFormatVersion,
+            Exe = gcmVersion
+        });
+    }
+
+    private void WriteStart(
+        string appPath,
+        string[] args,
+        string filePath,
+        int lineNumber)
+    {
+        // Prepend GCM exe to arguments
+        var argv = new List<string>()
+        {
+            Path.GetFileName(appPath),
+        };
+
+        if (args.Length > 0)
+        {
+            argv.AddRange(args);
+        }
+
+        WriteMessage(new StartMessage()
+        {
+            Event = Trace2Event.Start,
+            Sid = _sid,
+            Time = DateTimeOffset.UtcNow,
+            Thread = BuildThreadName(),
+            File = Path.GetFileName(filePath),
+            Line = lineNumber,
+            Argv = argv,
+            ElapsedTime = (DateTimeOffset.UtcNow - _applicationStartTime).TotalSeconds
+        });
+    }
+
+    private void WriteExit(int code, string filePath = "", int lineNumber = 0)
+    {
+        EnsureArgument.NotNull(code, nameof(code));
+
+        WriteMessage(new ExitMessage()
+        {
+            Event = Trace2Event.Exit,
+            Sid = _sid,
+            Time = DateTimeOffset.UtcNow,
+            Thread = BuildThreadName(),
+            File = Path.GetFileName(filePath),
+            Line = lineNumber,
+            Code = code,
+            ElapsedTime = (DateTimeOffset.UtcNow - _applicationStartTime).TotalSeconds
+        });
+    }
+
+    private void AddWriter(ITrace2Writer writer)
+    {
+        ThrowIfDisposed();
+
+        lock (_writersLock)
+        {
+            // Try not to add the same writer more than once
+            if (_writers.Contains(writer))
+                return;
+
+            _writers.Add(writer);
+        }
+    }
+
+    private void WriteMessage(Trace2Message message)
+    {
+        ThrowIfDisposed();
+
+        if (!_initialized)
+        {
+            return;
+        }
+
+        lock (_writersLock)
+        {
+            if (_writers.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var writer in _writers)
+            {
+                if (!writer.Failed)
+                {
+                    writer.Write(message);
+                }
+            }
+        }
+    }
+
+    private static string BuildThreadName()
+    {
+        // If this is the entry thread, call it "main", per Trace2 convention
+        if (Thread.CurrentThread.ManagedThreadId == 0)
+        {
+            return "main";
+        }
+
+        // If this is a thread pool thread, name it as such
+        if (Thread.CurrentThread.IsThreadPoolThread)
+        {
+            return $"thread_pool_{Environment.CurrentManagedThreadId}";
+        }
+
+        // Otherwise, if the thread is named, use it!
+        if (!string.IsNullOrEmpty(Thread.CurrentThread.Name))
+        {
+            return Thread.CurrentThread.Name;
+        }
+
+        // We don't know what this thread is!
+        return string.Empty;
+    }
+}

--- a/src/Core/Trace2CollectorWriter.cs
+++ b/src/Core/Trace2CollectorWriter.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.IO.Pipes;
+using System.Text;
+using System.Threading;
+using KnownGitCfg = GitCredentialManager.Constants.GitConfiguration;
+
+namespace GitCredentialManager
+{
+    /// <summary>
+    /// Accepts string messages from multiple threads and dispatches them over a named pipe from a
+    /// background thread.
+    /// </summary>
+    public class Trace2CollectorWriter : Trace2Writer
+    {
+        private const int DefaultMaxQueueSize = 256;
+
+        private readonly Func<NamedPipeClientStream> _createPipeFunc;
+        private readonly BlockingCollection<string> _queue;
+
+        private Thread _writerThread;
+        private NamedPipeClientStream _pipeClient;
+
+        public Trace2CollectorWriter(Trace2FormatTarget formatTarget,
+            Func<NamedPipeClientStream> createPipeFunc,
+            int maxQueueSize = DefaultMaxQueueSize) : base(formatTarget)
+        {
+            EnsureArgument.NotNull(createPipeFunc, nameof(createPipeFunc));
+            EnsureArgument.Positive(maxQueueSize, nameof(maxQueueSize));
+
+            _createPipeFunc = createPipeFunc;
+            _queue = new BlockingCollection<string>(new ConcurrentQueue<string>(), boundedCapacity: maxQueueSize);
+
+            Start();
+        }
+
+        public override void Write(Trace2Message message)
+        {
+           _queue.TryAdd(message.ToJson());
+        }
+
+        protected override void ReleaseManagedResources()
+        {
+            Stop();
+
+            _pipeClient?.Dispose();
+            _queue.Dispose();
+            base.ReleaseManagedResources();
+
+            _pipeClient = null;
+            _writerThread = null;
+        }
+
+        private void Start()
+        {
+            try
+            {
+                _writerThread = new Thread(BackgroundWriterThreadProc)
+                {
+                    Name = nameof(Trace2CollectorWriter),
+                    IsBackground = true
+                };
+
+                _writerThread.Start();
+                // Create a new pipe stream instance using the provided factory
+                _pipeClient = _createPipeFunc();
+
+                // Specify an instantaneous timeout because we don't want to hold up the
+                // background thread loop if the pipe is not available.
+                _pipeClient.Connect(timeout: 0);
+            }
+            catch
+            {
+                // Start failed. Disable this writer for this run.
+                Failed = true;
+            }
+        }
+
+        private void Stop()
+        {
+            if (_queue.IsAddingCompleted)
+            {
+                return;
+            }
+
+            // Signal to the queue draining thread that it should drain once more and then terminate.
+            _queue.CompleteAdding();
+            _writerThread.Join();
+            ReleaseManagedResources();
+        }
+
+        private void BackgroundWriterThreadProc()
+        {
+            // Drain the queue of all messages currently in the queue.
+            // TryTake() using an infinite timeout will block until either a message is available (returns true)
+            // or the queue has been marked as completed _and_ is empty (returns false).
+            while (_queue.TryTake(out string message, Timeout.Infinite))
+            {
+                if (message != null)
+                {
+                    WriteMessage(message);
+                }
+            }
+        }
+
+        private void WriteMessage(string message)
+        {
+            try
+            {
+                // We should signal the end of each message with a line-feed (LF) character.
+                if (!message.EndsWith("\n"))
+                {
+                    message += '\n';
+                }
+
+                byte[] data = Encoding.UTF8.GetBytes(message);
+                _pipeClient.Write(data, 0, data.Length);
+                _pipeClient.Flush();
+            }
+            catch
+            {
+                // We can't send this message for some reason (e.g., broken pipe); we attempt no recovery or retry
+                // mechanism but rather disable the writer for the rest of this run.
+                Failed = true;
+            }
+        }
+    }
+}

--- a/src/Core/Trace2Exception.cs
+++ b/src/Core/Trace2Exception.cs
@@ -1,0 +1,75 @@
+using System;
+using System.ComponentModel;
+using System.IO;
+using GitCredentialManager.Authentication.OAuth;
+using GitCredentialManager.Interop;
+
+namespace GitCredentialManager;
+
+public class Trace2Exception : Exception
+{
+    public Trace2Exception(ITrace2 trace2, string message) : base(message)
+    {
+        trace2.WriteError(message);
+    }
+
+    public Trace2Exception(ITrace2 trace2, string message, string messageFormat) : base(message)
+    {
+        trace2.WriteError(message, messageFormat);
+    }
+}
+
+public class Trace2InvalidOperationException : InvalidOperationException
+{
+    public Trace2InvalidOperationException(ITrace2 trace2, string message) : base(message)
+    {
+        trace2.WriteError(message);
+    }
+}
+
+public class Trace2OAuth2Exception : OAuth2Exception
+{
+    public Trace2OAuth2Exception(ITrace2 trace2, string message) : base(message)
+    {
+        trace2.WriteError(message);
+    }
+
+    public Trace2OAuth2Exception(ITrace2 trace2, string message, string messageFormat) : base(message)
+    {
+        trace2.WriteError(message, messageFormat);
+    }
+}
+
+public class Trace2InteropException : InteropException
+{
+    public Trace2InteropException(ITrace2 trace2, string message, int errorCode) : base(message, errorCode)
+    {
+        trace2.WriteError($"message: {message} error code: {errorCode}");
+    }
+
+    public Trace2InteropException(ITrace2 trace2, string message, Win32Exception ex) : base(message, ex)
+    {
+        trace2.WriteError(message);
+    }
+}
+
+public class Trace2GitException : GitException
+{
+    public Trace2GitException(ITrace2 trace2, string message, int errorCode, string gitMessage) :
+        base(message, gitMessage, errorCode)
+    {
+        var format = $"message: '{message}' error code: '{errorCode}' git message: '{{0}}'";
+        var traceMessage = string.Format(format, gitMessage);
+
+        trace2.WriteError(traceMessage, format);
+    }
+}
+
+public class Trace2FileNotFoundException : FileNotFoundException
+{
+    public Trace2FileNotFoundException(ITrace2 trace2, string message, string messageFormat, string fileName) :
+        base(message, fileName)
+    {
+        trace2.WriteError(message, messageFormat);
+    }
+}

--- a/src/Core/Trace2FileWriter.cs
+++ b/src/Core/Trace2FileWriter.cs
@@ -1,0 +1,40 @@
+using System.IO;
+using System;
+
+namespace GitCredentialManager;
+
+public class Trace2FileWriter : Trace2Writer
+{
+    private readonly string _path;
+
+    public Trace2FileWriter(Trace2FormatTarget formatTarget, string path) : base(formatTarget)
+    {
+        _path = path;
+    }
+
+    public override void Write(Trace2Message message)
+    {
+        try
+        {
+            File.AppendAllText(_path, Format(message));
+        }
+        catch (DirectoryNotFoundException)
+        {
+            // Do nothing, as this either means we don't have the
+            // parent directories above the file, or this trace2
+            // target points to a directory.
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // Do nothing, as this either means the file is not
+            // accessible with current permissions, or we are on
+            // Windows and the file is currently open for writing
+            // by another process (likely Git itself.)
+        }
+        catch (IOException)
+        {
+            // Do nothing, as this likely means that the file is currently
+            // open by another process (on Windows).
+        }
+    }
+}

--- a/src/Core/Trace2Message.cs
+++ b/src/Core/Trace2Message.cs
@@ -1,0 +1,535 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace GitCredentialManager;
+
+public abstract class Trace2Message
+{
+    private const int SourceColumnMaxWidth = 23;
+    private const string NormalPerfTimeFormat = "HH:mm:ss.ffffff";
+
+    protected const string EmptyPerformanceSpan =  "|     |           |           |             ";
+    protected static readonly JsonSerializerOptions JsonSerializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter(new SnakeCaseNamingPolicy()) }
+    };
+
+    [JsonPropertyName("event")]
+    [JsonPropertyOrder(1)]
+    public Trace2Event Event { get; set; }
+
+    [JsonPropertyName("sid")]
+    [JsonPropertyOrder(2)]
+    public string Sid { get; set; }
+
+    [JsonPropertyName("thread")]
+    [JsonPropertyOrder(3)]
+    public string Thread { get; set; }
+
+    [JsonPropertyName("time")]
+    [JsonPropertyOrder(4)]
+    public DateTimeOffset Time { get; set; }
+
+    [JsonPropertyName("file")]
+    [JsonPropertyOrder(5)]
+    public string File { get; set; }
+
+    [JsonPropertyName("line")]
+    [JsonPropertyOrder(6)]
+    public int Line { get; set; }
+
+    [JsonPropertyName("depth")]
+    [JsonPropertyOrder(7)]
+    public int Depth { get; set; }
+
+    public abstract string ToJson();
+
+    public abstract string ToNormalString();
+
+    public abstract string ToPerformanceString();
+
+    protected abstract string BuildPerformanceSpan();
+
+    protected string BuildNormalString()
+    {
+        string message = GetEventMessage(Trace2FormatTarget.Normal);
+
+        // The normal format uses local time rather than UTC time.
+        string time = Time.ToLocalTime().ToString(NormalPerfTimeFormat);
+        string source = GetSource();
+
+        // Git's TRACE2 normal format is:
+        // [<time> SP <filename>:<line> SP+] <event-name> [[SP] <event-message>] LF
+        return $"{time} {source,-33} {Event.ToString().ToSnakeCase()} {message}";
+    }
+
+    protected string BuildPerformanceString()
+    {
+        string message = GetEventMessage(Trace2FormatTarget.Performance);
+
+        // The performance format uses local time rather than UTC time.
+        var time = Time.ToLocalTime().ToString(NormalPerfTimeFormat);
+        var source = GetSource();
+
+        // Git's TRACE2 performance format is:
+        // [<time> SP <filename>:<line> SP+
+        //     BAR SP] d<depth> SP
+        //     BAR SP <thread-name> SP+
+        //     BAR SP <event-name> SP+
+        //     BAR SP [r<repo-id>] SP+
+        //     BAR SP [<t_abs>] SP+
+        //     BAR SP [<t_rel>] SP+
+        //     BAR SP [<category>] SP+
+        //     BAR SP DOTS* <perf-event-message>
+        //     LF
+        return $"{time} {source,-29}| d{Depth} | {Thread,-24} | {Event.ToString().ToSnakeCase(),-12} {BuildPerformanceSpan()} | {message}";
+    }
+
+    protected abstract string GetEventMessage(Trace2FormatTarget formatTarget);
+
+    private string GetSource()
+    {
+        // Source column format is file:line
+        string source = $"{File}:{Line}";
+        if (source.Length > SourceColumnMaxWidth)
+        {
+            return TraceUtils.FormatSource(source, SourceColumnMaxWidth);
+        }
+
+        return source;
+    }
+
+    internal static string BuildTimeSpan(double time)
+    {
+        var timeString = time.ToString("F6");
+        var component = new PerformanceFormatSpan()
+        {
+            Size = 11,
+            BeginPadding = 2,
+            EndPadding = 1
+        };
+
+        return BuildSpan(component, timeString);
+    }
+
+    internal static string BuildCategorySpan(string category)
+    {
+        var component = new PerformanceFormatSpan()
+        {
+            Size = 13,
+            BeginPadding = 1,
+            EndPadding = 1
+        };
+
+        return BuildSpan(component, category);
+    }
+
+    internal static string BuildRepoSpan(int repo)
+    {
+        var component = new PerformanceFormatSpan()
+        {
+            Size = 5,
+            BeginPadding = 1,
+            EndPadding = 2
+        };
+
+        return BuildSpan(component, $"r{repo}");
+    }
+
+    private static string BuildSpan(PerformanceFormatSpan component, string data)
+    {
+        var paddingTotal = component.BeginPadding + component.EndPadding;
+        var dataLimit = component.Size - paddingTotal;
+        var sizeDifference = dataLimit - data.Length;
+
+        if (sizeDifference <= 0)
+        {
+            if (double.TryParse(data, out _))
+            {
+                // Remove all padding for values that take up the entire span
+                if (Math.Abs(sizeDifference) == paddingTotal)
+                {
+                    component.BeginPadding = 0;
+                    component.EndPadding = 0;
+                }
+                else
+                {
+                    // Decrease BeginPadding for large time values that don't occupy entire span
+                    component.BeginPadding += sizeDifference;
+                }
+            }
+            else
+            {
+                // Truncate value
+                data = data.Substring(0, dataLimit);
+            }
+        }
+
+        if (data.Length < dataLimit)
+        {
+            // Increase end padding for short values
+            component.EndPadding += sizeDifference;
+        }
+
+        var beginPadding = new string(' ', component.BeginPadding);
+        var endPadding = new string(' ', component.EndPadding);
+
+        return $"{beginPadding}{data}{endPadding}";
+    }
+}
+
+public class VersionMessage : Trace2Message
+{
+    [JsonPropertyName("evt")]
+    [JsonPropertyOrder(8)]
+    public string Evt { get; set; }
+
+    [JsonPropertyName("exe")]
+    [JsonPropertyOrder(9)]
+    public string Exe { get; set; }
+
+    public override string ToJson()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializerOptions);
+    }
+
+    public override string ToNormalString()
+    {
+        return BuildNormalString();
+    }
+
+    public override string ToPerformanceString()
+    {
+        return BuildPerformanceString();
+    }
+
+    protected override string BuildPerformanceSpan()
+    {
+        return EmptyPerformanceSpan;
+    }
+
+    protected override string GetEventMessage(Trace2FormatTarget formatTarget)
+    {
+        return Exe.ToLower();
+    }
+}
+
+public class StartMessage : Trace2Message
+{
+    [JsonPropertyName("t_abs")]
+    [JsonPropertyOrder(8)]
+    public double ElapsedTime { get; set; }
+
+    [JsonPropertyName("argv")]
+    [JsonPropertyOrder(9)]
+    public List<string> Argv { get; set; }
+
+    public override string ToJson()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializerOptions);
+    }
+
+    public override string ToNormalString()
+    {
+        return BuildNormalString();
+    }
+
+    public override string ToPerformanceString()
+    {
+        return BuildPerformanceString();
+    }
+
+    protected override string BuildPerformanceSpan()
+    {
+        return $"|     |{BuildTimeSpan(ElapsedTime)}|           |             ";
+    }
+
+    protected override string GetEventMessage(Trace2FormatTarget formatTarget)
+    {
+        return string.Join(" ", Argv);
+    }
+}
+
+public class ExitMessage : Trace2Message
+{
+    [JsonPropertyName("t_abs")]
+    [JsonPropertyOrder(8)]
+    public double ElapsedTime { get; set; }
+
+    [JsonPropertyName("code")]
+    [JsonPropertyOrder(9)]
+    public int Code { get; set; }
+
+    public override string ToJson()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializerOptions);
+    }
+
+    public override string ToNormalString()
+    {
+        return BuildNormalString();
+    }
+
+    public override string ToPerformanceString()
+    {
+        return BuildPerformanceString();
+    }
+
+    protected override string BuildPerformanceSpan()
+    {
+        return $"|     |{BuildTimeSpan(ElapsedTime)}|           |             ";
+    }
+
+    protected override string GetEventMessage(Trace2FormatTarget formatTarget)
+    {
+        return $"elapsed:{ElapsedTime} code:{Code}";
+    }
+}
+
+public class ChildStartMessage : Trace2Message
+{
+    [JsonPropertyName("t_abs")]
+    [JsonPropertyOrder(8)]
+    public double ElapsedTime { get; set; }
+
+    [JsonPropertyName("argv")]
+    [JsonPropertyOrder(9)]
+    public IList<string> Argv { get; set; }
+
+    [JsonPropertyName("child_id")]
+    [JsonPropertyOrder(10)]
+    public long Id { get; set; }
+
+    [JsonPropertyName("child_class")]
+    [JsonPropertyOrder(11)]
+    public Trace2ProcessClass Classification { get; set; }
+
+    [JsonPropertyName("use_shell")]
+    [JsonPropertyOrder(12)]
+    public bool UseShell { get; set; }
+
+    public override string ToJson()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializerOptions);
+    }
+
+    public override string ToNormalString()
+    {
+        return BuildNormalString();
+    }
+
+    public override string ToPerformanceString()
+    {
+        return BuildPerformanceString();
+    }
+
+    protected override string BuildPerformanceSpan()
+    {
+        return $"|     |{BuildTimeSpan(ElapsedTime)}|           |             ";
+    }
+
+    protected override string GetEventMessage(Trace2FormatTarget formatTarget)
+    {
+        var sb = new StringBuilder();
+
+        if (formatTarget == Trace2FormatTarget.Performance)
+            sb.Append($"[ch{Id}]");
+        else
+            sb.Append($"[{Id}]");
+
+        sb.Append($" {string.Join(" ", Argv)}");
+
+        return sb.ToString();
+    }
+}
+
+public class ChildExitMessage : Trace2Message
+{
+    [JsonPropertyName("t_abs")]
+    [JsonPropertyOrder(8)]
+    public double ElapsedTime { get; set; }
+
+    [JsonPropertyName("t_rel")]
+    [JsonPropertyOrder(9)]
+    public double RelativeTime { get; set; }
+
+    [JsonPropertyName("child_id")]
+    [JsonPropertyOrder(10)]
+    public long Id { get; set; }
+
+    [JsonPropertyName("pid")]
+    [JsonPropertyOrder(11)]
+    public int Pid { get; set; }
+
+    [JsonPropertyName("code")]
+    [JsonPropertyOrder(12)]
+    public int Code { get; set; }
+
+    public override string ToJson()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializerOptions);
+    }
+
+    public override string ToNormalString()
+    {
+        return BuildNormalString();
+    }
+
+    public override string ToPerformanceString()
+    {
+        return BuildPerformanceString();
+    }
+
+    protected override string BuildPerformanceSpan()
+    {
+        return $"|     |{BuildTimeSpan(ElapsedTime)}|{BuildTimeSpan(RelativeTime)}|             ";
+    }
+
+    protected override string GetEventMessage(Trace2FormatTarget formatTarget)
+    {
+        var sb = new StringBuilder();
+
+        if (formatTarget == Trace2FormatTarget.Performance)
+            sb.Append($"[ch{Id}]");
+        else
+            sb.Append($"[{Id}]");
+
+        sb.Append($" pid:{Pid} code:{Code} elapsed:{RelativeTime}");
+        return sb.ToString();
+    }
+}
+
+public class ErrorMessage : Trace2Message
+{
+    [JsonPropertyName("msg")]
+    [JsonPropertyOrder(8)]
+    public string Message { get; set; }
+
+    [JsonPropertyName("format")]
+    [JsonPropertyOrder(9)]
+    public string ParameterizedMessage { get; set; }
+
+    public override string ToJson()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializerOptions);
+    }
+
+    public override string ToNormalString()
+    {
+        return BuildNormalString();
+    }
+
+    public override string ToPerformanceString()
+    {
+        return BuildPerformanceString();
+    }
+
+    protected override string BuildPerformanceSpan()
+    {
+        return EmptyPerformanceSpan;
+    }
+
+    protected override string GetEventMessage(Trace2FormatTarget formatTarget)
+    {
+        return Message;
+    }
+}
+
+public abstract class RegionMessage : Trace2Message
+{
+    [JsonPropertyName("t_abs")]
+    [JsonPropertyOrder(8)]
+    public double ElapsedTime { get; set; }
+
+    [JsonPropertyName("repo")]
+    [JsonPropertyOrder(9)]
+    // Defaults to 1, as does Git.
+    // See https://git-scm.com/docs/api-trace2#Documentation/technical/api-trace2.txt-codeltrepo-idgtcode for details.
+    public int Repo { get; set; } = 1;
+
+    // TODO: Remove default value if support for nested regions is implemented.
+    [JsonPropertyName("nesting")]
+    [JsonPropertyOrder(10)]
+    public int Nesting { get; set; } = 1;
+
+    [JsonPropertyName("category")]
+    [JsonPropertyOrder(11)]
+    public string Category { get; set; }
+
+    [JsonPropertyName("label")]
+    [JsonPropertyOrder(12)]
+    public string Label { get; set; }
+
+    [JsonPropertyName("msg")]
+    [JsonPropertyOrder(13)]
+    public string Message { get; set; }
+}
+
+public class RegionEnterMessage : RegionMessage
+{
+    public override string ToJson()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializerOptions);
+    }
+
+    public override string ToNormalString()
+    {
+        return BuildNormalString();
+    }
+
+    public override string ToPerformanceString()
+    {
+        return BuildPerformanceString();
+    }
+
+    protected override string BuildPerformanceSpan()
+    {
+        return $"|{BuildRepoSpan(Repo)}|{BuildTimeSpan(ElapsedTime)}|           |{BuildCategorySpan(Category)}";
+    }
+
+    protected override string GetEventMessage(Trace2FormatTarget formatTarget)
+    {
+        return Message;
+    }
+}
+
+public class RegionLeaveMessage : RegionMessage
+{
+    [JsonPropertyOrder(14)]
+    public double RelativeTime { get; set; }
+
+    public override string ToJson()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializerOptions);
+    }
+
+    public override string ToNormalString()
+    {
+        return BuildNormalString();
+    }
+
+    public override string ToPerformanceString()
+    {
+        return BuildPerformanceString();
+    }
+
+    protected override string BuildPerformanceSpan()
+    {
+        return $"|{BuildRepoSpan(Repo)}|{BuildTimeSpan(ElapsedTime)}|{BuildTimeSpan(RelativeTime)}|{BuildCategorySpan(Category)}";
+    }
+
+    protected override string GetEventMessage(Trace2FormatTarget formatTarget)
+    {
+        return Message;
+    }
+}
+
+public class SnakeCaseNamingPolicy : JsonNamingPolicy
+{
+    public override string ConvertName(string name) =>
+        name.ToSnakeCase();
+}

--- a/src/Core/Trace2StreamWriter.cs
+++ b/src/Core/Trace2StreamWriter.cs
@@ -1,0 +1,34 @@
+using System;
+using System.IO;
+
+namespace GitCredentialManager;
+
+public class Trace2StreamWriter : Trace2Writer
+{
+    private readonly TextWriter _writer;
+
+    public Trace2StreamWriter(Trace2FormatTarget formatTarget, TextWriter writer)
+        : base(formatTarget)
+    {
+        _writer = writer;
+    }
+
+    public override void Write(Trace2Message message)
+    {
+        try
+        {
+            _writer.Write(Format(message));
+            _writer.Flush();
+        }
+        catch
+        {
+            Failed = true;
+        }
+    }
+
+    protected override void ReleaseManagedResources()
+    {
+        _writer.Dispose();
+        base.ReleaseManagedResources();
+    }
+}

--- a/src/Core/TraceUtils.cs
+++ b/src/Core/TraceUtils.cs
@@ -1,0 +1,24 @@
+namespace GitCredentialManager;
+
+public static class TraceUtils
+{
+    public static string FormatSource(string source, int sourceColumnMaxWidth)
+    {
+        int idx = 0;
+        int maxlen = sourceColumnMaxWidth - 3;
+        int srclen = source.Length;
+
+        while (idx >= 0 && (srclen - idx) > maxlen)
+        {
+            idx = source.IndexOf('\\', idx + 1);
+        }
+
+        // If we cannot find a path separator which allows the path to be long enough, just truncate the file name
+        if (idx < 0)
+        {
+            idx = srclen - maxlen;
+        }
+
+        return "..." + source.Substring(idx);
+    }
+}

--- a/src/Core/UriExtensions.cs
+++ b/src/Core/UriExtensions.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Web;
+
+namespace GitCredentialManager
+{
+    public static class UriExtensions
+    {
+        public static IDictionary<string, string> ParseQueryString(string queryString)
+        {
+            var dict = new Dictionary<string, string>();
+
+            string[] queryParts = queryString.Split('&');
+            foreach (var queryPart in queryParts)
+            {
+                if (string.IsNullOrWhiteSpace(queryPart)) continue;
+
+                string[] parts = queryPart.Split('=');
+
+                var key = HttpUtility.UrlDecode(parts[0]);
+
+                string value = null;
+                if (parts.Length > 1)
+                {
+                    value = HttpUtility.UrlDecode(parts[1]);
+                }
+
+                dict[key] = value;
+            }
+
+            return dict;
+        }
+
+        public static IDictionary<string, string> GetQueryParameters(this Uri uri)
+        {
+            return ParseQueryString(uri.Query.TrimStart('?'));
+        }
+
+        public static bool TryGetUserInfo(this Uri uri, out string userName, out string password)
+        {
+            EnsureArgument.NotNull(uri, nameof(uri));
+            userName = null;
+            password = null;
+
+            if (string.IsNullOrWhiteSpace(uri.UserInfo))
+            {
+                return false;
+            }
+
+            /* According to RFC 3986 section 3.2.1 (https://www.rfc-editor.org/rfc/rfc3986#section-3.2.1)
+             * the user information component of a URI should look like:
+             *
+             *     url-encode(username):url-encode(password)
+             */
+            string[] split = uri.UserInfo.Split(new[] {':'}, count: 2);
+
+            if (split.Length > 0)
+            {
+                userName = WebUtility.UrlDecode(split[0]);
+            }
+            if (split.Length > 1)
+            {
+                password = WebUtility.UrlDecode(split[1]);
+            }
+
+            return split.Length > 0;
+        }
+
+        public static string GetUserName(this Uri uri)
+        {
+            return TryGetUserInfo(uri, out string userName, out _) ? userName : null;
+        }
+
+        public static Uri WithoutUserInfo(this Uri uri)
+        {
+            if (string.IsNullOrEmpty(uri.UserInfo))
+            {
+                return uri;
+            }
+
+            return new UriBuilder(uri) {UserName = string.Empty, Password = string.Empty}.Uri;
+        }
+
+        public static IEnumerable<string> GetGitConfigurationScopes(this Uri uri)
+        {
+            EnsureArgument.NotNull(uri, nameof(uri));
+
+            string schemeAndDelim = $"{uri.Scheme}{Uri.SchemeDelimiter}";
+            string host = uri.Host.TrimEnd('/');
+            // If port is default, don't append
+            string port = uri.IsDefaultPort ? "" : $":{uri.Port}";
+            string path = uri.AbsolutePath.Trim('/');
+
+            // Unfold the path by component, right-to-left
+            while (!string.IsNullOrWhiteSpace(path))
+            {
+                yield return $"{schemeAndDelim}{host}{port}/{path}";
+
+                // Trim off the last path component
+                if (!TryTrimString(path, StringExtensions.TruncateFromLastIndexOf, '/', out path))
+                {
+                    break;
+                }
+            }
+
+            // Check whether the URL only contains hostname.
+            // This usually means the host is on your local network.
+            if (!string.IsNullOrWhiteSpace(host) &&
+                !host.Contains("."))
+            {
+                yield return $"{schemeAndDelim}{host}{port}";
+                // If we have reached this point, there are no more subdomains to unfold, so exit early.
+                yield break;
+            }
+
+            // Unfold the host by sub-domain, left-to-right
+            while (!string.IsNullOrWhiteSpace(host))
+            {
+                if (host.Contains(".")) // Do not emit just the TLD
+                {
+                    yield return $"{schemeAndDelim}{host}{port}";
+                }
+
+                // Trim off the left-most sub-domain
+                if (!TryTrimString(host, StringExtensions.TrimUntilIndexOf, '.', out host))
+                {
+                    break;
+                }
+            }
+        }
+
+        private static bool TryTrimString(string input, Func<string, char, string> func, char c, out string output)
+        {
+            output = func(input, c);
+            return !StringComparer.Ordinal.Equals(input, output);
+        }
+    }
+}

--- a/src/Core/WslUtils.cs
+++ b/src/Core/WslUtils.cs
@@ -1,0 +1,314 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace GitCredentialManager
+{
+    public enum WindowsShell
+    {
+        Cmd,
+        PowerShell,
+    }
+
+    public static class WslUtils
+    {
+        private const string WslUncPrefix = @"\\wsl$\";
+        private const string WslLocalHostUncPrefix = @"\\wsl.localhost\";
+        private const string WslCommandName = "wsl.exe";
+        private const string WslInteropEnvar = "WSL_INTEROP";
+        private const string WslConfFilePath = "/etc/wsl.conf";
+        private const string DefaultWslMountPrefix = "/mnt";
+        private const string DefaultWslSysDriveMountName = "c";
+
+        internal const string WslViewShellHandlerName = "wslview";
+
+        /// <summary>
+        /// Cached Windows host session ID.
+        /// </summary>
+        /// <remarks>A value less than 0 represents "unknown".</remarks>
+        private static int _windowsSessionId = -1;
+
+        /// <summary>
+        /// Cached WSL version.
+        /// </summary>
+        /// <remarks>A value of 0 represents "not WSL", and a value less than 0 represents "unknown".</remarks>
+        private static int _wslVersion = -1;
+
+        /// <summary>
+        /// Cached Windows system drive mount path.
+        /// </summary>
+        private static string _sysDriveMountPath = null;
+
+        public static bool IsWslDistribution(IEnvironment env, IFileSystem fs, out int wslVersion)
+        {
+            if (_wslVersion < 0)
+            {
+                _wslVersion = GetWslVersion(env, fs);
+            }
+
+            wslVersion = _wslVersion;
+            return _wslVersion > 0;
+        }
+
+        private static int GetWslVersion(IEnvironment env, IFileSystem fs)
+        {
+            // All WSL distributions are Linux.. obviously!
+            if (!PlatformUtils.IsLinux())
+            {
+                return 0;
+            }
+
+            // The WSL_INTEROP variable is set in WSL2 distributions
+            if (env.Variables.TryGetValue(WslInteropEnvar, out _))
+            {
+                return 2;
+            }
+
+            const string procVersionPath = "/proc/version";
+            if (fs.FileExists(procVersionPath))
+            {
+                // Both WSL1 and WSL2 distributions include "[Mm]icrosoft" in the version string
+                string procVersion = fs.ReadAllText(procVersionPath);
+                if (!Regex.IsMatch(procVersion, "[Mm]icrosoft"))
+                {
+                    return 0;
+                }
+
+                // WSL2 distributions return "WSL2" in the version string
+                if (Regex.IsMatch(procVersion, "wsl2", RegexOptions.IgnoreCase))
+                {
+                    return 2;
+                }
+
+                return 1;
+            }
+
+            return 0;
+        }
+
+        /// <summary>
+        /// Test if a file path points to a location in a Windows Subsystem for Linux distribution.
+        /// </summary>
+        /// <param name="path">Path to test.</param>
+        /// <returns>True if <paramref name="path"/> is a WSL path, false otherwise.</returns>
+        public static bool IsWslPath(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path)) return false;
+
+            return (path.StartsWith(WslUncPrefix, StringComparison.OrdinalIgnoreCase) &&
+                    path.Length > WslUncPrefix.Length) ||
+                   (path.StartsWith(WslLocalHostUncPrefix, StringComparison.OrdinalIgnoreCase) &&
+                    path.Length > WslLocalHostUncPrefix.Length);
+        }
+
+        /// <summary>
+        /// Create a command to be executed in a Windows Subsystem for Linux distribution.
+        /// </summary>
+        /// <param name="distribution">WSL distribution name.</param>
+        /// <param name="command">Command to execute.</param>
+        /// <param name="trace2">The applications TRACE2 tracer.</param>
+        /// <param name="workingDirectory">Optional working directory.</param>
+        /// <returns><see cref="Process"/> object ready to start.</returns>
+        public static ChildProcess CreateWslProcess(string distribution,
+            string command,
+            ITrace2 trace2,
+            string workingDirectory = null)
+        {
+            var args = new StringBuilder();
+            args.AppendFormat("--distribution {0} ", distribution);
+            args.AppendFormat("--exec {0}", command);
+
+            string wslExePath = GetWslPath();
+
+            var psi = new ProcessStartInfo(wslExePath, args.ToString())
+            {
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = false, // Do not redirect stderr as tracing might be enabled
+                UseShellExecute = false,
+                WorkingDirectory = workingDirectory ?? string.Empty
+            };
+
+            return new ChildProcess(trace2, psi);
+        }
+
+        /// <summary>
+        /// Create a command to be executed in a shell in the host Windows operating system.
+        /// </summary>
+        /// <param name="fs">File system.</param>
+        /// <param name="shell">Shell used to execute the command in Windows.</param>
+        /// <param name="command">Command to execute.</param>
+        /// <param name="workingDirectory">Optional working directory.</param>
+        /// <returns><see cref="Process"/> object ready to start.</returns>
+        public static Process CreateWindowsShellProcess(IFileSystem fs,
+            WindowsShell shell, string command, string workingDirectory = null)
+        {
+            string sysDrive = GetSystemDriveMountPath(fs);
+
+            string launcher;
+            var args = new StringBuilder();
+
+            switch (shell)
+            {
+                case WindowsShell.Cmd:
+                    launcher = Path.Combine(sysDrive, "Windows/cmd.exe");
+                    args.AppendFormat("/C {0}", command);
+                    break;
+
+                case WindowsShell.PowerShell:
+                    const string psStreamSetup =
+                        "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; " +
+                        "[Console]::InputEncoding = [System.Text.Encoding]::UTF8; ";
+
+                    launcher = Path.Combine(sysDrive, "Windows/System32/WindowsPowerShell/v1.0/powershell.exe");
+                    args.Append(" -NoProfile -NonInteractive -ExecutionPolicy Bypass");
+                    args.AppendFormat(" -Command \"{0} {1}\"", psStreamSetup, command);
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(shell));
+            }
+
+            var psi = new ProcessStartInfo(launcher, args.ToString())
+            {
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = workingDirectory ?? string.Empty
+            };
+
+            return new Process { StartInfo = psi };
+        }
+
+        /// <summary>
+        /// Get the host Windows session ID.
+        /// </summary>
+        /// <returns>Windows session ID, or a negative value if it is not known.</returns>
+        public static int GetWindowsSessionId(IFileSystem fs)
+        {
+            if (_windowsSessionId < 0)
+            {
+                const string script = @"(Get-Process -ID $PID).SessionId";
+                using (Process proc = CreateWindowsShellProcess(fs, WindowsShell.PowerShell, script))
+                {
+                    proc.Start();
+                    proc.WaitForExit();
+
+                    if (proc.ExitCode == 0)
+                    {
+                        string output = proc.StandardOutput.ReadToEnd().Trim();
+                        if (int.TryParse(output, out int sessionId))
+                        {
+                            _windowsSessionId = sessionId;
+                        }
+                    }
+                }
+            }
+
+            return _windowsSessionId;
+        }
+
+        private static string GetSystemDriveMountPath(IFileSystem fs)
+        {
+            if (_sysDriveMountPath is null)
+            {
+                string mountPrefix = DefaultWslMountPrefix;
+
+                // If the wsl.conf file exists in this distribution the user may
+                // have changed the Windows volume mount point prefix. Use it!
+                if (fs.FileExists(WslConfFilePath))
+                {
+                    // Read wsl.conf for [automount] root = <path>
+                    IniFile wslConf = IniSerializer.Deserialize(fs, WslConfFilePath);
+                    if (wslConf.TryGetSection("automount", out IniSection automountSection) &&
+                        automountSection.TryGetProperty("root", out string value))
+                    {
+                        mountPrefix = value;
+                    }
+                }
+
+                // Try to locate the system volume by looking for the Windows\System32 directory
+                IEnumerable<string> mountPoints = fs.EnumerateDirectories(mountPrefix);
+                foreach (string mountPoint in mountPoints)
+                {
+                    string sys32Path = Path.Combine(mountPoint, "Windows", "System32");
+
+                    if (fs.DirectoryExists(sys32Path))
+                    {
+                        _sysDriveMountPath = mountPoint;
+                        return _sysDriveMountPath;
+                    }
+                }
+
+                _sysDriveMountPath = Path.Combine(mountPrefix, DefaultWslSysDriveMountName);
+            }
+
+            return _sysDriveMountPath;
+        }
+
+        public static string ConvertToDistroPath(string path, out string distribution)
+        {
+            if (!IsWslPath(path)) throw new ArgumentException("Must provide a WSL path", nameof(path));
+
+            int distroStart;
+            if (path.StartsWith(WslUncPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                distroStart = WslUncPrefix.Length;
+            }
+            else if (path.StartsWith(WslLocalHostUncPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                distroStart = WslLocalHostUncPrefix.Length;
+            }
+            else
+            {
+                throw new Exception("Invalid WSL path prefix");
+            }
+
+            int distroEnd = path.IndexOf('\\', distroStart);
+
+            if (distroEnd < 0) distroEnd = path.Length;
+
+            distribution = path.Substring(distroStart, distroEnd - distroStart);
+
+            if (path.Length > distroEnd)
+            {
+                return path.Substring(distroEnd).Replace('\\', '/');
+            }
+
+            return "/";
+        }
+
+        internal /*for testing purposes*/ static string GetWslPath()
+        {
+            // WSL is only supported on 64-bit operating systems
+            if (!Environment.Is64BitOperatingSystem)
+            {
+                throw new Exception("WSL is not supported on 32-bit operating systems");
+            }
+
+            //
+            // When running as a 32-bit application on a 64-bit operating system, we cannot access the real
+            // C:\Windows\System32 directory because the OS will redirect us transparently to the
+            // C:\Windows\SysWOW64 directory (containing 32-bit executables).
+            //
+            // In order to access the real 64-bit System32 directory, we must access via the pseudo directory
+            // C:\Windows\SysNative that does **not** experience any redirection for 32-bit applications.
+            //
+            // HOWEVER, if we're running as a 64-bit application on a 64-bit operating system, the SysNative
+            // directory does not exist! This means if running as a 64-bit application on a 64-bit OS we must
+            // use the System32 directory name directly.
+            //
+            var sysDir = Environment.ExpandEnvironmentVariables(
+                Environment.Is64BitProcess
+                    ? @"%WINDIR%\System32"
+                    : @"%WINDIR%\SysNative"
+            );
+
+            return Path.Combine(sysDir, WslCommandName);
+        }
+    }
+}

--- a/src/CredentialManager/CredentialManager.cs
+++ b/src/CredentialManager/CredentialManager.cs
@@ -5,8 +5,13 @@ namespace GitCredentialManager;
 
 /// <summary>
 /// Provides the factory method <see cref="Create"/> to instantiate a 
-/// <see cref="ICredentialStore"/> appropriate for the current platform.
+/// <see cref="ICredentialStore"/> appropriate for the current platform and 
+/// optionally configured store implementation.
 /// </summary>
+/// <remarks>
+/// See https://github.com/git-ecosystem/git-credential-manager/blob/main/docs/credstores.md 
+/// for more information.
+/// </remarks>
 public static class CredentialManager
 {
     /// <summary>
@@ -25,7 +30,7 @@ public static class CredentialManager
 
     class CommandContextWrapper(CommandContext context, string? @namespace) : ICommandContext
     {
-        ISettings settings = new SettingsWrapper(context.Settings, @namespace);
+        readonly ISettings settings = new SettingsWrapper(context.Settings, @namespace);
 
         public ISettings Settings => settings;
 

--- a/src/CredentialManager/CredentialManager.csproj
+++ b/src/CredentialManager/CredentialManager.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <IsPackable>true</IsPackable>
     <AssemblyName>Devlooped.CredentialManager</AssemblyName>
     <RootNamespace>GitCredentialManager</RootNamespace>
@@ -11,18 +11,47 @@
     
 Usage: 
 
-   var store = CredentialStore.Create();
+   var store = CredentialManager.Create();
 </Description>
   </PropertyGroup>  
     
   <ItemGroup>
-    <PackageReference Include="git-credential-manager" Version="2.4.1" IncludeAssets="tools" GeneratePathProperty="true" Pack="false" />
     <PackageReference Include="NuGetizer" Version="1.2.1" PrivateAssets="all" />
+    <PackageReference Include="ILRepack" Version="2.0.33" Pack="false" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(Pkggit-credential-manager)' != ''">
-    <Reference Include="gcmcore" HintPath="$(Pkggit-credential-manager)\tools\net7.0\any\gcmcore.dll" />
-    <PackageFile Include="$(Pkggit-credential-manager)\tools\net7.0\any\gcmcore.dll" PackFolder="lib" />
+  <ItemGroup>
+    <ProjectReference Include="..\Core\Core.csproj" Pack="false" />
   </ItemGroup>
+
+  <Target Name="ILRepack" BeforeTargets="CopyFilesToOutputDirectory" 
+          Inputs="@(IntermediateAssembly -&gt; '%(FullPath)')" 
+          Outputs="$(IntermediateOutputPath)ilrepack.txt" 
+          Returns="@(MergedAssemblies)" 
+          Condition="Exists(@(IntermediateAssembly -&gt; '%(FullPath)'))">
+    <Message Text="Repacking" Importance="high" />
+    <ItemGroup>
+      <MergedAssemblies Include="@(ReferencePath)" Condition="'%(Extension)' == '.dll' And $([MSBuild]::ValueOrDefault('%(FileName)', '')) == 'Core'" />
+    </ItemGroup>
+    <PropertyGroup>
+      <ILRepackArgs>$(ILRepackArgs) /out:"@(IntermediateAssembly -&gt; '%(FullPath)')"</ILRepackArgs>
+      <ILRepackArgs>$(ILRepackArgs) "@(IntermediateAssembly -&gt; '%(FullPath)')"</ILRepackArgs>
+      <ILRepackArgs>$(ILRepackArgs) @(MergedAssemblies -&gt; '"%(FullPath)"', ' ')</ILRepackArgs>
+    </PropertyGroup>
+    <Exec Command='"$(ILRepack)" /internalize:exclude.txt $(ILRepackArgs)'>
+      <Output TaskParameter="ConsoleOutput" PropertyName="ILRepackOutput" />
+      <Output TaskParameter="ExitCode" PropertyName="ExitCode" />
+    </Exec>
+    <Message Importance="high" Text="$(ILRepackOutput)" Condition="'$(ExitCode)' != '0'" />
+    <Delete Files="$(IntermediateOutputPath)ilrepack.txt" Condition="'$(ExitCode)' != '0'" />
+    <Touch AlwaysCreate="true" Files="$(IntermediateOutputPath)ilrepack.txt" Condition="'$(ExitCode)' == '0'" />
+    <Error Text="$(ILRepackOutput)" Condition="'$(ExitCode)' != '0' And '$(ContinueOnError)' != 'true'" />
+    <ItemGroup>
+      <MergedAssembliesToRemove Include="@(MergedAssemblies)" />
+      <MergedAssembliesToRemove Remove="@(ReferenceToPreserve)" />
+    </ItemGroup>
+    <Delete Files="@(MergedAssembliesToRemove -&gt; '$(MSBuildProjectDirectory)\$(OutputPath)%(Filename)%(Extension)')" 
+            Condition="Exists('$(MSBuildProjectDirectory)\$(OutputPath)%(Filename)%(Extension)')" />
+  </Target>
 
 </Project>

--- a/src/CredentialManager/CredentialManager.csproj
+++ b/src/CredentialManager/CredentialManager.csproj
@@ -38,7 +38,7 @@ Usage:
       <ILRepackArgs>$(ILRepackArgs) "@(IntermediateAssembly -&gt; '%(FullPath)')"</ILRepackArgs>
       <ILRepackArgs>$(ILRepackArgs) @(MergedAssemblies -&gt; '"%(FullPath)"', ' ')</ILRepackArgs>
     </PropertyGroup>
-    <Exec Command='"$(ILRepack)" /internalize:exclude.txt $(ILRepackArgs)'>
+    <Exec Command='"$(ILRepack)" /internalize:exclude.txt $(ILRepackArgs)' StandardErrorImportance="high" StandardOutputImportance="low" ConsoleToMSBuild="true" ContinueOnError="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="ILRepackOutput" />
       <Output TaskParameter="ExitCode" PropertyName="ExitCode" />
     </Exec>

--- a/src/CredentialManager/CredentialManager.csproj
+++ b/src/CredentialManager/CredentialManager.csproj
@@ -28,7 +28,7 @@ Usage:
           Inputs="@(IntermediateAssembly -&gt; '%(FullPath)')" 
           Outputs="$(IntermediateOutputPath)ilrepack.txt" 
           Returns="@(MergedAssemblies)" 
-          Condition="Exists(@(IntermediateAssembly -&gt; '%(FullPath)'))">
+          Condition="$(OS) == 'WINDOWS_NT' And Exists(@(IntermediateAssembly -&gt; '%(FullPath)'))">
     <Message Text="Repacking" Importance="high" />
     <ItemGroup>
       <MergedAssemblies Include="@(ReferencePath)" Condition="'%(Extension)' == '.dll' And $([MSBuild]::ValueOrDefault('%(FileName)', '')) == 'Core'" />

--- a/src/CredentialManager/exclude.txt
+++ b/src/CredentialManager/exclude.txt
@@ -1,0 +1,2 @@
+GitCredentialManager.ICredentialStore
+GitCredentialManager.ICredential


### PR DESCRIPTION
We remove the dependency on gcmcore as a binary, which at the moment targets net7.0, limiting this library portability.

By selectively bringing sources as-is, we can target NS2.0 while keeping a compatible implementation that's still easy to maintain in sync with upstream.

By leveraging ILRepack, we can internalize all types from gcmcore and therefore maintain a slim API with just the relevant interfaces.

Fixes #93