### PR TITLE
⬆️ Bump gcm from v2.6.1 to v2.7.0

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -30,6 +30,8 @@ indent_size = 2
 
 # Dotnet code style settings:
 [*.{cs,vb}]
+tab_width = 4
+
 # Sort using and Import directives with System.* appearing first
 dotnet_sort_system_directives_first = true
 # Avoid "this." and "Me." if not necessary
@@ -56,6 +58,9 @@ dotnet_style_require_accessibility_modifiers = omit_if_default:error
 
 # IDE0040: Add accessibility modifiers
 dotnet_diagnostic.IDE0040.severity = error
+
+# IDE1100: Error reading content of source file 'Project.TargetFrameworkMoniker' (i.e. from ThisAssembly)
+dotnet_diagnostic.IDE1100.severity = none
 
 [*.cs]
 # Top-level files are definitely OK

--- a/.github/workflows/includes.yml
+++ b/.github/workflows/includes.yml
@@ -5,8 +5,9 @@ on:
     branches:
       - 'main'
     paths:
-      - '**.md'    
+      - '**.md'
       - '!changelog.md'
+      - 'osmfeula.txt'
 
 jobs:
   includes:
@@ -31,14 +32,33 @@ jobs:
       - name: +Mᐁ includes
         uses: devlooped/actions-includes@v1
 
+      - name: 📝 OSMF EULA
+        shell: pwsh
+        run: |
+          $file = "osmfeula.txt"
+          $props = "src/Directory.Build.props"
+          if (-not (test-path $file) -or -not (test-path $props)) {
+            exit 0
+          }
+
+          $product = dotnet msbuild $props -getproperty:Product
+          if (-not $product) { 
+            write-error 'To use OSMF EULA, ensure the $(Product) property is set in Directory.props'
+            exit 1
+          }
+          
+          ((get-content -raw $file) -replace '\$product\$',$product).trim() | set-content $file
+
       - name: ✍ pull request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
-          add-paths: '**.md'
+          add-paths: |
+            **.md
+            *.txt
           base: main
           branch: markdown-includes
           delete-branch: true
-          labels: docs
+          labels: dependencies
           author: ${{ env.BOT_AUTHOR }}
           committer: ${{ env.BOT_AUTHOR }}
           commit-message: +Mᐁ includes

--- a/.netconfig
+++ b/.netconfig
@@ -1,7 +1,7 @@
 [file "src/Core/Authentication/OAuth"]
-	url = https://github.com/git-ecosystem/git-credential-manager/tree/v2.6.1/src/shared/Core/Authentication/OAuth/
+	url = https://github.com/git-ecosystem/git-credential-manager/tree/v2.7.0/src/shared/Core/Authentication/OAuth/
 [file "src/Core/Interop"]
-	url = https://github.com/git-ecosystem/git-credential-manager/tree/v2.6.1/src/shared/Core/Interop/
+	url = https://github.com/git-ecosystem/git-credential-manager/tree/v2.7.0/src/shared/Core/Interop/
 [file]
 	url = https://github.com/devlooped/oss
 	url = https://github.com/clarius/pages
@@ -42,8 +42,8 @@
 	skip
 [file ".editorconfig"]
 	url = https://github.com/devlooped/oss/blob/main/.editorconfig
-	sha = c779d3d4e468358106dea03e93ba2cd35bb01ecb
-	etag = 7298c6450967975a8782b5c74f3071e1910fc59686e48f9c9d5cd7c68213cf59
+	sha = a62c45934ac2952f2f5d54d8aea4a7ebc1babaff
+	etag = b5e919b472a52d4b522f86494f0f2c0ba74a6d9601454e20e4cbaf744317ff62
 	weak
 [file ".gitattributes"]
 	url = https://github.com/devlooped/oss/blob/main/.gitattributes
@@ -93,8 +93,8 @@
 	weak
 [file "src/Directory.Build.props"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.props
-	sha = c509be4378ff6789df4f66338cb88119453c0975
-	etag = cbbdc1a4d3030f353f3e5306a6c380238dd4ed0945aad2d56ba87b49fcfcd66d
+	sha = 0ff8b7b79a82112678326d1dc5543ed890311366
+	etag = 3ebde0a8630d526b80f15801179116e17a857ff880a4442e7db7b075efa4fd63
 	weak
 [file "src/Directory.Build.targets"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.targets
@@ -116,8 +116,8 @@
 	weak
 [file ".github/workflows/includes.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/includes.yml
-	sha = 85829f2510f335f4a411867f3dbaaa116c3ab3de
-	etag = 086f6b6316cc6ea7089c0dcc6980be519e6ed6e6201e65042ef41b82634ec0ee
+	sha = 06628725a6303bb8c4cf3076a384fc982a91bc0b
+	etag = 478f91d4126230e57cc601382da1ba23f9daa054645b4af89800d8dd862e64fd
 	weak
 [file ".github/workflows/combine-prs.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/combine-prs.yml
@@ -133,256 +133,256 @@
 	etag = 556a28914eeeae78ca924b1105726cdaa211af365671831887aec81f5f4301b4
 	weak
 [file "src/Core/CommandContext.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/CommandContext.cs
-	sha = de1ff8bdeac3d60a76e0ebba98e01781d38a9d4d
-	etag = a62f430e31fd818c9576ebd4b07544fccb16d7a5fd29bcabcc840d7ba3c523c0
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/CommandContext.cs
+	sha = b05317f74562e087b56ce8e7fdfc44e33c400589
+	etag = 9120172d92156490a9112678de85f72d13a5e4f4af164f3202f89b1eee0f80da
 	weak
 [file "src/Core/Trace2.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Trace2.cs
-	sha = a0599d08e06097b84c0fbbb18e9133ebe9977177
-	etag = a8e7322f388aa565e9222cd0b32ffd44d7b4072da04db7ccbe3fa5d561d07b56
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Trace2.cs
+	sha = d4e2f59030b0862a7d0d01b96fad454f27d5932e
+	etag = 5799aca7d1d61ca620d3320c7a581765e5b47be47ec8379f33c75f9b3af2ae2a
 	weak
 [file "src/Core/StandardStreams.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/StandardStreams.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/StandardStreams.cs
 	sha = 61e4fa4c328c232445618dd4ae7a0c5f31776fc5
 
 	etag = b8b7e537bbe07310e5d8e741a41e2e84f14279d58aab4dfe973161b5c0f59baf
 	weak
 [file "src/Core/ITerminal.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/ITerminal.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/ITerminal.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = 576b88afbd5990a6839bc20ae78006a6d270f57cfc864402b5b7fc50f3dde8c1
 	weak
 [file "src/Core/ISessionManager.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/ISessionManager.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/ISessionManager.cs
 	sha = e040cdff0eb0cdda610cbca1c730d020cbbfe5e8
 	etag = d0d8884d316a5782a88affa5ff83705b259e1407d328ae2ee405f477bb60a6d5
 	weak
 [file "src/Core/FileSystem.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/FileSystem.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/FileSystem.cs
 	sha = d37c201c3dc9a61078777ccaf770b707579d7722
 	etag = 11c4b510355966ca7fb9401bfb7a9ea7c08f02a061ca0c27c6aa16a3e20ec0d3
 	weak
 [file "src/Core/ICredentialStore.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/ICredentialStore.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/ICredentialStore.cs
 	sha = 28edc00ccca5cac29407687e09f6be4320f63f95
 	etag = a3d76b41023dad821a121db5f97cd1c8ca13050a3b67aaff159eed8d379f9c99
 	weak
 [file "src/Core/Credential.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Credential.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Credential.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = c9e982b5a617e964e668a9441c599cad48a1bcfdb328cdba1c16aacc960b7c43
 	weak
 [file "src/Core/Trace.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Trace.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Trace.cs
 	sha = e104c1881cbf18bc7a1efbc4d1eceb32fe3370fe
 	etag = e7c3cce66cc5be89165f1bae27bda691cf35186e6056c0221d62c8f7c937046f
 	weak
 [file "src/Core/HttpClientFactory.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/HttpClientFactory.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/HttpClientFactory.cs
 	sha = a656832ff360c66313d0b669e27eebf22cb44e30
 	etag = 88c94e9107332d43f3b7685f376f7a1c3639367fce2a7f2294c154dd061b1051
 	weak
 [file "src/Core/Git.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Git.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Git.cs
 	sha = 6931c9275780477eae6b682a542c739924d44a36
 	etag = 08a172d297cf60dd5d978b20557021c559acf9c4028cd556f02cb23b075cdb68
 	weak
 [file "src/Core/EnvironmentBase.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/EnvironmentBase.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/EnvironmentBase.cs
 	sha = f25667261e9df8d96b8fce25b7c39f48a800b554
 	etag = 07812af00bf0bc0d845e8c0c263d945a8e99ae058c0e46da066f27d205907b39
 	weak
 [file "src/Core/ProcessManager.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/ProcessManager.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/ProcessManager.cs
 	sha = 65e5a883bacd1e3e54fc40726812237a1066c8f4
 	etag = 55bda8c781d56304e55d0da982a613bf877c69f604e535c3ffe4b41c454df4fe
 	weak
 [file "src/Core/DisposableObject.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/DisposableObject.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/DisposableObject.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = 6c463a8bb34938152853feea21a08a60292d3ffb7c894ebb689f15d047bc0802
 	weak
 [file "src/Core/PlatformUtils.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/PlatformUtils.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/PlatformUtils.cs
 	sha = 59f01d9d737cd4b649c1596a81054e22b390fd32
 	etag = 9a2583672f4b82b9b3e18bbb13b5c83ffe3aa80db53083717df3d770c62f0cab
 	weak
 [file "src/Core/Trace2Exception.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Trace2Exception.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Trace2Exception.cs
 	sha = 23997510a8cebb2e3494e9f6307b66bcfa13b6f5
 	etag = e79adb2b44d0ed5dd3feedd07689df6ab51f7aed487c1ced0d04be9c97732925
 	weak
 [file "src/Core/Trace2FileWriter.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Trace2FileWriter.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Trace2FileWriter.cs
 	sha = 933bb26c9fa675732492eca8334db3f0dcb3d050
 	etag = 0d96497993637c9030895038c34eee99249e510ee8a8f00ee7ad0d265e6dfc35
 	weak
 [file "src/Core/Trace2StreamWriter.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Trace2StreamWriter.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Trace2StreamWriter.cs
 	sha = ec9359d15296eaaeac65056eb1b934a85680c898
 	etag = 739a550aef55822386820b8e9a4e35a7a00be51f83865e79592c3969d9e49252
 	weak
 [file "src/Core/Trace2Message.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Trace2Message.cs
-	sha = 865a3c52e0374b78f5cf29553d4c9f37799b050b
-	etag = 43c7b1db7ece0e09f8ed8576f1151bec9855f174eec33a881fc596418d4cfe08
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Trace2Message.cs
+	sha = 480b32c515cb6f05359765471657962a94901437
+	etag = 20f1f8bf60bd5d466fdb336499b541d3e4aa9769b3cd2358c1eeddcc0123c10d
 	weak
 [file "src/Core/ITrace2Writer.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/ITrace2Writer.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/ITrace2Writer.cs
 	sha = 59a2692614fb3f1a8afdfeaa03f4d7e38318e648
 	etag = dd8851bb18d908dc790f6eb49326ac33325895ceaff4b43100ce4e18124303b8
 	weak
 [file "src/Core/Settings.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Settings.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Settings.cs
 	sha = 32d205b8ea623dfdb8d663a1ff8b2d5da3a8903b
 
 	etag = cef2ef5775f780128d7a284c9e642d3eac12e2fa2f877cbef8d8cde03fd58526
 	weak
 [file "src/Core/PlaintextCredentialStore.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/PlaintextCredentialStore.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/PlaintextCredentialStore.cs
 	sha = e8b02e00891f718d8b9617d7944c523ebf17e60f
 	etag = 40dea3f67e29e27b9289ca3a0d8879dea85e057e77f3c3fb030260cb09fa399e
 	weak
 [file "src/Core/ISystemPrompts.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/ISystemPrompts.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/ISystemPrompts.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = 673adabdaa4e48aa4ce75b28145c113a6a905239c710e6dd0ad0de79e3cd9134
 	weak
 [file "src/Core/Gpg.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Gpg.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Gpg.cs
 	sha = 40f75089539bd6908b88f3a6ae867003cd34126a
 	etag = 0e31e59cffabf4bcc13c98cf2ac5fd483e5c23a38782d44f6dbf2ea33e864843
 	weak
 [file "src/Core/GitConfiguration.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/GitConfiguration.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/GitConfiguration.cs
 	sha = 336278cdd430a73139d685b1d81dfd6108797a97
 	etag = 4e90a0ab5f1d8406441525f2cb93e9ba945944d11fdc51dcc9f4812377d36ce8
 	weak
 [file "src/Core/FileCredential.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/FileCredential.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/FileCredential.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = c6f8ec0141576d6fc00db4c4fc6f390c901576d9ab05aead2836fe62516d0693
 	weak
 [file "src/Core/GitVersion.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/GitVersion.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/GitVersion.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = 9ea13a9c4ca7e0938ea1b374104a4fa45f3e29f26b81acc90ddd427626b35551
 	weak
 [file "src/Core/ChildProcess.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/ChildProcess.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/ChildProcess.cs
 	sha = 40f75089539bd6908b88f3a6ae867003cd34126a
 	etag = e09e721226f8c97b6481291a7d1486ccba656bfca69eace5cb637535a7d8850a
 	weak
 [file "src/Core/GitConfigurationEntry.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/GitConfigurationEntry.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/GitConfigurationEntry.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = 74e4373ccff2f0f06c249c8300510286484efa9932031df1d5d82df357a077cb
 	weak
 [file "src/Core/Constants.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Constants.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Constants.cs
 	sha = b05317f74562e087b56ce8e7fdfc44e33c400589
 
-	etag = 8f3baf8cd7da7a182199462982107ffa98478c224a7017a5f32d16a7fc2fec91
+	etag = 0867deaeb1e726c7fe482a2f96ae9aa56c2243833349e2860a33b63135649fb1
 	weak
 [file "src/Core/ConvertUtils.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/ConvertUtils.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/ConvertUtils.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = 53cd52a712295538009308b0ce7cb008ab776f1a8b686f90b0ad6c783b2b02cd
 	weak
 [file "src/Core/EnsureArgument.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/EnsureArgument.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/EnsureArgument.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = 1930fdc866b9fa2228fdf338cb5a6420d775c8d7e3d321ff30c47535aeaa2115
 	weak
 [file "src/Core/StringExtensions.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/StringExtensions.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/StringExtensions.cs
 	sha = 7d2a8cc583a8aeae104c6cb144fde1328ef50cae
 	etag = f7b83bbe6f2c0d41b0f8b15f1be54d571ca0180e95ed4d016375c4f6b05ed800
 	weak
 [file "src/Core/StreamExtensions.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/StreamExtensions.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/StreamExtensions.cs
 	sha = 93cada914ca47632dd6972e6f5d927eebe78ca37
 	etag = 9cc36b7d21782a7a42acd08526921a2dd2f106418d13b0ad49e1e4efa182cc1d
 	weak
 [file "src/Core/Trace2CollectorWriter.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Trace2CollectorWriter.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Trace2CollectorWriter.cs
 	sha = e9db80225e3961aa33442d0918827bf44176ded5
 	etag = 551cd3c933737a31c0e9cc6923eea89846146fa3072174667127b351db3847b7
 	weak
 [file "src/Core/CurlCookie.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/CurlCookie.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/CurlCookie.cs
 	sha = cebbc7342410e8f3f9c03eb42124ea7f78f0beb1
 	etag = 3f60948fc943c01317d5fc3901c5fee0eabda96945c0a210f9e07f36b49a9e0f
 	weak
 [file "src/Core/WslUtils.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/WslUtils.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/WslUtils.cs
 	sha = d0b767b37d6e6fa42b7c738a3729cdfc41e1c0d1
 	etag = b5e18ee7a809623c704540c922d3fdca94ae72b97cf5b8562e232e41025dfd7c
 	weak
 [file "src/Core/TraceUtils.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/TraceUtils.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/TraceUtils.cs
 	sha = c2366f7444e93600f6421da61e3773701f663e80
 	etag = 44b1a076f7212a0b2e22fefdd0430473cc0076db1371af54e69f7f4861010369
 	weak
 [file "src/Core/GitConfigurationKeyComparer.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/GitConfigurationKeyComparer.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/GitConfigurationKeyComparer.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = 6aa47b7ad804d36e31807eddd6c8297d9f3314d76e486e82824df493caeaa75a
 	weak
 [file "src/Core/IniFile.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/IniFile.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/IniFile.cs
 	sha = 6b887e1a28f8fcc876168a9f5b0f39b9ead3879d
 	etag = 34f073b3757e0d7b536de1efa9d4f994951f11ab0e755e0f7efb6015da035fc6
 	weak
 [file "src/Core/CredentialStore.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/CredentialStore.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/CredentialStore.cs
 	sha = a96afbb254675544a1f60cf7a6865b540785deac
 
 	etag = 4311ca41c4664690a5a4cb34e3368ecf7dee914a48b7152e35e2d6d863cd426f
 	weak
 [file "src/Core/CredentialCacheStore.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/CredentialCacheStore.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/CredentialCacheStore.cs
 	sha = 28edc00ccca5cac29407687e09f6be4320f63f95
 	etag = 35ce2cdfa6252d82a900e35c5dcbae44397e386621c2a261622f73a2a594143d
 	weak
 [file "src/Core/EncodingEx.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/EncodingEx.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/EncodingEx.cs
 	sha = b8f4c28742268a7b5c783c1b302e12450ef7b8b1
 	etag = 62aedc21b88779f163601f289a557884d19a3c888cab3add58247a0dc3dd66ea
 	weak
 [file "src/Core/BrowserUtils.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/BrowserUtils.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/BrowserUtils.cs
 	sha = d0b767b37d6e6fa42b7c738a3729cdfc41e1c0d1
 	etag = f9a39627fd901ab3d2070430b6c5db768398314645cefde773e3aaf43c89904d
 	weak
 [file "src/Core/AssemblyUtils.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/AssemblyUtils.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/AssemblyUtils.cs
 	sha = 7cee518ca65a7d455d5c6fcbbad0402222d311b7
 	etag = 9a900d42799b17385cb34bd4742b4ba67fd6b332fc569b91a579f22e73173ae1
 	weak
 [file "src/Core/Base64UrlConvert.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Base64UrlConvert.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Base64UrlConvert.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = 245a19ebb1c92ca2f5d90d6a7d1ad1409d2114b1dbd5f3a6304e6dd86292c622
 	weak
 [file "src/Core/UriExtensions.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/UriExtensions.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/UriExtensions.cs
 	sha = 62abc306bfa051ced74fb9e82a9db5b365aa57a8
 	etag = 313c8e305a46518dbb6e9ac462eba0254a6f22aeb5d691b1e656d1a60642bd4c
 	weak
 [file "src/Core/DictionaryExtensions.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/DictionaryExtensions.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/DictionaryExtensions.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = 752b70be414a32723694ce143c852e92baf8fd8b865a94f3b6382f47c95fa2e1
 	weak
 [file "src/Core/NameValueCollectionExtensions.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/NameValueCollectionExtensions.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/NameValueCollectionExtensions.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = ebc36bdebb0c2e2a5668b8641db5df33dc70f51b11d8e05ee54d5492ece5aa71
 	weak
 [file "src/Core/HttpRequestExtensions.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/HttpRequestExtensions.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/HttpRequestExtensions.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = 86395d5341813a666be65cc17b651204e05959f79060c015f1edb6a98d33c85e
 	weak
@@ -392,342 +392,342 @@
 	etag = 013a47739e348f06891f37c45164478cca149854e6cd5c5158e6f073f852b61a
 	weak
 [file "src/Core/Authentication/OAuth/HttpListenerExtensions.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Authentication/OAuth/HttpListenerExtensions.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Authentication/OAuth/HttpListenerExtensions.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = a6ae61ce88ceb358eb66c51e70a7f8f33fbab4d054b1285706083c0c012064f2
 	weak
 [file "src/Core/Authentication/OAuth/IOAuth2WebBrowser.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Authentication/OAuth/IOAuth2WebBrowser.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Authentication/OAuth/IOAuth2WebBrowser.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = 01968d1415a4c442dc85584255960f56905738856847610d7d485be3692b92b3
 	weak
 [file "src/Core/Authentication/OAuth/Json/DeviceAuthorizationEndpointResponseJson.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Authentication/OAuth/Json/DeviceAuthorizationEndpointResponseJson.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Authentication/OAuth/Json/DeviceAuthorizationEndpointResponseJson.cs
 	sha = 71d03fb493060e75f9e45bf8b87a97582a51a7b2
 	etag = 525c9d16e0e14c00d3b5b99be72068d173d39f303e9a72619e7158093331428e
 	weak
 [file "src/Core/Authentication/OAuth/Json/ErrorResponseJson.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Authentication/OAuth/Json/ErrorResponseJson.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Authentication/OAuth/Json/ErrorResponseJson.cs
 	sha = 71d03fb493060e75f9e45bf8b87a97582a51a7b2
 	etag = da7bd48c0d137f97c77b5daead4c0a51be52271ae6a0ceded3352bcaef9b15da
 	weak
 [file "src/Core/Authentication/OAuth/Json/TokenEndpointResponseJson.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Authentication/OAuth/Json/TokenEndpointResponseJson.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Authentication/OAuth/Json/TokenEndpointResponseJson.cs
 	sha = f1bed778d415cc67758952a9a17d56f0b611f626
 	etag = 2fc143bcb9d7a6b7ee021bc980f8ec3e60cf070697a4d60e0846a62c5abdc4f4
 	weak
 [file "src/Core/Authentication/OAuth/OAuth2AuthorizationCodeResult.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Authentication/OAuth/OAuth2AuthorizationCodeResult.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Authentication/OAuth/OAuth2AuthorizationCodeResult.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = 343a0d586b41b7152576114d241755e867a39007fd0236daafa4bd7a0c198931
 	weak
 [file "src/Core/Authentication/OAuth/OAuth2Client.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Authentication/OAuth/OAuth2Client.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Authentication/OAuth/OAuth2Client.cs
 	sha = 4e8674aeb62317641a5a53834563d48441cf4d95
 	etag = 118bf95993f7cf58dc2627b599b1d0b7915d7023ad0a4b515b2ba8c3f2df8d1a
 	weak
 [file "src/Core/Authentication/OAuth/OAuth2Constants.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Authentication/OAuth/OAuth2Constants.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Authentication/OAuth/OAuth2Constants.cs
 	sha = 06a3edf16174d9a7ffbc29c56e8554197d96d8fa
 	etag = 9eca313464868508c8a9d6163415320f29912b8fd944e1838ba8cf9ddedfd373
 	weak
 [file "src/Core/Authentication/OAuth/OAuth2CryptographicGenerator.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Authentication/OAuth/OAuth2CryptographicGenerator.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Authentication/OAuth/OAuth2CryptographicGenerator.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = c8c66d11b08f57cd6f1ced424d0f49cf340de3aee2f3dc724cd23f6ca77a5713
 	weak
 [file "src/Core/Authentication/OAuth/OAuth2DeviceCodeResult.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Authentication/OAuth/OAuth2DeviceCodeResult.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Authentication/OAuth/OAuth2DeviceCodeResult.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = a49a6b19c24542663dd176f971ea46c8eb17473b5c1183219441e379a747ae7b
 	weak
 [file "src/Core/Authentication/OAuth/OAuth2Exception.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Authentication/OAuth/OAuth2Exception.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Authentication/OAuth/OAuth2Exception.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = a5fac5128a0bc160e4fd95fdf9f115e2a80eaacb4f2e2a6129eebfe17ba1308a
 	weak
 [file "src/Core/Authentication/OAuth/OAuth2ServerEndpoints.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Authentication/OAuth/OAuth2ServerEndpoints.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Authentication/OAuth/OAuth2ServerEndpoints.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = 957ea8a9567c7b7012a88a28cfc50c65f2002254e2e35eb2c0ff6c78d37c4331
 	weak
 [file "src/Core/Authentication/OAuth/OAuth2SystemWebBrowser.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Authentication/OAuth/OAuth2SystemWebBrowser.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Authentication/OAuth/OAuth2SystemWebBrowser.cs
+	weak
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = f1dfa70e7f6096ef5a0fccc3d3737bcb4e22089dfeeb2afc6b3e722ca40da888
-	weak
 [file "src/Core/Authentication/OAuth/OAuth2TokenResult.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Authentication/OAuth/OAuth2TokenResult.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Authentication/OAuth/OAuth2TokenResult.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = 7942488c12152b9069d6cf11921fa0506b4a656628f2f96cad62ea91b1c165b6
 	weak
 [file "src/Core/Interop/InteropException.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/InteropException.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/InteropException.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = f4a2b97bdc2307040e191943e20a408e1add3895eb8c2409659ce067251dca15
 	weak
 [file "src/Core/Interop/InteropUtils.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/InteropUtils.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/InteropUtils.cs
 	sha = 43b5c5133780046ed42e94aa7eb9c94fd07afe40
 	etag = dca8d5613f5627ead2e2229f46d3db365cfe533e0677c32077fbc943d38b0ad0
 	weak
 [file "src/Core/Interop/Linux/LinuxFileSystem.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/Linux/LinuxFileSystem.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/Linux/LinuxFileSystem.cs
 	sha = ca19938cc0171e89245447be8e534ee93507ed6a
 	etag = 45542500a9797765b8cb91f4cc588af80ee1345050db2fadcb6edf71ce299d7b
 	weak
 [file "src/Core/Interop/Linux/LinuxSessionManager.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/Linux/LinuxSessionManager.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/Linux/LinuxSessionManager.cs
 	sha = d0b767b37d6e6fa42b7c738a3729cdfc41e1c0d1
 	etag = 84b54d3c5af611ac8410acffe5600b9644e359d64b33550259bf7ad1293c1dd0
 	weak
 [file "src/Core/Interop/Linux/LinuxTerminal.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/Linux/LinuxTerminal.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/Linux/LinuxTerminal.cs
 	sha = 94f8d91eacc5ffc5037ab0d96337a531419b4021
 	etag = 7feccef50d58fd90c408910dd2e33e7226676b5cc2635c23a44649d57a776115
 	weak
 [file "src/Core/Interop/Linux/Native/Glib.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/Linux/Native/Glib.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/Linux/Native/Glib.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = 5bc2ebdca310c5e15d1d6c7e3e4ca31942f44b4097a1285cdf8578de1b912efb
 	weak
 [file "src/Core/Interop/Linux/Native/Gobject.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/Linux/Native/Gobject.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/Linux/Native/Gobject.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = e1382665b774a1bbb6bec13f90c8089d078df7dd3bb866c41f5b81ae4f9f1419
 	weak
 [file "src/Core/Interop/Linux/Native/Libsecret.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/Linux/Native/Libsecret.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/Linux/Native/Libsecret.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = 8adee76b5d50c9ddec440987cf9a6111c296ea6095b72df92a1bb29327db3c31
 	weak
 [file "src/Core/Interop/Linux/Native/termios_Linux.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/Linux/Native/termios_Linux.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/Linux/Native/termios_Linux.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = 6df5d1e191d616cbff2fe3d71636c62674c577b6638add1cd42364ff24acd82d
 	weak
 [file "src/Core/Interop/Linux/SecretServiceCollection.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/Linux/SecretServiceCollection.cs
-	sha = e8b02e00891f718d8b9617d7944c523ebf17e60f
-	etag = 972a9897b6965920d50df8ac0096fd20b19d5b8ca6ab47545efb13727c7f09d8
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/Linux/SecretServiceCollection.cs
+	sha = f6fe9ca629b29d7e7d06baab6166b3ac40fb6514
+	etag = 21542170d1fc87a6a11a777564aacac3bd485357cc95b109e776d4cf46959c3c
 	weak
 [file "src/Core/Interop/Linux/SecretServiceCredential.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/Linux/SecretServiceCredential.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/Linux/SecretServiceCredential.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = 81f9f6596053c460f2985fb34f18c81bff20592da3b049ad8c6e22a8f0437dc7
 	weak
 [file "src/Core/Interop/MacOS/MacOSEnvironment.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/MacOS/MacOSEnvironment.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/MacOS/MacOSEnvironment.cs
 	sha = a130fec718edbc83e8067f0cde58b1fd720ce087
 	etag = 632d1e96b5fd90a4f5c8bcc6d5301d0e6091730e6201474e42ee1c4881340450
 	weak
 [file "src/Core/Interop/MacOS/MacOSFileSystem.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/MacOS/MacOSFileSystem.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/MacOS/MacOSFileSystem.cs
 	sha = ca19938cc0171e89245447be8e534ee93507ed6a
 	etag = 35caf38c0f385f3b4c25be84b3c2e653aea3bfb01fc6e70b8c3a976bae40c0f9
 	weak
 [file "src/Core/Interop/MacOS/MacOSKeychain.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/MacOS/MacOSKeychain.cs
-	sha = e8b02e00891f718d8b9617d7944c523ebf17e60f
-	etag = b5620ea3389be1b835fea207842a003bf9454e0170b00ccd22472e0a9ce0f4fc
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/MacOS/MacOSKeychain.cs
 	weak
+	sha = 5f6d32ae4e43694b0b7e329d5c87fcf4d7a1348a
+	etag = 0db9cb9c975c7b5814d8be55e2c562616ade445658574ecc0beda2821dfd05a7
 [file "src/Core/Interop/MacOS/MacOSKeychainCredential.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/MacOS/MacOSKeychainCredential.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/MacOS/MacOSKeychainCredential.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = a779c3a8d51f10326eb557063f185276b2f78807e1bbe064876658561fdbcb22
 	weak
 [file "src/Core/Interop/MacOS/MacOSSessionManager.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/MacOS/MacOSSessionManager.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/MacOS/MacOSSessionManager.cs
 	sha = d0b767b37d6e6fa42b7c738a3729cdfc41e1c0d1
 	etag = a841138dad7dd688e2b6481f099b2f81d4caec1f57e1ff9d4f487f5fe5dd4bf1
 	weak
 [file "src/Core/Interop/MacOS/MacOSTerminal.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/MacOS/MacOSTerminal.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/MacOS/MacOSTerminal.cs
 	sha = 94f8d91eacc5ffc5037ab0d96337a531419b4021
 	etag = 8781a490dcd3f396279f9de3d4a164cd36cc49044227494b974f0359d2aa365b
 	weak
 [file "src/Core/Interop/MacOS/Native/CoreFoundation.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/MacOS/Native/CoreFoundation.cs
-	sha = c91294385db910f8dd15c0345e100cd034e6482f
-	etag = 62b890c452dfaafdf8d681084b6625d146373ac2bb37c446defc70128dbb7179
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/MacOS/Native/CoreFoundation.cs
+	sha = 5f6d32ae4e43694b0b7e329d5c87fcf4d7a1348a
+	etag = 48528cb070b4737cb1bbd667847e7283747ee990a88bd391ae5b7d3463f5dc21
 	weak
 [file "src/Core/Interop/MacOS/Native/LibC.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/MacOS/Native/LibC.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/MacOS/Native/LibC.cs
 	sha = 7366a54fef612322a8fcbe8c2b8c273e46737358
 	etag = 2f699a6798408046255138f57a090168028d4d41a00a78924b70dc66f4345cc5
 	weak
 [file "src/Core/Interop/MacOS/Native/LibSystem.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/MacOS/Native/LibSystem.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/MacOS/Native/LibSystem.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = b498c2d322c4078bec002ac1b26335c37917231ca1dec6d04746411872de97a6
 	weak
 [file "src/Core/Interop/MacOS/Native/SecurityFramework.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/MacOS/Native/SecurityFramework.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/MacOS/Native/SecurityFramework.cs
 	sha = 28edc00ccca5cac29407687e09f6be4320f63f95
 	etag = 1fceccc37794b0938b6d5d01f48ead468d1956dff3c032edb998a1a9e85bdefc
 	weak
 [file "src/Core/Interop/MacOS/Native/termios_MacOS.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/MacOS/Native/termios_MacOS.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/MacOS/Native/termios_MacOS.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = ff460668bc6e9f9d431ca4aa3e5ed6066453d411572fbc00b17ec2303aed1f9f
 	weak
 [file "src/Core/Interop/Posix/GpgPassCredentialStore.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/Posix/GpgPassCredentialStore.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/Posix/GpgPassCredentialStore.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = 29dbffffd90bd6167a3f6e6f52e0a918ee1447cf571da3257aaea077b2ea41e5
 	weak
 [file "src/Core/Interop/Posix/Native/Fcntl.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/Posix/Native/Fcntl.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/Posix/Native/Fcntl.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = dd87dc81c72259c941104f12199323916698f06bbdf7e157c895280ef147eb3e
 	weak
 [file "src/Core/Interop/Posix/Native/Signal.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/Posix/Native/Signal.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/Posix/Native/Signal.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = aee509b4626bd9de0ee713ba08315e9c816bca7c90f7379ab4730bb7b3488e1c
 	weak
 [file "src/Core/Interop/Posix/Native/Stat.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/Posix/Native/Stat.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/Posix/Native/Stat.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = 6d0d2b5deff0b6554cf2e8fcdba10717253a85aca9abeebde39b264cc39d452e
 	weak
 [file "src/Core/Interop/Posix/Native/Stdio.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/Posix/Native/Stdio.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/Posix/Native/Stdio.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = 03500cbe78f498f2d72fe86ffb05e9207022e8ff1898015903cba2aec16f5d1c
 	weak
 [file "src/Core/Interop/Posix/Native/Stdlib.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/Posix/Native/Stdlib.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/Posix/Native/Stdlib.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = 1397abe89883a92138b9b011751c611e7e1a8ac3fa10a104e8c8e038789b1fba
 	weak
 [file "src/Core/Interop/Posix/Native/Termios.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/Posix/Native/Termios.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/Posix/Native/Termios.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = b86393bf808f9246e62f78bbdbe5e49fe13dc0a26f0fccb9fa71561c9e410020
 	weak
 [file "src/Core/Interop/Posix/Native/Unistd.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/Posix/Native/Unistd.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/Posix/Native/Unistd.cs
 	sha = 7366a54fef612322a8fcbe8c2b8c273e46737358
 	etag = 3753d6444a3319b6bc35c7ab719d989bd2d79ff8e297247ce5dbe15d4a49a566
 	weak
 [file "src/Core/Interop/Posix/PosixEnvironment.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/Posix/PosixEnvironment.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/Posix/PosixEnvironment.cs
 	sha = a130fec718edbc83e8067f0cde58b1fd720ce087
 	etag = 12e8e06a15efbef40f84b7cf38432146d66416012dfbd8c47815dd279ed75d7e
 	weak
 [file "src/Core/Interop/Posix/PosixFileDescriptor.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/Posix/PosixFileDescriptor.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/Posix/PosixFileDescriptor.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = 125d0a1c8ca34099eb44bccb0b5dfeece94186857dd485ab30ca48cd69e75665
 	weak
 [file "src/Core/Interop/Posix/PosixFileSystem.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/Posix/PosixFileSystem.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/Posix/PosixFileSystem.cs
 	sha = ca19938cc0171e89245447be8e534ee93507ed6a
 	etag = 9d4c92402f7abcd44248d9029af7acd52395d0c15619e4bc8fa29acf86f2fcf3
 	weak
 [file "src/Core/Interop/Posix/PosixSessionManager.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/Posix/PosixSessionManager.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/Posix/PosixSessionManager.cs
 	sha = d0b767b37d6e6fa42b7c738a3729cdfc41e1c0d1
 	etag = 6bd57a3335e1d5d594b32aa874c4185a870b25b98558d4da56a98c3660269857
 	weak
 [file "src/Core/Interop/Posix/PosixTerminal.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/Posix/PosixTerminal.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/Posix/PosixTerminal.cs
 	sha = dfd3dadc75a823ccdd58222af2435bb811fc2ab0
 	etag = 45b94e78b9a3c918368421196073da6b178e9d4b846274d79d9ee4bd483c0f69
 	weak
 [file "src/Core/Interop/U8StringConverter.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/U8StringConverter.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/U8StringConverter.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = 6c842097307e6fa8ea6f8b97f5deef4d33f3a7300c66566bedff7316baf3c089
 	weak
 [file "src/Core/Interop/U8StringMarshaler.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/main/src/shared/Core/Interop/U8StringMarshaler.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/U8StringMarshaler.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = a1551b8a18fbb79a48a6d6e78a8202f5d0ba83e81bc1ec35dce7119cd43b8407
 	weak
 [file "src/Core/Interop/Windows/DpapiCredentialStore.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/Windows/DpapiCredentialStore.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/Windows/DpapiCredentialStore.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = 80f94fbc0f53a91cc31db26114611f17372fa925734e647f081bfe2379814411
 	weak
 [file "src/Core/Interop/Windows/Native/Advapi32.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/Windows/Native/Advapi32.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/Windows/Native/Advapi32.cs
 	sha = e0218ace4a93dcb152e528b24f600bed0ee8483c
 	etag = 4e799d8a0fb8841225668697344a55f0042763f63edb67290fe56bedfcce8fb4
 	weak
 [file "src/Core/Interop/Windows/Native/CredUi.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/Windows/Native/CredUi.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/Windows/Native/CredUi.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = 40fd47027fe8477fab05a514a76b86beef9f6b4d9d6750454d06a0a638dc23a0
 	weak
 [file "src/Core/Interop/Windows/Native/Kernel32.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/Windows/Native/Kernel32.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/Windows/Native/Kernel32.cs
 	sha = 134e622aefa7f334f656c3356120956c2997e595
 	etag = b2e62982877004fe44051a5a398fc725ac432c917a5baa24820323a2cbde5565
 	weak
 [file "src/Core/Interop/Windows/Native/Ole32.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/Windows/Native/Ole32.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/Windows/Native/Ole32.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = f8d11d3dc82d81f75f58198023073e640313b01954b47387c50f59981290447a
 	weak
 [file "src/Core/Interop/Windows/Native/Shell32.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/Windows/Native/Shell32.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/Windows/Native/Shell32.cs
 	sha = fa2cc1805a6f617d7e4dd242501fad860d5fbce2
 	etag = 8e8d401cedb13f66c314e7f695903d72a880802f00a8a6722dbd24c8dbffbdab
 	weak
 [file "src/Core/Interop/Windows/Native/User32.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/Windows/Native/User32.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/Windows/Native/User32.cs
 	sha = 134e622aefa7f334f656c3356120956c2997e595
 	etag = 73f2ef305aa6614bc3f9d81933fa9c2148c77ab5b7fc3254f4d8084bdc011ff2
 	weak
 [file "src/Core/Interop/Windows/Native/Win32Error.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/Windows/Native/Win32Error.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/Windows/Native/Win32Error.cs
 	sha = 94f8d91eacc5ffc5037ab0d96337a531419b4021
 	etag = a067404240ae5a98728e74994a426ee85fae5421b573e8658adbaa3034562a4d
 	weak
 [file "src/Core/Interop/Windows/WindowsCredential.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/Windows/WindowsCredential.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/Windows/WindowsCredential.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = d9bb85480d058d90c08096b5dfabf4d51934a155627218ec7aceaa67f7dc964d
 	weak
 [file "src/Core/Interop/Windows/WindowsCredentialManager.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/Windows/WindowsCredentialManager.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/Windows/WindowsCredentialManager.cs
 	sha = e8b02e00891f718d8b9617d7944c523ebf17e60f
 	etag = 3c1ba5e089f75be24172e73767805ca16200230a725f8390c8d1866d9c7a876b
 	weak
 [file "src/Core/Interop/Windows/WindowsEnvironment.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/Windows/WindowsEnvironment.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/Windows/WindowsEnvironment.cs
 	sha = a130fec718edbc83e8067f0cde58b1fd720ce087
 	etag = 905ca0898944337420aab8f31e6dc3babc54f1921c8d9346f58f785ff2e7fbf1
 	weak
 [file "src/Core/Interop/Windows/WindowsFileSystem.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/Windows/WindowsFileSystem.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/Windows/WindowsFileSystem.cs
 	sha = ca19938cc0171e89245447be8e534ee93507ed6a
 	etag = aff622066a29a9b90e6c77ef75206cf8fde7627a4d6c9ff88e0c3126e9a0df2b
 	weak
 [file "src/Core/Interop/Windows/WindowsProcessManager.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/Windows/WindowsProcessManager.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/Windows/WindowsProcessManager.cs
 	sha = d1b64ccd07239bdb8de4b732e9963753d4e89a62
 	etag = fc48908142dff5de467bfdbe61d7e026cc463d2abefaa92f39301e4b43b56540
 	weak
 [file "src/Core/Interop/Windows/WindowsSessionManager.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/Windows/WindowsSessionManager.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/Windows/WindowsSessionManager.cs
 	sha = d0b767b37d6e6fa42b7c738a3729cdfc41e1c0d1
 	etag = 64ea73ae307d85e4f2e8d69c130454743cc9587a67cc0c1242d4a65f03fd2f32
 	weak
 [file "src/Core/Interop/Windows/WindowsSettings.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/Windows/WindowsSettings.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/Windows/WindowsSettings.cs
 	sha = 8122dc0c8fdff17654ce3dea17b3a6fb0c899fff
 	etag = 723171f86db2ec3eb329eed519d74078c75571c44a16eb23b0b95063306b105d
 	weak
 [file "src/Core/Interop/Windows/WindowsSystemPrompts.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/Windows/WindowsSystemPrompts.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/Windows/WindowsSystemPrompts.cs
 	sha = c91294385db910f8dd15c0345e100cd034e6482f
 	etag = 4e9d2b7252fd16b25dd68daa1dc2703f39cfe223a97b7629d6d93a1b318d1ed5
 	weak
 [file "src/Core/Interop/Windows/WindowsTerminal.cs"]
-	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.6.1/src/shared/Core/Interop/Windows/WindowsTerminal.cs
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/Windows/WindowsTerminal.cs
 	sha = 94f8d91eacc5ffc5037ab0d96337a531419b4021
 	etag = 6ee21893c4a201ba834c9749b5518fb25f5702e7c4a29c68d3abd5cdf547301e
 	weak
@@ -740,4 +740,22 @@
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/dotnet-env.yml
 	sha = 77e83f238196d2723640abef0c7b6f43994f9747
 	etag = fcb9759a96966df40dcd24906fd328ddec05953b7e747a6bb8d0d1e4c3865274
+	weak
+[file "src/Core/Interop/MacOS/MacOSPreferences.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/MacOS/MacOSPreferences.cs
+	sha = 5f6d32ae4e43694b0b7e329d5c87fcf4d7a1348a
+	etag = d95af24fa5413dfc5960dba16e9dd73e3b14b840949fbcf631bbdb364f17116c
+	weak
+[file "src/Core/Interop/MacOS/MacOSSettings.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Interop/MacOS/MacOSSettings.cs
+	sha = b05317f74562e087b56ce8e7fdfc44e33c400589
+	etag = 252165b93f7889643c32f0a53723e1b91e900895bda7b5f413b687c307912455
+	weak
+[file ".github/workflows/dotnet-file-core.yml"]
+	url = https://github.com/devlooped/oss/blob/main/.github/workflows/dotnet-file-core.yml
+	skip
+[file "src/shared/Core/Authentication/OAuth/OAuth2SystemWebBrowser.cs"]
+	url = https://github.com/git-ecosystem/git-credential-manager/blob/v2.7.0/src/shared/Core/Authentication/OAuth/OAuth2SystemWebBrowser.cs
+	sha = c91294385db910f8dd15c0345e100cd034e6482f
+	etag = f1dfa70e7f6096ef5a0fccc3d3737bcb4e22089dfeeb2afc6b3e722ca40da888
 	weak

--- a/src/Core/CommandContext.cs
+++ b/src/Core/CommandContext.cs
@@ -131,7 +131,7 @@ namespace GitCredentialManager
                                             gitPath,
                                             FileSystem.GetCurrentDirectory()
                                         );
-                Settings          = new Settings(Environment, Git);
+                Settings          = new MacOSSettings(Environment, Git, Trace);
             }
             else if (PlatformUtils.IsLinux())
             {

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -16,6 +16,7 @@ namespace GitCredentialManager
 
         public const string GcmDataDirectoryName = ".gcm";
 
+        public const string MacOSBundleId = "git-credential-manager";
         public static readonly Guid DevBoxPartnerId = new("e3171dd9-9a5f-e5be-b36c-cc7c4f3f3bcf");
 
         /// <summary>

--- a/src/Core/Interop/Linux/SecretServiceCollection.cs
+++ b/src/Core/Interop/Linux/SecretServiceCollection.cs
@@ -66,7 +66,7 @@ namespace GitCredentialManager.Interop.Linux
                     secService,
                     ref schema,
                     queryAttrs,
-                    SecretSearchFlags.SECRET_SEARCH_UNLOCK,
+                    SecretSearchFlags.SECRET_SEARCH_UNLOCK | SecretSearchFlags.SECRET_SEARCH_ALL,
                     IntPtr.Zero,
                     out error);
 

--- a/src/Core/Interop/MacOS/MacOSKeychain.cs
+++ b/src/Core/Interop/MacOS/MacOSKeychain.cs
@@ -66,7 +66,6 @@ namespace GitCredentialManager.Interop.MacOS
                         if (typeId == CFArrayGetTypeID())
                         {
                             int len = (int)CFArrayGetCount(resultPtr);
-                            // NOTE: removed len from HashSet ctor since it's not supported in NS2.0
                             var accounts = new HashSet<string>();
                             for (int i = 0; i < len; i++)
                             {
@@ -303,35 +302,18 @@ namespace GitCredentialManager.Interop.MacOS
                 return null;
             }
 
-            IntPtr buffer = IntPtr.Zero;
-            try
+            if (CFDictionaryGetValueIfPresent(dict, key, out IntPtr value) && value != IntPtr.Zero)
             {
-                if (CFDictionaryGetValueIfPresent(dict, key, out IntPtr value) && value != IntPtr.Zero)
+                if (CFGetTypeID(value) == CFStringGetTypeID())
                 {
-                    if (CFGetTypeID(value) == CFStringGetTypeID())
-                    {
-                        int stringLength = (int)CFStringGetLength(value);
-                        int bufferSize = stringLength + 1;
-                        buffer = Marshal.AllocHGlobal(bufferSize);
-                        if (CFStringGetCString(value, buffer, bufferSize, CFStringEncoding.kCFStringEncodingUTF8))
-                        {
-                            return Marshal.PtrToStringAuto(buffer, stringLength);
-                        }
-                    }
-
-                    if (CFGetTypeID(value) == CFDataGetTypeID())
-                    {
-                        int length = CFDataGetLength(value);
-                        IntPtr ptr = CFDataGetBytePtr(value);
-                        return Marshal.PtrToStringAuto(ptr, length);
-                    }
+                    return CFStringToString(value);
                 }
-            }
-            finally
-            {
-                if (buffer != IntPtr.Zero)
+
+                if (CFGetTypeID(value) == CFDataGetTypeID())
                 {
-                    Marshal.FreeHGlobal(buffer);
+                    int length = CFDataGetLength(value);
+                    IntPtr ptr = CFDataGetBytePtr(value);
+                    return Marshal.PtrToStringAuto(ptr, length);
                 }
             }
 

--- a/src/Core/Interop/MacOS/MacOSPreferences.cs
+++ b/src/Core/Interop/MacOS/MacOSPreferences.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using GitCredentialManager.Interop.MacOS.Native;
+using static GitCredentialManager.Interop.MacOS.Native.CoreFoundation;
+
+namespace GitCredentialManager.Interop.MacOS;
+
+public class MacOSPreferences
+{
+    private readonly string _appId;
+
+    public MacOSPreferences(string appId)
+    {
+        EnsureArgument.NotNull(appId, nameof(appId));
+
+        _appId = appId;
+    }
+
+    /// <summary>
+    /// Return a <see cref="string"/> typed value from the app preferences.
+    /// </summary>
+    /// <param name="key">Preference name.</param>
+    /// <exception cref="InvalidOperationException">Thrown if the preference is not a string.</exception>
+    /// <returns>
+    /// <see cref="string"/> or null if the preference with the given key does not exist.
+    /// </returns>
+    public string GetString(string key)
+    {
+        return TryGet(key, CFStringToString, out string value)
+            ? value
+            : null;
+    }
+
+    /// <summary>
+    /// Return a <see cref="int"/> typed value from the app preferences.
+    /// </summary>
+    /// <param name="key">Preference name.</param>
+    /// <exception cref="InvalidOperationException">Thrown if the preference is not an integer.</exception>
+    /// <returns>
+    /// <see cref="int"/> or null if the preference with the given key does not exist.
+    /// </returns>
+    public int? GetInteger(string key)
+    {
+        return TryGet(key, CFNumberToInt32, out int value)
+            ? value
+            : null;
+    }
+
+    /// <summary>
+    /// Return a <see cref="IDictionary{TKey,TValue}"/> typed value from the app preferences.
+    /// </summary>
+    /// <param name="key">Preference name.</param>
+    /// <exception cref="InvalidOperationException">Thrown if the preference is not a dictionary.</exception>
+    /// <returns>
+    /// <see cref="IDictionary{TKey,TValue}"/> or null if the preference with the given key does not exist.
+    /// </returns>
+    public IDictionary<string, string> GetDictionary(string key)
+    {
+        return TryGet(key, CFDictionaryToDictionary, out IDictionary<string, string> value)
+            ? value
+            : null;
+    }
+
+    private bool TryGet<T>(string key, Func<IntPtr, T> converter, out T value)
+    {
+        IntPtr cfValue = IntPtr.Zero;
+        IntPtr keyPtr = IntPtr.Zero;
+        IntPtr appIdPtr = CreateAppIdPtr();
+
+        try
+        {
+            keyPtr = CFStringCreateWithCString(IntPtr.Zero, key, CFStringEncoding.kCFStringEncodingUTF8);
+            cfValue = CFPreferencesCopyAppValue(keyPtr, appIdPtr);
+
+            if (cfValue == IntPtr.Zero)
+            {
+                value = default;
+                return false;
+            }
+
+            value = converter(cfValue);
+            return true;
+        }
+        finally
+        {
+            if (cfValue != IntPtr.Zero) CFRelease(cfValue);
+            if (keyPtr != IntPtr.Zero) CFRelease(keyPtr);
+            if (appIdPtr != IntPtr.Zero) CFRelease(appIdPtr);
+        }
+    }
+
+    private IntPtr CreateAppIdPtr()
+    {
+        return CFStringCreateWithCString(IntPtr.Zero, _appId, CFStringEncoding.kCFStringEncodingUTF8);
+    }
+}

--- a/src/Core/Interop/MacOS/MacOSSettings.cs
+++ b/src/Core/Interop/MacOS/MacOSSettings.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+
+namespace GitCredentialManager.Interop.MacOS
+{
+    /// <summary>
+    /// Reads settings from Git configuration, environment variables, and defaults from the system.
+    /// </summary>
+    public class MacOSSettings : Settings
+    {
+        private readonly ITrace _trace;
+
+        public MacOSSettings(IEnvironment environment, IGit git, ITrace trace)
+            : base(environment, git)
+        {
+            EnsureArgument.NotNull(trace, nameof(trace));
+            _trace = trace;
+
+            PlatformUtils.EnsureMacOS();
+        }
+
+        protected override bool TryGetExternalDefault(string section, string scope, string property, out string value)
+        {
+            value = null;
+
+            try
+            {
+                // Check for app default preferences for our bundle ID.
+                // Defaults can be deployed system administrators via device management profiles.
+                var prefs = new MacOSPreferences(Constants.MacOSBundleId);
+                IDictionary<string, string> dict = prefs.GetDictionary("configuration");
+
+                if (dict is null)
+                {
+                    // No configuration key exists
+                    return false;
+                }
+
+                // Wrap the raw dictionary in one configured with the Git configuration key comparer.
+                // This means we can use the same key comparison rules as Git in our configuration plist dict,
+                // That is, sections and names are insensitive to case, but the scope is case-sensitive.
+                var config = new Dictionary<string, string>(dict, GitConfigurationKeyComparer.Instance);
+
+                string name = string.IsNullOrWhiteSpace(scope)
+                    ? $"{section}.{property}"
+                    : $"{section}.{scope}.{property}";
+
+                if (!config.TryGetValue(name, out value))
+                {
+                    // No property exists
+                    return false;
+                }
+
+                _trace.WriteLine($"Default setting found in app preferences: {name}={value}");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                // Reading defaults is not critical to the operation of the application
+                // so we can ignore any errors and just log the failure.
+                _trace.WriteLine("Failed to read default setting from app preferences.");
+                _trace.WriteException(ex);
+                return false;
+            }
+        }
+    }
+}

--- a/src/Core/Interop/MacOS/Native/CoreFoundation.cs
+++ b/src/Core/Interop/MacOS/Native/CoreFoundation.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using static GitCredentialManager.Interop.MacOS.Native.LibSystem;
 
@@ -56,6 +57,9 @@ namespace GitCredentialManager.Interop.MacOS.Native
             CFStringEncoding encoding, bool isExternalRepresentation);
 
         [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr CFStringCreateWithCString(IntPtr alloc, string cStr, CFStringEncoding encoding);
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
         public static extern long CFStringGetLength(IntPtr theString);
 
         [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
@@ -83,14 +87,129 @@ namespace GitCredentialManager.Interop.MacOS.Native
         public static extern int CFArrayGetTypeID();
 
         [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int CFNumberGetTypeID();
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr CFDataGetBytePtr(IntPtr theData);
 
         [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
         public static extern int CFDataGetLength(IntPtr theData);
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr CFPreferencesCopyAppValue(IntPtr key, IntPtr appID);
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern bool CFNumberGetValue(IntPtr number, CFNumberType theType, out IntPtr valuePtr);
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr CFDictionaryGetKeysAndValues(IntPtr theDict, IntPtr[] keys, IntPtr[] values);
+
+        [DllImport(CoreFoundationFrameworkLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        public static extern long CFDictionaryGetCount(IntPtr theDict);
+
+        public static string CFStringToString(IntPtr cfString)
+        {
+            if (cfString == IntPtr.Zero)
+            {
+                throw new ArgumentNullException(nameof(cfString));
+            }
+
+            if (CFGetTypeID(cfString) != CFStringGetTypeID())
+            {
+                throw new InvalidOperationException("Object is not a CFString.");
+            }
+
+            long length = CFStringGetLength(cfString);
+            IntPtr buffer = Marshal.AllocHGlobal((int)length + 1);
+
+            try
+            {
+                if (!CFStringGetCString(cfString, buffer, length + 1, CFStringEncoding.kCFStringEncodingUTF8))
+                {
+                    throw new InvalidOperationException("Failed to convert CFString to C string.");
+                }
+
+                return Marshal.PtrToStringAnsi(buffer);
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(buffer);
+            }
+        }
+
+        public static int CFNumberToInt32(IntPtr cfNumber)
+        {
+            if (cfNumber == IntPtr.Zero)
+            {
+                throw new ArgumentNullException(nameof(cfNumber));
+            }
+
+            if (CFGetTypeID(cfNumber) != CFNumberGetTypeID())
+            {
+                throw new InvalidOperationException("Object is not a CFNumber.");
+            }
+
+            if (!CFNumberGetValue(cfNumber, CFNumberType.kCFNumberIntType, out IntPtr valuePtr))
+            {
+                throw new InvalidOperationException("Failed to convert CFNumber to Int32.");
+            }
+
+            return valuePtr.ToInt32();
+        }
+
+        public static IDictionary<string, string> CFDictionaryToDictionary(IntPtr cfDict)
+        {
+            if (cfDict == IntPtr.Zero)
+            {
+                throw new ArgumentNullException(nameof(cfDict));
+            }
+
+            if (CFGetTypeID(cfDict) != CFDictionaryGetTypeID())
+            {
+                throw new InvalidOperationException("Object is not a CFDictionary.");
+            }
+
+            int count = (int)CFDictionaryGetCount(cfDict);
+            var keys = new IntPtr[count];
+            var values = new IntPtr[count];
+
+            CFDictionaryGetKeysAndValues(cfDict, keys, values);
+
+            var dict = new Dictionary<string, string>(capacity: count);
+            for (int i = 0; i < count; i++)
+            {
+                string keyStr = CFStringToString(keys[i])!;
+                string valueStr = CFStringToString(values[i]);
+
+                dict[keyStr] = valueStr;
+            }
+
+            return dict;
+        }
     }
 
     public enum CFStringEncoding
     {
         kCFStringEncodingUTF8 = 0x08000100,
+    }
+
+    public enum CFNumberType
+    {
+        kCFNumberSInt8Type = 1,
+        kCFNumberSInt16Type = 2,
+        kCFNumberSInt32Type = 3,
+        kCFNumberSInt64Type = 4,
+        kCFNumberFloat32Type = 5,
+        kCFNumberFloat64Type = 6,
+        kCFNumberCharType = 7,
+        kCFNumberShortType = 8,
+        kCFNumberIntType = 9,
+        kCFNumberLongType = 10,
+        kCFNumberLongLongType = 11,
+        kCFNumberFloatType = 12,
+        kCFNumberDoubleType = 13,
+        kCFNumberCFIndexType = 14,
+        kCFNumberNSIntegerType = 15,
+        kCFNumberCGFloatType = 16
     }
 }

--- a/src/Core/Trace2.cs
+++ b/src/Core/Trace2.cs
@@ -480,13 +480,16 @@ public class Trace2 : DisposableObject, ITrace2
     internal static bool TryGetPipeName(string eventTarget, out string name)
     {
         // Use prefixes to determine whether target is a named pipe/socket
-        if (eventTarget.Contains("af_unix:", StringComparison.OrdinalIgnoreCase) ||
-            eventTarget.Contains("\\\\.\\pipe\\", StringComparison.OrdinalIgnoreCase) ||
-            eventTarget.Contains("/./pipe/", StringComparison.OrdinalIgnoreCase))
+        if (eventTarget.StartsWith("af_unix:", StringComparison.OrdinalIgnoreCase) ||
+            eventTarget.StartsWith(@"\\.\pipe\", StringComparison.OrdinalIgnoreCase) ||
+            eventTarget.StartsWith("//./pipe/", StringComparison.OrdinalIgnoreCase))
         {
             name = PlatformUtils.IsWindows()
-                ? eventTarget.TrimUntilLastIndexOf("\\")
-                : eventTarget.TrimUntilLastIndexOf(":");
+                ? eventTarget.Replace('/', '\\')
+                    .TrimUntilIndexOf(@"\\.\pipe\")
+                : eventTarget.Replace("af_unix:dgram:", "")
+                    .Replace("af_unix:stream:", "")
+                    .Replace("af_unix:", "");
             return true;
         }
 

--- a/src/Core/Trace2Message.cs
+++ b/src/Core/Trace2Message.cs
@@ -409,7 +409,7 @@ public class ErrorMessage : Trace2Message
     [JsonPropertyOrder(8)]
     public string Message { get; set; }
 
-    [JsonPropertyName("format")]
+    [JsonPropertyName("fmt")]
     [JsonPropertyOrder(9)]
     public string ParameterizedMessage { get; set; }
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,4 +1,4 @@
-<Project>
+<Project TreatAsLocalProperty="VersionPrefix">
   <!-- To extend/change the defaults, create a Directory.props alongside this file -->
 
   <PropertyGroup Label="CI" Condition="'$(CI)' == ''">
@@ -43,6 +43,10 @@
 
     <!-- Ensure MSBuild tooling can access package artifacts always via PKG_[PackageId] -->
     <GeneratePathProperty>true</GeneratePathProperty>
+    <!-- Avoid warnings for test projects when we run dotnet pack on the whole solution. -->
+    <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
+    <!-- See https://learn.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#prunepackagereference-specification -->
+    <RestoreEnablePackagePruning>true</RestoreEnablePackagePruning>
   </PropertyGroup>
 
   <PropertyGroup Label="Build">
@@ -134,6 +138,15 @@
     <VersionSuffix Condition="!$(VersionLabel.Contains('refs/tags/'))">$(_VersionLabel)</VersionSuffix>
     <!-- Special case for tags, the label is actually the version. Backs compat since passed-in value overrides MSBuild-set one -->
     <Version Condition="$(VersionLabel.Contains('refs/tags/'))">$(_VersionLabel)</Version>
+
+    <!-- In order for latest from main/master to always be greatest when using -prerelease switch on install/run, 
+         we change the scheme as follows:
+         - main/master remain as today: VersionPrefix: 42.42.${{ github.run_number }}  (from yaml)
+         - others: VersionPrefix: 42.42.0-[label].${{ github.run_number }}
+    -->
+    <IsMaster Condition="$(VersionLabel.Contains('refs/heads/main')) or $(VersionLabel.Contains('refs/heads/master'))">true</IsMaster>
+    <VersionPrefix Condition="'$(IsMaster)' != 'true'">42.42.0</VersionPrefix>
+    <VersionSuffix Condition="'$(IsMaster)' != 'true'">$(VersionSuffix).$(GITHUB_RUN_NUMBER)</VersionSuffix>
   </PropertyGroup>
 
   <ItemGroup Label="ThisAssembly.Project">

--- a/src/shared/Core/Authentication/OAuth/OAuth2SystemWebBrowser.cs
+++ b/src/shared/Core/Authentication/OAuth/OAuth2SystemWebBrowser.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GitCredentialManager.Authentication.OAuth
+{
+    public class OAuth2WebBrowserOptions
+    {
+        internal const string DefaultSuccessHtml = @"<!DOCTYPE html><html><head>
+<style>body{font-family:sans-serif;}dt{font-weight:bold;}dd{margin-bottom:10px;}</style>
+<title>Authentication successful</title></head>
+<body><h1>Authentication successful</h1><p>You can now close this page.</p></body>
+</html>";
+        internal const string DefaultFailureHtmlFormat = @"<!DOCTYPE html><html><head>
+<style>body{{font-family:sans-serif;}}dt{{font-weight:bold;}}dd{{margin-bottom:10px;}}</style>
+<title>Authentication failed</title></head>
+<body><h1>Authentication failed</h1><dl>
+<dt>Error:</dt><dd>{0}</dd>
+<dt>Description:</dt><dd>{1}</dd>
+<dt>URL:</dt><dd>{2}</dd>
+</dl></body></html>";
+
+        public string SuccessResponseHtml { get; set; }
+        public string FailureResponseHtmlFormat { get; set; }
+
+        public Uri SuccessRedirect { get; set; }
+        public Uri FailureRedirectFormat { get; set; }
+    }
+
+    public class OAuth2SystemWebBrowser : IOAuth2WebBrowser
+    {
+        private readonly IEnvironment _environment;
+        private readonly OAuth2WebBrowserOptions _options;
+
+        public OAuth2SystemWebBrowser(IEnvironment environment, OAuth2WebBrowserOptions options)
+        {
+            EnsureArgument.NotNull(environment, nameof(environment));
+            EnsureArgument.NotNull(options, nameof(options));
+
+            _environment = environment;
+            _options = options;
+        }
+
+        public Uri UpdateRedirectUri(Uri uri)
+        {
+            if (!uri.IsLoopback)
+            {
+                throw new ArgumentException("Only localhost is supported as a redirect URI.", nameof(uri));
+            }
+
+            // If a port has been specified use it, otherwise find a free one
+            if (uri.IsDefaultPort)
+            {
+                int port = GetFreeTcpPort();
+                return new UriBuilder(uri) {Port = port}.Uri;
+            }
+
+            return uri;
+        }
+
+        public async Task<Uri> GetAuthenticationCodeAsync(Uri authorizationUri, Uri redirectUri, CancellationToken ct)
+        {
+            if (!redirectUri.IsLoopback)
+            {
+                throw new ArgumentException("Only localhost is supported as a redirect URI.", nameof(redirectUri));
+            }
+
+            Task<Uri> interceptTask = InterceptRequestsAsync(redirectUri, ct);
+
+            BrowserUtils.OpenDefaultBrowser(_environment, authorizationUri);
+
+            return await interceptTask;
+        }
+
+        private async Task<Uri> InterceptRequestsAsync(Uri listenUri, CancellationToken ct)
+        {
+            // Create a TaskCompletionSource which completes when we're asked to cancel.
+            // We can then await the this task together with other tasks that don't take a
+            // CancellationToken and exit the method quickly when cancelled.
+            var tcs = new TaskCompletionSource<Uri>();
+            ct.Register(() => tcs.SetCanceled());
+
+            // Prefixes must end with a '/'
+            string prefix = listenUri.GetLeftPart(UriPartial.Path);
+            if (!prefix.EndsWith("/"))
+            {
+                prefix += "/";
+            }
+
+            var listener = new HttpListener {Prefixes = {prefix}};
+            listener.Start();
+
+            try
+            {
+                Task<HttpListenerContext> contextTask = listener.GetContextAsync();
+                Task<Uri> cancelTask = tcs.Task;
+
+                Task completedTask = await Task.WhenAny(contextTask, tcs.Task);
+
+                // Check if we 'completed' the context task or the cancellation task
+                if (completedTask == cancelTask)
+                {
+                    // We were cancelled!
+                    return await cancelTask;
+                }
+
+                // We intercepted a request!
+                HttpListenerContext context = await contextTask;
+
+                await HandleInterceptedRequestAsync(context.Request, context.Response);
+
+                // Return the final intercepted URI
+                return context.Request.Url;
+            }
+            finally
+            {
+                listener.Stop();
+                listener.Close();
+            }
+        }
+
+        private async Task HandleInterceptedRequestAsync(HttpListenerRequest request, HttpListenerResponse response)
+        {
+            IDictionary<string, string> queryParams = request.QueryString.ToDictionary(StringComparer.OrdinalIgnoreCase);
+
+            // If we have an error value then the request failed and we should reply with a page containing the error information
+            bool hasError = queryParams.TryGetValue(OAuth2Constants.AuthorizationGrantResponse.ErrorCodeParameter, out string errorCode);
+            queryParams.TryGetValue(OAuth2Constants.AuthorizationGrantResponse.ErrorDescriptionParameter, out string errorDescription);
+            queryParams.TryGetValue(OAuth2Constants.AuthorizationGrantResponse.ErrorUriParameter, out string errorUri);
+            if (hasError)
+            {
+                string FormatError(string format)
+                {
+                    if (string.IsNullOrWhiteSpace(errorCode)) errorCode = "unknown";
+                    if (string.IsNullOrWhiteSpace(errorDescription)) errorDescription = "Unknown error.";
+                    if (string.IsNullOrWhiteSpace(errorUri)) errorUri = "none";
+                    return string.Format(format, errorCode, errorDescription, errorUri);
+                }
+
+                // Prefer redirection options to raw HTML
+                if (_options.FailureRedirectFormat != null)
+                {
+                    string failureUrl = FormatError(_options.FailureRedirectFormat.ToString());
+                    response.Redirect(failureUrl);
+                    response.Close();
+                }
+                else
+                {
+                    string failureHtml = FormatError(_options.FailureResponseHtmlFormat ?? OAuth2WebBrowserOptions.DefaultFailureHtmlFormat);
+                    await response.WriteResponseAsync(failureHtml);
+                    response.Close();
+                }
+            }
+            else
+            {
+                // Prefer redirection options to raw HTML
+                if (_options.SuccessRedirect != null)
+                {
+                    string successUrl = _options.SuccessRedirect.ToString();
+                    response.Redirect(successUrl);
+                    response.Close();
+                }
+                else
+                {
+                    string successHtml = _options.SuccessResponseHtml ?? OAuth2WebBrowserOptions.DefaultSuccessHtml;
+                    await response.WriteResponseAsync(successHtml);
+                    response.Close();
+                }
+            }
+        }
+
+        private static int GetFreeTcpPort()
+        {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+
+            try
+            {
+                listener.Start();
+                return ((IPEndPoint) listener.LocalEndpoint).Port;
+            }
+            finally
+            {
+                listener.Stop();
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
# git-ecosystem/git-credential-manager

- macospreferences: add class to read macOS app preferences https://github.com/git-ecosystem/git-credential-manager/commit/5f6d32a
- macossettings: implement default settings for macOS https://github.com/git-ecosystem/git-credential-manager/commit/b05317f
- Return only unique accounts from credential stores (#1369) https://github.com/git-ecosystem/git-credential-manager/commit/4e2a898
- trace2: fix pipe/socket name parsing https://github.com/git-ecosystem/git-credential-manager/commit/d4e2f59
- trace2: use 'fmt' for the formatted message event field https://github.com/git-ecosystem/git-credential-manager/commit/480b32c
- Fix: Add flag to search query for SecretService to retrieve all accounts https://github.com/git-ecosystem/git-credential-manager/commit/f6fe9ca

# devlooped/oss

- Upgrade create-pull-request action to version 8 https://github.com/devlooped/oss/commit/d00364f
- Disable warnings for non-packable test projects https://github.com/devlooped/oss/commit/95b338b
- Update versioning scheme in Directory.Build.props https://github.com/devlooped/oss/commit/f2400ef
- Enable package pruning in Directory.Build.props https://github.com/devlooped/oss/commit/0ff8b7b
- Enhance include workflow with OSMF EULA support https://github.com/devlooped/oss/commit/f2050db
- Trim whitespace in file content replacement https://github.com/devlooped/oss/commit/e53557f
- Fix path pattern for markdown files in workflow https://github.com/devlooped/oss/commit/6a6de05
- Fix error message quotes in includes.yml https://github.com/devlooped/oss/commit/26e8cb7
- Change label from 'docs' to 'dependencies' https://github.com/devlooped/oss/commit/2d1fb4e
- Avoid failure on PR creation if osmfeula.txt doesn't exist in repo https://github.com/devlooped/oss/commit/8ff5178
- Update create-pull-request action to version 8 https://github.com/devlooped/oss/commit/0662872
- Ignore sponsorlink sources in formatting https://github.com/devlooped/oss/commit/f571a42
- SponsorLink code should be checked as regular code https://github.com/devlooped/oss/commit/e81ab75
- Set severity of IDE1100 to none https://github.com/devlooped/oss/commit/1ed9afe
- Set explicit tab size and eol for code files https://github.com/devlooped/oss/commit/5dba0d0
- Revert EOL change in editorconfig for C# files https://github.com/devlooped/oss/commit/2d0e5a5
- Revert indent size for project files https://github.com/devlooped/oss/commit/a62c459