### PR TITLE
Expose command context from store

### DIFF
--- a/src/Tests/EndToEnd.cs
+++ b/src/Tests/EndToEnd.cs
@@ -103,6 +103,8 @@ public class EndToEnd : IDisposable
     {
         var store = CredentialManager.Create(Guid.NewGuid().ToString("N"));
 
+        Assert.NotNull(store.Context);
+
         var usr = Guid.NewGuid().ToString("N");
         var pwd = Guid.NewGuid().ToString("N");
 


### PR DESCRIPTION
This allows using the same mechanism in other contexts (i.e. when using GCM authentication handlers).