### PR TITLE
⬆️ Bump files with dotnet-file sync

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -30,6 +30,8 @@ indent_size = 2
 
 # Dotnet code style settings:
 [*.{cs,vb}]
+tab_width = 4
+
 # Sort using and Import directives with System.* appearing first
 dotnet_sort_system_directives_first = true
 # Avoid "this." and "Me." if not necessary
@@ -56,6 +58,9 @@ dotnet_style_require_accessibility_modifiers = omit_if_default:error
 
 # IDE0040: Add accessibility modifiers
 dotnet_diagnostic.IDE0040.severity = error
+
+# IDE1100: Error reading content of source file 'Project.TargetFrameworkMoniker' (i.e. from ThisAssembly)
+dotnet_diagnostic.IDE1100.severity = none
 
 [*.cs]
 # Top-level files are definitely OK

--- a/.github/workflows/dotnet-file-core.yml
+++ b/.github/workflows/dotnet-file-core.yml
@@ -1,0 +1,95 @@
+# Synchronizes .netconfig-configured files with dotnet-file
+name: dotnet-file-core
+on:
+  workflow_call:
+    secrets:
+      BOT_NAME:
+        required: false
+      BOT_EMAIL:
+        required: false
+      GH_TOKEN:
+        required: false
+
+env:
+  DOTNET_NOLOGO: true
+
+defaults:
+  run:
+    shell: pwsh
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest 
+    continue-on-error: true
+    steps:
+      - name: 🤖 defaults
+        uses: devlooped/actions-bot@v1
+        with:
+          name: ${{ secrets.BOT_NAME }}
+          email: ${{ secrets.BOT_EMAIL }}
+          gh_token: ${{ secrets.GH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 🤘 checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+          token: ${{ env.GH_TOKEN }}
+
+      - name: ⌛ rate
+        if: github.event_name != 'workflow_dispatch'
+        run: |
+          # add random sleep since we run on fixed schedule
+          sleep (get-random -max 60)
+          # get currently authenticated user rate limit info
+          $rate = gh api rate_limit | convertfrom-json | select -expandproperty rate
+          # if we don't have at least 100 requests left, wait until reset
+          if ($rate.remaining -lt 10) {
+              $wait = ($rate.reset - (Get-Date (Get-Date).ToUniversalTime() -UFormat %s))
+              echo "Rate limit remaining is $($rate.remaining), waiting for $($wait / 1000) seconds to reset"
+              sleep $wait
+              $rate = gh api rate_limit | convertfrom-json | select -expandproperty rate
+              echo "Rate limit has reset to $($rate.remaining) requests"
+          }
+
+      - name: 🔄 sync
+        run: |
+          dotnet tool update -g dotnet-gcm
+          # store credentials in plaintext for linux compat
+          git config --local credential.credentialStore plaintext
+          dotnet gcm store --protocol=https --host=github.com --username=$env:GITHUB_ACTOR --password=$env:GH_TOKEN
+          gh auth status
+
+          dotnet tool update -g dotnet-file
+          $changelog = "$([System.IO.Path]::GetTempPath())dotnet-file.md"
+          dotnet file sync -c:$changelog
+          if (test-path $changelog) {
+            echo 'CHANGES<<EOF' >> $env:GITHUB_ENV
+            cat $changelog >> $env:GITHUB_ENV
+            echo 'EOF' >> $env:GITHUB_ENV
+            cat $changelog
+          } else {
+            echo 'No changelog was generated'
+          }
+
+      - name: +Mᐁ includes
+        uses: devlooped/actions-includes@v1
+        with:
+          validate: false
+
+      - name: ✍ pull request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          base: main
+          branch: dotnet-file-sync
+          delete-branch: true
+          labels: dependencies
+          author: ${{ env.BOT_AUTHOR }}
+          committer: ${{ env.BOT_AUTHOR }}
+          commit-message: ⬆️ Bump files with dotnet-file sync
+          
+            ${{ env.CHANGES }}
+          title: "⬆️ Bump files with dotnet-file sync"
+          body: ${{ env.CHANGES }}
+          token: ${{ env.GH_TOKEN }}

--- a/.github/workflows/includes.yml
+++ b/.github/workflows/includes.yml
@@ -5,8 +5,9 @@ on:
     branches:
       - 'main'
     paths:
-      - '**.md'    
+      - '**.md'
       - '!changelog.md'
+      - 'osmfeula.txt'
 
 jobs:
   includes:
@@ -31,14 +32,33 @@ jobs:
       - name: +Mᐁ includes
         uses: devlooped/actions-includes@v1
 
+      - name: 📝 OSMF EULA
+        shell: pwsh
+        run: |
+          $file = "osmfeula.txt"
+          $props = "src/Directory.Build.props"
+          if (-not (test-path $file) -or -not (test-path $props)) {
+            exit 0
+          }
+
+          $product = dotnet msbuild $props -getproperty:Product
+          if (-not $product) { 
+            write-error 'To use OSMF EULA, ensure the $(Product) property is set in Directory.props'
+            exit 1
+          }
+          
+          ((get-content -raw $file) -replace '\$product\$',$product).trim() | set-content $file
+
       - name: ✍ pull request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
-          add-paths: '**.md'
+          add-paths: |
+            **.md
+            *.txt
           base: main
           branch: markdown-includes
           delete-branch: true
-          labels: docs
+          labels: dependencies
           author: ${{ env.BOT_AUTHOR }}
           committer: ${{ env.BOT_AUTHOR }}
           commit-message: +Mᐁ includes

--- a/.netconfig
+++ b/.netconfig
@@ -42,8 +42,8 @@
 	skip
 [file ".editorconfig"]
 	url = https://github.com/devlooped/oss/blob/main/.editorconfig
-	sha = c779d3d4e468358106dea03e93ba2cd35bb01ecb
-	etag = 7298c6450967975a8782b5c74f3071e1910fc59686e48f9c9d5cd7c68213cf59
+	sha = a62c45934ac2952f2f5d54d8aea4a7ebc1babaff
+	etag = b5e919b472a52d4b522f86494f0f2c0ba74a6d9601454e20e4cbaf744317ff62
 	weak
 [file ".gitattributes"]
 	url = https://github.com/devlooped/oss/blob/main/.gitattributes
@@ -93,8 +93,8 @@
 	weak
 [file "src/Directory.Build.props"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.props
-	sha = c509be4378ff6789df4f66338cb88119453c0975
-	etag = cbbdc1a4d3030f353f3e5306a6c380238dd4ed0945aad2d56ba87b49fcfcd66d
+	sha = 0ff8b7b79a82112678326d1dc5543ed890311366
+	etag = 3ebde0a8630d526b80f15801179116e17a857ff880a4442e7db7b075efa4fd63
 	weak
 [file "src/Directory.Build.targets"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.targets
@@ -116,8 +116,8 @@
 	weak
 [file ".github/workflows/includes.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/includes.yml
-	sha = 85829f2510f335f4a411867f3dbaaa116c3ab3de
-	etag = 086f6b6316cc6ea7089c0dcc6980be519e6ed6e6201e65042ef41b82634ec0ee
+	sha = 06628725a6303bb8c4cf3076a384fc982a91bc0b
+	etag = 478f91d4126230e57cc601382da1ba23f9daa054645b4af89800d8dd862e64fd
 	weak
 [file ".github/workflows/combine-prs.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/combine-prs.yml
@@ -453,8 +453,8 @@
 	weak
 [file "src/Core/Authentication/OAuth/OAuth2SystemWebBrowser.cs"]
 	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Authentication/OAuth/OAuth2SystemWebBrowser.cs
-	sha = c91294385db910f8dd15c0345e100cd034e6482f
-	etag = f1dfa70e7f6096ef5a0fccc3d3737bcb4e22089dfeeb2afc6b3e722ca40da888
+	sha = a344fe937a566311330e824b1042d9d3de694531
+	etag = 3e8f40f52c87f233dc0263140fd735f64d1d2f46793eaf006ab226973b83712c
 	weak
 [file "src/Core/Authentication/OAuth/OAuth2TokenResult.cs"]
 	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Authentication/OAuth/OAuth2TokenResult.cs
@@ -740,4 +740,9 @@
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/dotnet-env.yml
 	sha = 77e83f238196d2723640abef0c7b6f43994f9747
 	etag = fcb9759a96966df40dcd24906fd328ddec05953b7e747a6bb8d0d1e4c3865274
+	weak
+[file ".github/workflows/dotnet-file-core.yml"]
+	url = https://github.com/devlooped/oss/blob/main/.github/workflows/dotnet-file-core.yml
+	sha = d00364faaa84c414b868c0758b9e1a5fc0520dcc
+	etag = d3b7d8ca69e6d22066a2348f02b409e2d6fb900f5039f68940c14e4ce6021826
 	weak

--- a/src/Core/Authentication/OAuth/OAuth2SystemWebBrowser.cs
+++ b/src/Core/Authentication/OAuth/OAuth2SystemWebBrowser.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
@@ -33,15 +32,15 @@ namespace GitCredentialManager.Authentication.OAuth
 
     public class OAuth2SystemWebBrowser : IOAuth2WebBrowser
     {
-        private readonly IEnvironment _environment;
+        private readonly ISessionManager _sessionManager;
         private readonly OAuth2WebBrowserOptions _options;
 
-        public OAuth2SystemWebBrowser(IEnvironment environment, OAuth2WebBrowserOptions options)
+        public OAuth2SystemWebBrowser(ISessionManager sessionManager, OAuth2WebBrowserOptions options)
         {
-            EnsureArgument.NotNull(environment, nameof(environment));
+            EnsureArgument.NotNull(sessionManager, nameof(sessionManager));
             EnsureArgument.NotNull(options, nameof(options));
 
-            _environment = environment;
+            _sessionManager = sessionManager;
             _options = options;
         }
 
@@ -71,7 +70,7 @@ namespace GitCredentialManager.Authentication.OAuth
 
             Task<Uri> interceptTask = InterceptRequestsAsync(redirectUri, ct);
 
-            BrowserUtils.OpenDefaultBrowser(_environment, authorizationUri);
+            _sessionManager.OpenBrowser(authorizationUri);
 
             return await interceptTask;
         }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,4 +1,4 @@
-<Project>
+<Project TreatAsLocalProperty="VersionPrefix">
   <!-- To extend/change the defaults, create a Directory.props alongside this file -->
 
   <PropertyGroup Label="CI" Condition="'$(CI)' == ''">
@@ -43,6 +43,10 @@
 
     <!-- Ensure MSBuild tooling can access package artifacts always via PKG_[PackageId] -->
     <GeneratePathProperty>true</GeneratePathProperty>
+    <!-- Avoid warnings for test projects when we run dotnet pack on the whole solution. -->
+    <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
+    <!-- See https://learn.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#prunepackagereference-specification -->
+    <RestoreEnablePackagePruning>true</RestoreEnablePackagePruning>
   </PropertyGroup>
 
   <PropertyGroup Label="Build">
@@ -134,6 +138,15 @@
     <VersionSuffix Condition="!$(VersionLabel.Contains('refs/tags/'))">$(_VersionLabel)</VersionSuffix>
     <!-- Special case for tags, the label is actually the version. Backs compat since passed-in value overrides MSBuild-set one -->
     <Version Condition="$(VersionLabel.Contains('refs/tags/'))">$(_VersionLabel)</Version>
+
+    <!-- In order for latest from main/master to always be greatest when using -prerelease switch on install/run, 
+         we change the scheme as follows:
+         - main/master remain as today: VersionPrefix: 42.42.${{ github.run_number }}  (from yaml)
+         - others: VersionPrefix: 42.42.0-[label].${{ github.run_number }}
+    -->
+    <IsMaster Condition="$(VersionLabel.Contains('refs/heads/main')) or $(VersionLabel.Contains('refs/heads/master'))">true</IsMaster>
+    <VersionPrefix Condition="'$(IsMaster)' != 'true'">42.42.0</VersionPrefix>
+    <VersionSuffix Condition="'$(IsMaster)' != 'true'">$(VersionSuffix).$(GITHUB_RUN_NUMBER)</VersionSuffix>
   </PropertyGroup>
 
   <ItemGroup Label="ThisAssembly.Project">


### PR DESCRIPTION
# git-ecosystem/git-credential-manager

- sessionmanager: move browserutils.openbrowser https://github.com/git-ecosystem/git-credential-manager/commit/a344fe9

# devlooped/oss

- Revert indent size for project files https://github.com/devlooped/oss/commit/a62c459
- Update create-pull-request action to version 8 https://github.com/devlooped/oss/commit/0662872
- Upgrade create-pull-request action to version 8 https://github.com/devlooped/oss/commit/d00364f
- Enable package pruning in Directory.Build.props https://github.com/devlooped/oss/commit/0ff8b7b