### PR TITLE
Note git dependency is required

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ and may issue IDE-only warnings if no active sponsorship is detected.*
 <!-- https://github.com/devlooped/.github/raw/main/sponsorlink.md -->
 
 Packages the official [Git Credential Manager](https://github.com/git-ecosystem/git-credential-manager/) cross-platform credential store 
-implementation supporting Windows, macOS and Linux for use as a NS2.0 library with no UI or external dependencies.
+implementation supporting Windows, macOS and Linux for use as a NS2.0 library with no UI or external dependencies beyond just git.
 
 Release version numbers track the [GCM releases](https://github.com/GitCredentialManager/git-credential-manager/releases) themselves.
 


### PR DESCRIPTION
Besides all the mentions to *Git* Credential Manager, make it super obvious that git is actually a runtime dependency.

Fixes #125