### PR TITLE
Make sure we honor credentials namespace/scope

### DIFF
--- a/src/CredentialManager/CredentialManager.cs
+++ b/src/CredentialManager/CredentialManager.cs
@@ -22,10 +22,9 @@ public static class CredentialManager
     /// <returns>The <see cref="ICredentialStore"/>.</returns>
     public static ICredentialStore Create(string? @namespace = default)
     {
-        using var context = new CommandContextWrapper(new CommandContext(), @namespace);
         // The context already does the check for the platform and configured store to initialize.
         // By overriding the settings with our wrapper, we ensure just the namespace is overriden.
-        return context.CredentialStore;
+        return new CredentialStore(new CommandContextWrapper(new CommandContext(), @namespace));
     }
 
     class CommandContextWrapper(CommandContext context, string? @namespace) : ICommandContext

--- a/src/Tests/EndToEnd.cs
+++ b/src/Tests/EndToEnd.cs
@@ -56,6 +56,24 @@ public class EndToEnd : IDisposable
         Run();
     }
 
+    [WindowsFact]
+    public void SavedOneNamespaceCannotRetrieveAnother()
+    {
+        var ns1 = Guid.NewGuid().ToString("N");
+        var ns2 = Guid.NewGuid().ToString("N");
+
+        var store1 = CredentialManager.Create(ns1);
+        var store2 = CredentialManager.Create(ns2);
+
+        var usr = Guid.NewGuid().ToString("N");
+        var pwd = Guid.NewGuid().ToString("N");
+
+        store1.AddOrUpdate("https://test.com", usr, pwd);
+
+        Assert.Null(store2.Get("https://test.com", usr));
+        Assert.Empty(store2.GetAccounts("https://test.com"));
+    }
+
     void Run()
     {
         var store = CredentialManager.Create(Guid.NewGuid().ToString("N"));


### PR DESCRIPTION
A missing test uncovers the issue: we're not filtering credentials at all and are instead just defaulting to the 'git' default namespace.

We ensure now that the credential store uses our context and settings wrappers to override this value.

Fixes #103