### PR TITLE
Test freedesktop secretservice implementation on linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
           path: bin
 
       - name: 🧪 test
-        run: dotnet test -p:VersionLabel="$GITHUB_REF.$GITHUB_RUN_NUMBER" --nologo -bl --logger:"console;verbosity=normal" -p:VSTestVerbosity=detailed
+        run: dotnet test -p:VersionLabel="$GITHUB_REF.$GITHUB_RUN_NUMBER" --nologo -bl -l:"console;verbosity=normal"
 
       - name: 🐛 logs
         uses: actions/upload-artifact@v3

--- a/src/Tests/Attributes.cs
+++ b/src/Tests/Attributes.cs
@@ -55,3 +55,12 @@ public class LinuxTheoryAttribute() : OSTheoryAttribute(OSPlatform.Linux);
 public class macOSTheoryAttribute() : OSTheoryAttribute(OSPlatform.OSX);
 
 public class UnixTheoryAttribute() : OSTheoryAttribute(OSPlatform.Linux, OSPlatform.OSX);
+
+public class LocalFactAttribute : OSFactAttribute
+{
+    public LocalFactAttribute(params string[] onPlatforms) : base(onPlatforms)
+    {
+        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CI")))
+            Skip = "Local-only test";
+    }
+}

--- a/src/Tests/EndToEnd.cs
+++ b/src/Tests/EndToEnd.cs
@@ -38,6 +38,24 @@ public class EndToEnd : IDisposable
         Run();
     }
 
+    [LocalFact(nameof(OSPlatform.Linux))]
+    public void LinuxSecretService()
+    {
+        // To test this locally, you need:
+        //  sudo apt-get update
+        //  sudo apt install libsecret-1-0 libsecret-1-dev
+        //  sudo apt install gnome-keyring
+        //  dbus-launch --sh-syntax
+        //  export $(dbus-launch)
+        //  gnome-keyring-daemon -r -d
+
+        // Then run the tests: dotnet test
+        // This will require keyring unlocking interactively before tests proceed.
+
+        Environment.SetEnvironmentVariable("GCM_CREDENTIAL_STORE", "secretservice");
+        Run();
+    }
+
     void Run()
     {
         var store = CredentialManager.Create(Guid.NewGuid().ToString("N"));


### PR DESCRIPTION
See https://github.com/git-ecosystem/git-credential-manager/blob/main/docs/credstores.md#freedesktoporg-secret-service-api

Document in code how to run this test locally, since it requires interactively unlocking the gnome keyring.