### PR TITLE
Remove dependency on installed git

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,10 @@ on:
 env:
   DOTNET_NOLOGO: true
   SLEET_CONNECTION: ${{ secrets.SLEET_CONNECTION }}
+  MSBUILDTERMINALLOGGER: auto
+  GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  Configuration: ${{ github.event.inputs.configuration || 'Release' }}
+  SLEET_FEED_URL: ${{ vars.SLEET_FEED_URL }}
 
 defaults:
   run:
@@ -98,8 +102,16 @@ jobs:
           name: pkg
           path: bin
 
+      - name: ⚙ dotnet
+        uses: devlooped/actions-dotnet-env@v1
+
+      - name: 🙏 build
+        run: dotnet build
+
       - name: 🧪 test
-        run: dotnet test --nologo -bl --logger:"console;verbosity=normal"
+        run: |
+          dotnet tool update -g dotnet-retest
+          dotnet retest -- --no-build
 
       - name: 🐛 logs
         uses: actions/upload-artifact@v4

--- a/src/CredentialManager/CredentialManager.csproj
+++ b/src/CredentialManager/CredentialManager.csproj
@@ -17,6 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="DotNetConfig" Version="1.2.0" />
     <PackageReference Include="NuGetizer" Version="1.2.3" PrivateAssets="all" />
     <PackageReference Include="ILRepack" Version="2.0.33" Pack="false" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
@@ -28,11 +29,7 @@
     <ProjectReference Include="..\Core\Core.csproj" Pack="false" />
   </ItemGroup>
 
-  <Target Name="ILRepack" BeforeTargets="CopyFilesToOutputDirectory"
-          Inputs="@(IntermediateAssembly -> '%(FullPath)')"
-          Outputs="$(IntermediateOutputPath)ilrepack.txt"
-          Returns="@(MergedAssemblies)"
-          Condition="$(OS) == 'WINDOWS_NT' And Exists(@(IntermediateAssembly -&gt; '%(FullPath)'))">
+  <Target Name="ILRepack" BeforeTargets="CopyFilesToOutputDirectory" Inputs="@(IntermediateAssembly -> '%(FullPath)')" Outputs="$(IntermediateOutputPath)ilrepack.txt" Returns="@(MergedAssemblies)" Condition="$(OS) == 'WINDOWS_NT' And Exists(@(IntermediateAssembly -> '%(FullPath)'))">
     <Message Text="Repacking" Importance="high" />
     <ItemGroup>
       <MergedAssemblies Include="@(ReferencePath)" Condition="'%(Extension)' == '.dll' And $([MSBuild]::ValueOrDefault('%(FileName)', '')) == 'Core'" />
@@ -42,7 +39,7 @@
       <ILRepackArgs>$(ILRepackArgs) "@(IntermediateAssembly -> '%(FullPath)')"</ILRepackArgs>
       <ILRepackArgs>$(ILRepackArgs) @(MergedAssemblies -> '"%(FullPath)"', ' ')</ILRepackArgs>
     </PropertyGroup>
-    <Exec Command='"$(ILRepack)" /internalize:exclude.txt $(ILRepackArgs)' StandardErrorImportance="high" StandardOutputImportance="low" ConsoleToMSBuild="true" ContinueOnError="true">
+    <Exec Command="&quot;$(ILRepack)&quot; /internalize:exclude.txt $(ILRepackArgs)" StandardErrorImportance="high" StandardOutputImportance="low" ConsoleToMSBuild="true" ContinueOnError="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="ILRepackOutput" />
       <Output TaskParameter="ExitCode" PropertyName="ExitCode" />
     </Exec>
@@ -54,8 +51,7 @@
       <MergedAssembliesToRemove Include="@(MergedAssemblies)" />
       <MergedAssembliesToRemove Remove="@(ReferenceToPreserve)" />
     </ItemGroup>
-    <Delete Files="@(MergedAssembliesToRemove -> '$(MSBuildProjectDirectory)\$(OutputPath)%(Filename)%(Extension)')"
-            Condition="Exists('$(MSBuildProjectDirectory)\$(OutputPath)%(Filename)%(Extension)')" />
+    <Delete Files="@(MergedAssembliesToRemove -> '$(MSBuildProjectDirectory)\$(OutputPath)%(Filename)%(Extension)')" Condition="Exists('$(MSBuildProjectDirectory)\$(OutputPath)%(Filename)%(Extension)')" />
   </Target>
 
 </Project>

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
-    <PackageReference Include="Devlooped.CredentialManager" Version="42.*" Condition="!$(CI)" />
+    <PackageReference Include="Devlooped.CredentialManager" Version="42.42.42-main.*" Condition="!$(CI)" />
     <PackageReference Include="Devlooped.CredentialManager" Version="$(Version)" Condition="$(CI) And Exists('$(PackageOutputPath)')" />
   </ItemGroup>
 


### PR DESCRIPTION
By reading the global .gitconfig directly using the compatible DotNetConfig, we can remove this dependency which was just for a couple of global settings (the default credential namespace, credential store and an MS Auth setting).

Fixes #125 for real.